### PR TITLE
feat: keep right panel responsive

### DIFF
--- a/webroot/assets/responsive.css
+++ b/webroot/assets/responsive.css
@@ -1,12 +1,17 @@
 /* Responsive tweaks for slideshow layout */
+
 @media (max-width: 900px), (orientation: portrait) {
-  .rightPanel {
-    display:block;
-    position:relative;
-    width:100%;
-    height:40vh;
-    -webkit-clip-path:none;
-            clip-path:none;
+  :root {
+    --rightW:30%;
+    --cutTop:40%;
+    --cutBottom:20%;
   }
-  .container.has-right { padding-right:0; }
+}
+
+@media (max-width: 600px) {
+  :root {
+    --rightW:24%;
+    --cutTop:45%;
+    --cutBottom:25%;
+  }
 }

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -24,6 +24,21 @@ let previewMode = IS_PREVIEW; // NEU: in Preview sofort aktiv (kein Pairing)
     }).catch(()=>{ urlCache.set(url, ''); });
   }
 
+  const imgCache = new Set();
+  function preloadImage(url){
+    return new Promise(res=>{
+      if (!url || imgCache.has(url)) return res();
+      const i = new Image();
+      i.onload = i.onerror = () => res();
+      i.src = url;
+      imgCache.add(url);
+    });
+  }
+  async function preloadRightImages(){
+    const urls = Object.values(settings?.assets?.rightImages || {});
+    await Promise.all(urls.filter(Boolean).map(preloadImage));
+  }
+
   // ---------- Time helpers ----------
   const nowMinutes = () => { const d = new Date(); return d.getHours() * 60 + d.getMinutes(); };
   const parseHM = (hm) => { const m = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(hm || ''); return m ? (+m[1]) * 60 + (+m[2]) : null; };
@@ -51,7 +66,9 @@ async function loadDeviceResolved(id){
   }
   schedule = j.schedule;
   settings = j.settings;
-  applyTheme(); applyDisplay(); maybeApplyPreset(); await buildQueue();
+  applyTheme(); applyDisplay(); maybeApplyPreset();
+  await preloadRightImages();
+  await buildQueue();
 }
 
 
@@ -66,6 +83,7 @@ async function loadDeviceResolved(id){
     applyTheme();
     applyDisplay();
     maybeApplyPreset();
+    await preloadRightImages();
     await buildQueue();
   }
 


### PR DESCRIPTION
## Summary
- scale right image panel with viewport via CSS variables
- preload sauna right-panel images before slides render
- keep diagonal right panel layout on small viewports

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5eb04a4483208527a336184ee48e