### PR TITLE
Use percentage-based chip height for responsive layout

### DIFF
--- a/webroot/admin/api/load_settings.php
+++ b/webroot/admin/api/load_settings.php
@@ -19,7 +19,7 @@ echo json_encode([
     'family'=>"-apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
     'scale'=>1, 'h1Scale'=>1, 'h2Scale'=>1,
     'overviewTitleScale'=>1, 'overviewHeadScale'=>0.9, 'overviewCellScale'=>0.8,
-    'tileTextScale'=>0.8, 'tileWeight'=>600, 'chipHeight'=>44,
+    'tileTextScale'=>0.8, 'tileWeight'=>600, 'chipHeight'=>1,
     'chipOverflowMode'=>'scale','flamePct'=>55,'flameGapPx'=>6
   ],
   'h2'=>['mode'=>'text','text'=>'Aufgusszeiten','showOnOverview'=>true],

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -224,7 +224,7 @@
           <div class="kv"><label>Übersichtstitel Scale</label><input id="ovTitleScale" class="input" type="number" step="0.05" min="0.4" max="4" value="1"></div>
           <div class="kv"><label>Kopf‑Scale</label><input id="ovHeadScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.9"></div>
           <div class="kv"><label>Zellen‑Scale</label><input id="ovCellScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.8"></div>
-          <div class="kv"><label>Chip‑Höhe (px)</label><input id="chipH" class="input" type="number" min="20" max="120" value="44"></div>
+          <div class="kv"><label>Chip‑Höhe (%)</label><input id="chipH" class="input" type="number" min="50" max="200" value="100"></div>
           <div class="help">Chips sind immer gleich breit/hoch (füllen die Zelle) und zentriert.</div>
 <div class="kv"><label>Textüberlänge</label>
   <select id="chipOverflowMode" class="input">

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -204,7 +204,7 @@ function renderSlidesBox(){
   setV('#ovTitleScale', f.overviewTitleScale ?? 1);
   setV('#ovHeadScale',  f.overviewHeadScale  ?? 0.9);
   setV('#ovCellScale',  f.overviewCellScale  ?? 0.8);
-  setV('#chipH',        f.chipHeight         ?? 44);
+  setV('#chipH',        Math.round((f.chipHeight ?? 1)*100));
 
   // Saunafolien (Kacheln)
   setV('#tileTextScale', f.tileTextScale ?? 0.8);
@@ -236,7 +236,7 @@ function renderSlidesBox(){
     setV('#ovTitleScale', DEFAULTS.fonts.overviewTitleScale);
     setV('#ovHeadScale',  DEFAULTS.fonts.overviewHeadScale);
     setV('#ovCellScale',  DEFAULTS.fonts.overviewCellScale);
-    setV('#chipH',        DEFAULTS.fonts.chipHeight);
+    setV('#chipH',        Math.round(DEFAULTS.fonts.chipHeight*100));
     setV('#chipOverflowMode', DEFAULTS.fonts.chipOverflowMode);
     setV('#flamePct',         DEFAULTS.fonts.flamePct);
     setV('#flameGap',         DEFAULTS.fonts.flameGapPx);
@@ -526,7 +526,7 @@ function collectSettings(){
         overviewTitleScale:+($('#ovTitleScale').value||1),
         overviewHeadScale:+($('#ovHeadScale').value||0.9),
         overviewCellScale:+($('#ovCellScale').value||0.8),
-        chipHeight:+($('#chipH').value||44),
+        chipHeight:(+($('#chipH').value||100)/100),
         chipOverflowMode: ($('#chipOverflowMode')?.value || 'scale'),
         flamePct:   +($('#flamePct')?.value || 55),
         flameGapPx: +($('#flameGap')?.value || 6),

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -23,7 +23,7 @@ export const DEFAULTS = {
     family:"system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
     scale:1, h1Scale:1, h2Scale:1,
     overviewTitleScale:1, overviewHeadScale:0.9, overviewCellScale:0.8,
-    tileTextScale:0.8, tileWeight:600, chipHeight:44,
+    tileTextScale:0.8, tileWeight:600, chipHeight:1,
     chipOverflowMode:'scale', flamePct:55, flameGapPx:6
   },
   h2:{ mode:'text', text:'Aufgusszeiten', showOnOverview:true },

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -16,9 +16,12 @@
   /* typography */
   --font:-apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   --baseScale:1; --vwScale:1; --scale:calc(var(--baseScale)*var(--vwScale)); --h1Scale:1; --h2Scale:1; --ovHeadScale:0.90; --ovCellScale:0.80;
-  --tileTextScale:0.80; --tileWeight:600; --flameSizePx:28; --chipH:44px;
---chipFlamePct:.55;   /* Anteil der Chip-Höhe für Flammen */
---chipFlameGap:6px;   /* Abstand zwischen Flammen */
+  --tileTextScale:0.80; --tileWeight:600; --flameSizePx:28;
+  --chipHBase:calc(44px*var(--scale));
+  --chipHScale:1;
+  --chipH:calc(var(--chipHBase)*var(--chipHScale));
+  --chipFlamePct:.55;   /* Anteil der Chip-Höhe für Flammen */
+  --chipFlameGap:6px;   /* Abstand zwischen Flammen */
   --ovAuto:1; /* overview-only autoscale factor */
 
   /* right panel shape */

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -100,7 +100,7 @@ async function loadDeviceResolved(id){
       '--ovCellScale': settings?.fonts?.overviewCellScale || 0.8,
       '--tileTextScale': settings?.fonts?.tileTextScale || 0.8,
       '--tileWeight': settings?.fonts?.tileWeight || 600,
-      '--chipH': (settings?.fonts?.chipHeight || 44) + 'px'
+      '--chipHScale': (settings?.fonts?.chipHeight || 1)
     });
     if (settings?.fonts?.family) document.documentElement.style.setProperty('--font', settings.fonts.family);
 // Chip-Optionen (Übersicht): Größen & Overflow-Modus aus den Settings


### PR DESCRIPTION
## Summary
- Replace fixed chip height pixel value with responsive base plus adjustable factor
- Update admin UI to configure chip height in percent
- Pass chip height factor through settings and slideshow variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2aeb6b348320a456be9617413123