### PR TITLE
Refine admin workflow and device pane styling

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -86,6 +86,14 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
 .mut,.help{ color:var(--muted); }
 
+/* Utility classes for headings and toolbars */
+.subh{ font-weight:700; margin:8px 0; }
+.card-head{ display:flex; justify-content:space-between; align-items:center; gap:8px; margin-bottom:8px; }
+.card-title{ font-weight:800; }
+.device-toolbar{ display:flex; flex-wrap:wrap; gap:6px; }
+.btn.icon-label{ gap:4px; }
+.devices-section{ margin-top:12px; }
+
 /* ---------- Header ---------- */
 header{
   position:sticky; top:0; z-index:60;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -136,67 +136,6 @@
       </div>
     </details>
 
-    <!-- Unterbox 2: Fußnoten -->
-<details class="ac sub" id="boxFootnotes">
-  <summary>
-    <div class="ttl">▶<span class="chev">⮞</span> Fußnoten</div>
-    <div class="actions"><button class="btn sm" id="fnAdd">Hinzufügen</button></div>
-  </summary>
-  <div class="content">
-    <div id="fnList"></div>
-    <div class="subh">Darstellung</div>
-    <div class="kv">
-      <label>Fußnoten-Layout</label>
-      <select id="footnoteLayout" class="input">
-        <option value="one-line" selected>Möglichst einzeilig</option>
-        <option value="multi">Mehrzeilig</option>
-        <option value="stacked">Untereinander (jede Zeile)</option>
-      </select>
-    </div>
-  </div>
-</details>
-
-    <!-- Unterbox 3: Bild-Slides -->
-    <details class="ac sub" id="boxImages">
-<summary>
-    <div class="ttl">▶<span class="chev">⮞</span> Bild-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnInterAdd2">Bild hinzufügen</button></div>
-  </summary>
-<small class="help">* Dauer nur sichtbar, wenn „Individuell pro Slide“ gewählt ist.</small>
-  <div class="content">
-<div class="sl-head sl-images">
-    <span class="col-name">Name</span>
-    <span class="col-prev">Preview</span>
-    <span class="col-dur" id="headImgDur">Dauer (s)</span>
-    <span class="col-up">Upload</span>
-    <span class="col-del">✕</span>
-    <span class="col-after">Nach Slide</span>
-    <span class="col-vis">Anzeigen</span>
-  </div>
-    <div id="interList2"></div>
-  </div>
-</details>
-
-<!-- Unterbox 4: HTML-Slides -->
-<details class="ac sub" id="boxHtml">
-  <summary>
-    <div class="ttl">▶<span class="chev">⮞</span> HTML-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnHtmlAdd">HTML hinzufügen</button></div>
-  </summary>
-  <div class="content">
-    <div class="sl-head sl-html">
-      <span class="col-name">Name</span>
-      <span class="col-prev">Preview</span>
-      <span class="col-edit">Bearbeiten</span>
-      <span class="col-dur" id="headHtmlDur">Dauer (s)</span>
-      <span class="col-del">✕</span>
-      <span class="col-after">Nach Slide</span>
-      <span class="col-vis">Anzeigen</span>
-    </div>
-    <div id="htmlList"></div>
-  </div>
-</details>
-
   </div>
 </details>
 
@@ -297,7 +236,68 @@
             </div>
           </div>
         </div>
-      </details>
+</details>
+
+<!-- Fußnoten -->
+<details class="ac" id="boxFootnotes">
+  <summary>
+    <div class="ttl">▶<span class="chev">⮞</span> Fußnoten</div>
+    <div class="actions"><button class="btn sm" id="fnAdd">Hinzufügen</button></div>
+  </summary>
+  <div class="content">
+    <div id="fnList"></div>
+    <div class="subh">Darstellung</div>
+    <div class="kv">
+      <label>Fußnoten-Layout</label>
+      <select id="footnoteLayout" class="input">
+        <option value="one-line" selected>Möglichst einzeilig</option>
+        <option value="multi">Mehrzeilig</option>
+        <option value="stacked">Untereinander (jede Zeile)</option>
+      </select>
+    </div>
+  </div>
+</details>
+
+<!-- Bild-Slides -->
+<details class="ac" id="boxImages">
+  <summary>
+    <div class="ttl">▶<span class="chev">⮞</span> Bild-Slides</div>
+    <div class="actions"><button class="btn sm" id="btnInterAdd2">Bild hinzufügen</button></div>
+  </summary>
+  <small class="help">* Dauer nur sichtbar, wenn „Individuell pro Slide“ gewählt ist.</small>
+  <div class="content">
+    <div class="sl-head sl-images">
+      <span class="col-name">Name</span>
+      <span class="col-prev">Preview</span>
+      <span class="col-dur" id="headImgDur">Dauer (s)</span>
+      <span class="col-up">Upload</span>
+      <span class="col-del">✕</span>
+      <span class="col-after">Nach Slide</span>
+      <span class="col-vis">Anzeigen</span>
+    </div>
+    <div id="interList2"></div>
+  </div>
+</details>
+
+<!-- HTML-Slides -->
+<details class="ac" id="boxHtml">
+  <summary>
+    <div class="ttl">▶<span class="chev">⮞</span> HTML-Slides</div>
+    <div class="actions"><button class="btn sm" id="btnHtmlAdd">HTML hinzufügen</button></div>
+  </summary>
+  <div class="content">
+    <div class="sl-head sl-html">
+      <span class="col-name">Name</span>
+      <span class="col-prev">Preview</span>
+      <span class="col-edit">Bearbeiten</span>
+      <span class="col-dur" id="headHtmlDur">Dauer (s)</span>
+      <span class="col-del">✕</span>
+      <span class="col-after">Nach Slide</span>
+      <span class="col-vis">Anzeigen</span>
+    </div>
+    <div id="htmlList"></div>
+  </div>
+</details>
 
       <details class="ac">
         <summary>
@@ -305,9 +305,7 @@
           <div class="actions"><button class="btn sm ghost" id="resetColors">Standardwerte</button></div>
         </summary>
         <div class="content color-cols" id="colorList"></div>
-    </div>
-</details>     
-</details>
+      </details>
 
       <details class="ac">
         <summary>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -680,23 +680,23 @@ async function createDevicesPane(){
   card.id = 'devicesPane';
   card.innerHTML = `
     <div class="content">
-      <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:8px">
-        <div style="font-weight:800">Geräte</div>
-        <div class="row" style="gap:6px">
-          <button class="btn sm" id="devPairManual">Code eingeben…</button>
-          <button class="btn sm" id="devRefresh">Aktualisieren</button>
-          <button class="btn sm" id="devPin"></button>
-          <button class="btn sm danger" id="devGc">Aufräumen</button>
-      </div>
+      <div class="card-head">
+        <div class="card-title">Geräte</div>
+        <div class="device-toolbar">
+          <button class="btn sm icon-label" id="devPairManual"><span class="icon">⌨️</span><span class="label">Code eingeben…</span></button>
+          <button class="btn sm icon-label" id="devRefresh"><span class="icon">⟳</span><span class="label">Aktualisieren</span></button>
+          <button class="btn sm icon-label" id="devPin"></button>
+          <button class="btn sm danger icon-label" id="devGc"><span class="icon">🧹</span><span class="label">Aufräumen</span></button>
+        </div>
       </div>
 
       <div id="devPendingWrap">
-        <div class="subh" style="font-weight:700;margin:8px 0">Ungepairt</div>
+        <div class="subh">Ungepairt</div>
         <div id="devPendingList" class="kv"></div>
       </div>
 
-      <div id="devPairedWrap" style="margin-top:12px">
-        <div class="subh" style="font-weight:700;margin:8px 0">Gepaart</div>
+      <div id="devPairedWrap" class="devices-section">
+        <div class="subh">Gepaart</div>
         <div id="devPairedList" class="kv"></div>
       </div>
 
@@ -842,7 +842,10 @@ async function createDevicesPane(){
   await render();
 
   const pinBtn = card.querySelector('#devPin');
-  const updatePin = ()=>{ pinBtn.textContent = devicesPinned ? 'Loslösen' : 'Anpinnen'; document.body.classList.toggle('devices-pinned', devicesPinned); };
+  const updatePin = ()=>{
+    pinBtn.innerHTML = `<span class="icon">📌</span><span class="label">${devicesPinned ? 'Loslösen' : 'Anpinnen'}</span>`;
+    document.body.classList.toggle('devices-pinned', devicesPinned);
+  };
   pinBtn.onclick = ()=>{ devicesPinned = !devicesPinned; localStorage.setItem('devicesPinned', devicesPinned?'1':'0'); updatePin(); showView(currentView); };
   updatePin();
 


### PR DESCRIPTION
## Summary
- replace inline device pane styles with reusable CSS classes and icon-labeled toolbar
- add utility CSS for headings, toolbar spacing, and section separation
- reorder admin sections so footnotes, image slides, and HTML slides follow slide settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb65ff62f48320851b61e8defe9bf1