### PR TITLE
Use scale factors for layout spacing

### DIFF
--- a/webroot/admin/api/load_settings.php
+++ b/webroot/admin/api/load_settings.php
@@ -20,13 +20,13 @@ echo json_encode([
     'scale'=>1, 'h1Scale'=>1, 'h2Scale'=>1,
     'overviewTitleScale'=>1, 'overviewHeadScale'=>0.9, 'overviewCellScale'=>0.8,
     'tileTextScale'=>0.8, 'tileWeight'=>600, 'chipHeight'=>1,
-    'chipOverflowMode'=>'scale','flamePct'=>55,'flameGapPx'=>6
+    'chipOverflowMode'=>'scale','flamePct'=>55,'flameGapPct'=>14
   ],
   'h2'=>['mode'=>'text','text'=>'Aufgusszeiten','showOnOverview'=>true],
   'display'=>['fit'=>'cover','rightWidthPercent'=>38,'cutTopPercent'=>28,'cutBottomPercent'=>12],
   'slides'=>[
     'overviewDurationSec'=>10,'saunaDurationSec'=>6,'transitionMs'=>500,
-    'tileWidthPercent'=>45,'tileMinPx'=>480,'tileMaxPx'=>1100,
+    'tileWidthPercent'=>45,'tileMinPct'=>25,'tileMaxPct'=>57,
     'durationMode'=>'uniform','globalDwellSec'=>6,'loop'=>true,
     'order'=>['overview']
   ],

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -236,8 +236,8 @@
 <div class="kv"><label>Flammen-Größe (% der Chip-Höhe)</label>
   <input id="flamePct" class="input" type="number" min="30" max="100" value="55">
 </div>
-<div class="kv"><label>Flammen-Abstand (px)</label>
-  <input id="flameGap" class="input" type="number" min="0" max="24" value="6">
+<div class="kv"><label>Flammen-Abstand (%)</label>
+  <input id="flameGap" class="input" type="number" min="0" max="100" value="14">
 </div>
 
           <div class="subh">Saunafolien (Kacheln)</div>
@@ -252,8 +252,8 @@
             </select>
           </div>
           <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
-          <div class="kv"><label>Kachel‑Breite min (px)</label><input id="tileMin" class="input" type="number" min="100" max="2000" value="480"></div>
-          <div class="kv"><label>Kachel‑Breite max (px)</label><input id="tileMax" class="input" type="number" min="200" max="3000" value="1100"></div>
+          <div class="kv"><label>Kachel‑Breite min (%)</label><input id="tileMin" class="input" type="number" min="0" max="100" value="25"></div>
+          <div class="kv"><label>Kachel‑Breite max (%)</label><input id="tileMax" class="input" type="number" min="0" max="100" value="57"></div>
 
           <div class="subh">Bildspalte / Schrägschnitt</div>
           <div class="kv"><label>Breite rechts (%)</label><input id="rightW" class="input" type="number" min="0" max="70" value="38"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -204,7 +204,7 @@ function renderSlidesBox(){
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#chipOverflowMode', f.chipOverflowMode ?? 'scale');
   setV('#flamePct',         f.flamePct         ?? 55);
-  setV('#flameGap',         f.flameGapPx       ?? 6);
+  setV('#flameGap',         f.flameGapPct      ?? 14);
 
   // H2
   setV('#h2Mode', settings.h2?.mode ?? DEFAULTS.h2.mode);
@@ -221,8 +221,8 @@ function renderSlidesBox(){
   setV('#tileTextScale', f.tileTextScale ?? 0.8);
   setV('#tileWeight',    f.tileWeight    ?? 600);
   setV('#tilePct',       settings.slides?.tileWidthPercent ?? 45);
-  setV('#tileMin',       settings.slides?.tileMinPx ?? 480);
-  setV('#tileMax',       settings.slides?.tileMaxPx ?? 1100);
+  setV('#tileMin',       settings.slides?.tileMinPct ?? 25);
+  setV('#tileMax',       settings.slides?.tileMaxPct ?? 57);
 
   // Bildspalte / Schrägschnitt
   setV('#rightW',   settings.display?.rightWidthPercent ?? 38);
@@ -250,13 +250,13 @@ function renderSlidesBox(){
     setV('#chipH',        Math.round(DEFAULTS.fonts.chipHeight*100));
     setV('#chipOverflowMode', DEFAULTS.fonts.chipOverflowMode);
     setV('#flamePct',         DEFAULTS.fonts.flamePct);
-    setV('#flameGap',         DEFAULTS.fonts.flameGapPx);
+    setV('#flameGap',         DEFAULTS.fonts.flameGapPct);
 
     setV('#tileTextScale', DEFAULTS.fonts.tileTextScale);
     setV('#tileWeight',    DEFAULTS.fonts.tileWeight);
     setV('#tilePct',       DEFAULTS.slides.tileWidthPercent);
-    setV('#tileMin',       DEFAULTS.slides.tileMinPx);
-    setV('#tileMax',       DEFAULTS.slides.tileMaxPx);
+    setV('#tileMin',       DEFAULTS.slides.tileMinPct);
+    setV('#tileMax',       DEFAULTS.slides.tileMaxPct);
 
     setV('#rightW',   DEFAULTS.display.rightWidthPercent);
     setV('#cutTop',   DEFAULTS.display.cutTopPercent);
@@ -540,7 +540,7 @@ function collectSettings(){
         chipHeight:(+($('#chipH').value||100)/100),
         chipOverflowMode: ($('#chipOverflowMode')?.value || 'scale'),
         flamePct:   +($('#flamePct')?.value || 55),
-        flameGapPx: +($('#flameGap')?.value || 6),
+        flameGapPct:+($('#flameGap')?.value || 14),
         tileTextScale:+($('#tileTextScale').value||0.8),
         tileWeight:+($('#tileWeight').value||600)
       },
@@ -551,8 +551,11 @@ function collectSettings(){
       },
       slides:{
         ...(settings.slides||{}),
+        tileWidthPercent:+($('#tilePct')?.value || 45),
+        tileMinPct:+($('#tileMin')?.value || 25),
+        tileMaxPct:+($('#tileMax')?.value || 57),
         showOverview: !!document.getElementById('ovShow')?.checked,
-	overviewDurationSec: (() => {
+        overviewDurationSec: (() => {
   	const el = document.getElementById('ovSec') || document.getElementById('ovSecGlobal');
   	const fallback = settings?.slides?.overviewDurationSec ?? (DEFAULTS?.slides?.overviewDurationSec ?? 10);
   	const v = el?.value;

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -2,7 +2,7 @@
 // DEFAULTS + Wochentags-Helfer als Single Source of Truth
 
 export const DEFAULTS = {
-  slides:{ overviewDurationSec:10, saunaDurationSec:6, transitionMs:500, tileWidthPercent:45, tileMinPx:480, tileMaxPx:1100 },
+  slides:{ overviewDurationSec:10, saunaDurationSec:6, transitionMs:500, tileWidthPercent:45, tileMinPct:25, tileMaxPct:57 },
   display:{ fit:'cover', baseW:1920, baseH:1080, rightWidthPercent:38, cutTopPercent:28, cutBottomPercent:12 },
   theme:{
     bg:'#E8DEBD', fg:'#5C3101', accent:'#5C3101',
@@ -24,7 +24,7 @@ export const DEFAULTS = {
     scale:1, h1Scale:1, h2Scale:1,
     overviewTitleScale:1, overviewHeadScale:0.9, overviewCellScale:0.8,
     tileTextScale:0.8, tileWeight:600, chipHeight:1,
-    chipOverflowMode:'scale', flamePct:55, flameGapPx:6
+    chipOverflowMode:'scale', flamePct:55, flameGapPct:14
   },
   h2:{ mode:'text', text:'Aufgusszeiten', showOnOverview:true },
   assets:{ flameImage:'/assets/img/flame_test.svg' },

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -21,13 +21,14 @@
   --chipHScale:1;
   --chipH:calc(var(--chipHBase)*var(--chipHScale));
   --chipFlamePct:.55;   /* Anteil der Chip-Höhe für Flammen */
-  --chipFlameGap:6px;   /* Abstand zwischen Flammen */
+  --chipFlameGapFactor:0.14; /* Anteil der Chip-Höhe als Abstand */
+  --chipFlameGap:calc(var(--chipH) * var(--chipFlameGapFactor));
   --ovAuto:1; /* overview-only autoscale factor */
 
   /* right panel shape */
   --rightW:38%; --cutTop:28%; --cutBottom:12%;
 
-  /* sauna tile clamp (JS sets --tileTargetPx) */
+  /* sauna tile clamp (JS sets --tileTargetPx and min/max via factors) */
   --tileMinPx:480px; --tileMaxPx:1100px; --tileTargetPx:860px;
   --flameSizePxOv:18; /* kleine Flames in Übersicht-Chips */
   --ovTitleScale:1; /* nur H1 der Übersicht */

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -111,10 +111,10 @@ async function loadDeviceResolved(id){
     });
     if (settings?.fonts?.family) document.documentElement.style.setProperty('--font', settings.fonts.family);
 // Chip-Optionen (Übersicht): Größen & Overflow-Modus aus den Settings
-const f = settings?.fonts || {};
-setVars({
+  const f = settings?.fonts || {};
+  setVars({
   '--chipFlamePct': Math.max(0.3, Math.min(1, (f.flamePct || 55) / 100)),
-  '--chipFlameGap': (f.flameGapPx ?? 6) + 'px'
+  '--chipFlameGapFactor': Math.max(0, (f.flameGapPct ?? 14) / 100)
 });
 // 'scale' = Text automatisch verkleinern, 'ellipsis' = auf „…“ kürzen
 document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
@@ -527,8 +527,10 @@ function renderHtmlSlide(html) {
     const avail = computeAvailContentWidth(container);
     const pct = (settings?.slides?.tileWidthPercent ?? 45) / 100;
     const target = Math.max(0, avail * pct);
-    const minPx = settings?.slides?.tileMinPx ?? 480;
-    const maxPx = settings?.slides?.tileMaxPx ?? 1100;
+    const minPct = Math.max(0, (settings?.slides?.tileMinPct ?? 25) / 100);
+    const maxPct = Math.max(minPct, (settings?.slides?.tileMaxPct ?? 57) / 100);
+    const minPx = avail * minPct;
+    const maxPx = avail * maxPct;
     container.style.setProperty('--tileTargetPx', target + 'px');
     container.style.setProperty('--tileMinPx', minPx + 'px');
     container.style.setProperty('--tileMaxPx', maxPx + 'px');

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -15,7 +15,8 @@
   },
   "fonts": {
     "family": "-apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-    "scale": 1.00
+    "scale": 1.00,
+    "flameGapPct": 14
   },
   "display": {
     "rightWidthPercent": 38,
@@ -27,8 +28,8 @@
     "saunaDurationSec": 6,
     "transitionMs": 500,
     "tileWidthPercent": 45,
-    "tileMinPx": 480,
-    "tileMaxPx": 1100,
+    "tileMinPct": 25,
+    "tileMaxPct": 57,
     "loop": true,
     "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"]
   },


### PR DESCRIPTION
## Summary
- Switch flame gap and tile width controls from pixels to scalable percentages
- Compute pixel values from stored factors in design and slideshow scripts
- Persist only scale factors in defaults and serialization

## Testing
- `php -l webroot/admin/api/load_settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb5eb603b48320a0cb58045879ea84