### PR TITLE
Prevent slideshow headings from overlapping image panel

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -54,6 +54,8 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 .container{position:relative; height:100%; padding:calc(32px*var(--vwScale)); display:flex; flex-direction:column; align-items:flex-start}
 .container.has-right{padding-right:calc(var(--rightW) + 32px)}
 .container.overview{padding-right:32px}
+.headings{width:100%;}
+.container.has-right .headings{max-width:calc(100% - var(--rightW));}
 .h1{font-weight:800;letter-spacing:.02em;font-size:calc(56px*var(--scale)*var(--h1Scale));margin:0 0 10px}
 .h2{font-weight:700;letter-spacing:.01em;opacity:.95;font-size:calc(36px*var(--scale)*var(--h2Scale));margin:0 0 14px}
 .overview .h1{font-size:calc(56px*var(--scale)*var(--h1Scale)*var(--ovAuto))}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -485,7 +485,7 @@ while (m.totalH > availH && iter < 12) {
     const rightH2 = (((settings?.h2?.showOnOverview) ?? true) && (settings?.h2?.mode||'text')!=='none')
       ? h('h2',{class:'h2'}, computeH2Text() || '')
       : null;
-    const bar = h('div',{class:'ovbar'}, [ h('h1',{class:'h1'}, 'Aufgussplan'), rightH2 ]);
+    const bar = h('div',{class:'ovbar headings'}, [ h('h1',{class:'h1'}, 'Aufgussplan'), rightH2 ]);
     const c = h('div', {class:'container overview fade show'}, [ bar, h('div', {class:'ovwrap'}, [table]) ]);
 const recalc = () => { 
   autoScaleOverview(c);
@@ -538,10 +538,13 @@ function renderHtmlSlide(html) {
   function renderSauna(name) {
     const hlMap = getHighlightMap();
     const rightUrl = settings?.assets?.rightImages?.[name] || '';
+    const headingWrap = h('div', { class: 'headings' }, [
+      h('h1', { class: 'h1', style: 'color:var(--saunaColor);' }, name),
+      h('h2', { class: 'h2' }, computeH2Text() || '')
+    ]);
     const c = h('div', { class: 'container has-right fade show' }, [
       h('div', { class: 'rightPanel', style: rightUrl ? ('background-image:url(' + JSON.stringify(rightUrl) + ')') : 'display:none;' }),
-      h('h1', { class: 'h1', style: 'color:var(--saunaColor);' }, name),
-      h('h2', {class:'h2'}, computeH2Text() || '')
+      headingWrap
     ]);
 
     const body = h('div', { class: 'body' });


### PR DESCRIPTION
## Summary
- Introduce a `.headings` wrapper with width constraints to keep titles out of the right-side image region.
- Render slideshow `h1`/`h2` elements inside this wrapper for both overview and sauna slides.

## Testing
- `node -e "const right=0.38; [320,480].forEach(w=>console.log('screen', w, 'max', w*(1-right)));"`
- `node -e "const base=1920; [320,480].forEach(w=>console.log('vwScale for',w,'=',Math.max(0.25, w/base)));"`


------
https://chatgpt.com/codex/tasks/task_e_68bb5eb7843c83208ec03da6bc2890a2