### PR TITLE
Add admin help overlay and tooltips

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -198,6 +198,24 @@ details[open] .chev{ transform: rotate(90deg); }
 .btn.ghost{
   background:var(--ghost-bg); color:var(--ghost-fg); border:1px solid var(--ghost-border);
 }
+
+/* ---------- Hilfe-Overlay & Tooltips ---------- */
+.tip{ cursor:help; color:var(--muted); margin-left:4px; }
+
+#helpOverlay{
+  position:fixed; inset:0; z-index:100;
+  background:rgba(0,0,0,.6);
+  display:flex; align-items:center; justify-content:center;
+}
+#helpOverlay[hidden]{ display:none; }
+#helpOverlay .panel{
+  background:var(--panel); color:var(--fg);
+  border:1px solid var(--border); border-radius:16px;
+  padding:24px; max-width:500px; width:90%;
+  position:relative;
+}
+#helpOverlay .panel h2{ margin-top:0; }
+#helpClose{ position:absolute; top:8px; right:8px; }
 .btn.ghost:hover{ background: color-mix(in oklab, var(--ghost-fg) 6%, transparent); }
 
 /* Toggle */

--- a/webroot/admin/help.md
+++ b/webroot/admin/help.md
@@ -1,0 +1,13 @@
+# Hilfe für den Admin-Bereich
+
+## Slides hinzufügen
+1. Öffne den Abschnitt **Saunen & Übersicht**.
+2. Klicke auf **Sauna hinzufügen** und wähle eine Datei.
+3. Passe Dauer und Sichtbarkeit an und speichere.
+
+## Geräte bearbeiten
+1. Wechsle über das Ansicht-Menü zur Ansicht **Geräte**.
+2. Wähle ein Gerät aus der Liste, um Name oder Preset zu ändern.
+3. Speichere, um die Änderungen zu übernehmen.
+
+Weitere Hinweise findest du direkt in der Anwendung.

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -25,7 +25,7 @@
     <button class="dd-item" role="menuitemradio" data-view="devices" aria-checked="false">🖥 Geräte</button>
   </div>
 </div>
-
+      <button class="btn" id="btnHelp">Hilfe</button>
       <button class="btn" id="btnOpen">Slideshow öffnen</button>
       <button class="btn primary" id="btnSave">Speichern</button>
     </div>
@@ -71,7 +71,7 @@
 
 <!-- Dauer-Modus (global, gilt für Saunen + Bilder) -->
 <div class="kv" id="rowDurMode">
-  <label>Dauer-Modus</label>
+  <label>Dauer-Modus <span class="tip" title="Bestimmt, ob alle Slides dieselbe Dauer haben oder individuell gesteuert werden.">❔</span></label>
   <div class="row">
     <label class="btn sm ghost" style="gap:6px"><input type="radio" name="durMode" id="durUniform" value="uniform"> Einheitlich</label>
     <label class="btn sm ghost" style="gap:6px"><input type="radio" name="durMode" id="durPer" value="per"> Individuell pro Slide</label>
@@ -94,7 +94,7 @@
   <input id="transMs2" class="input" type="number" min="0" value="500">
 </div>
 
-<div class="kv"><label>Auto je Wochentag</label><input id="presetAuto" type="checkbox"></div>
+<div class="kv"><label>Auto je Wochentag <span class="tip" title="Lädt beim Start automatisch das Preset des aktuellen Wochentags.">❔</span></label><input id="presetAuto" type="checkbox"></div>
 <div class="help">Wenn aktiv, wird beim Öffnen und beim Wechsel des Tabs automatisch das Preset des aktuellen Wochentags geladen (falls vorhanden).</div>
 
     <!-- Unterbox 1: Saunen & Übersicht -->
@@ -146,7 +146,7 @@
     <div id="fnList"></div>
     <div class="subh">Darstellung</div>
     <div class="kv">
-      <label>Fußnoten-Layout</label>
+      <label>Fußnoten-Layout <span class="tip" title="Legt fest, wie mehrere Fußnoten dargestellt werden.">❔</span></label>
       <select id="footnoteLayout" class="input">
         <option value="one-line" selected>Möglichst einzeilig</option>
         <option value="multi">Mehrzeilig</option>
@@ -396,6 +396,18 @@
   </div>
 </div>
 
+<div id="helpOverlay" hidden>
+  <div class="panel">
+    <button id="helpClose" class="btn icon" aria-label="Schließen">✕</button>
+    <h2>Schnellstart</h2>
+    <ul>
+      <li>Nutze „Sauna hinzufügen“, um neue Slides zu erstellen.</li>
+      <li>Wechsle zur Ansicht „Geräte“, um Displays zu bearbeiten.</li>
+    </ul>
+    <p>Mehr Hilfe in der <a href="/admin/help.md" target="_blank">Dokumentation</a>.</p>
+  </div>
+</div>
+
 <script>
 
   (function(){
@@ -408,6 +420,7 @@
   })();
 
 </script>
+<script type="module" src="/admin/js/help.js"></script>
 <script type="module" src="/admin/js/app.js"></script>
 </body>
 </html>

--- a/webroot/admin/js/help.js
+++ b/webroot/admin/js/help.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('btnHelp');
+  const overlay = document.getElementById('helpOverlay');
+  const close = document.getElementById('helpClose');
+  if (!btn || !overlay || !close) return;
+  const hide = () => { overlay.hidden = true; };
+  btn.addEventListener('click', () => {
+    overlay.hidden = false;
+  });
+  close.addEventListener('click', hide);
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) hide();
+  });
+});


### PR DESCRIPTION
## Summary
- Add "Hilfe" button with overlay and quick-start guidance
- Explain complex settings with tooltip icons
- Provide help.md with common workflows and link from overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb65fe18888320912c3c4ac128f500