### PR TITLE
Use scale factors for tile sizing and flame gaps

### DIFF
--- a/webroot/admin/api/load_settings.php
+++ b/webroot/admin/api/load_settings.php
@@ -20,13 +20,13 @@ echo json_encode([
     'scale'=>1, 'h1Scale'=>1, 'h2Scale'=>1,
     'overviewTitleScale'=>1, 'overviewHeadScale'=>0.9, 'overviewCellScale'=>0.8,
     'tileTextScale'=>0.8, 'tileWeight'=>600, 'chipHeight'=>1,
-    'chipOverflowMode'=>'scale','flamePct'=>55,'flameGapPct'=>14
+    'chipOverflowMode'=>'scale','flamePct'=>55,'flameGapScale'=>0.14
   ],
   'h2'=>['mode'=>'text','text'=>'Aufgusszeiten','showOnOverview'=>true],
   'display'=>['fit'=>'cover','rightWidthPercent'=>38,'cutTopPercent'=>28,'cutBottomPercent'=>12],
   'slides'=>[
     'overviewDurationSec'=>10,'saunaDurationSec'=>6,'transitionMs'=>500,
-    'tileWidthPercent'=>45,'tileMinPct'=>25,'tileMaxPct'=>57,
+    'tileWidthPercent'=>45,'tileMinScale'=>0.25,'tileMaxScale'=>0.57,
     'durationMode'=>'uniform','globalDwellSec'=>6,'loop'=>true,
     'order'=>['overview']
   ],

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -258,8 +258,8 @@
 <div class="kv"><label>Flammen-Größe (% der Chip-Höhe)</label>
   <input id="flamePct" class="input" type="number" min="30" max="100" value="55">
 </div>
-<div class="kv"><label>Flammen-Abstand (%)</label>
-  <input id="flameGap" class="input" type="number" min="0" max="100" value="14">
+<div class="kv"><label>Flammen-Abstand (Faktor)</label>
+  <input id="flameGap" class="input" type="number" min="0" max="1" step="0.01" value="0.14">
 </div>
 
           <div class="subh">Saunafolien (Kacheln)</div>
@@ -274,8 +274,8 @@
             </select>
           </div>
           <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
-          <div class="kv"><label>Kachel‑Breite min (%)</label><input id="tileMin" class="input" type="number" min="0" max="100" value="25"></div>
-          <div class="kv"><label>Kachel‑Breite max (%)</label><input id="tileMax" class="input" type="number" min="0" max="100" value="57"></div>
+          <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
+          <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
 
           <div class="subh">Bildspalte / Schrägschnitt</div>
           <div class="kv"><label>Breite rechts (%)</label><input id="rightW" class="input" type="number" min="0" max="70" value="38"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -204,7 +204,7 @@ function renderSlidesBox(){
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#chipOverflowMode', f.chipOverflowMode ?? 'scale');
   setV('#flamePct',         f.flamePct         ?? 55);
-  setV('#flameGap',         f.flameGapPct      ?? 14);
+  setV('#flameGap',         f.flameGapScale    ?? 0.14);
 
   // H2
   setV('#h2Mode', settings.h2?.mode ?? DEFAULTS.h2.mode);
@@ -221,8 +221,8 @@ function renderSlidesBox(){
   setV('#tileTextScale', f.tileTextScale ?? 0.8);
   setV('#tileWeight',    f.tileWeight    ?? 600);
   setV('#tilePct',       settings.slides?.tileWidthPercent ?? 45);
-  setV('#tileMin',       settings.slides?.tileMinPct ?? 25);
-  setV('#tileMax',       settings.slides?.tileMaxPct ?? 57);
+  setV('#tileMin',       settings.slides?.tileMinScale ?? 0.25);
+  setV('#tileMax',       settings.slides?.tileMaxScale ?? 0.57);
 
   // Bildspalte / Schrägschnitt
   setV('#rightW',   settings.display?.rightWidthPercent ?? 38);
@@ -250,13 +250,13 @@ function renderSlidesBox(){
     setV('#chipH',        Math.round(DEFAULTS.fonts.chipHeight*100));
     setV('#chipOverflowMode', DEFAULTS.fonts.chipOverflowMode);
     setV('#flamePct',         DEFAULTS.fonts.flamePct);
-    setV('#flameGap',         DEFAULTS.fonts.flameGapPct);
+    setV('#flameGap',         DEFAULTS.fonts.flameGapScale);
 
     setV('#tileTextScale', DEFAULTS.fonts.tileTextScale);
     setV('#tileWeight',    DEFAULTS.fonts.tileWeight);
     setV('#tilePct',       DEFAULTS.slides.tileWidthPercent);
-    setV('#tileMin',       DEFAULTS.slides.tileMinPct);
-    setV('#tileMax',       DEFAULTS.slides.tileMaxPct);
+    setV('#tileMin',       DEFAULTS.slides.tileMinScale);
+    setV('#tileMax',       DEFAULTS.slides.tileMaxScale);
 
     setV('#rightW',   DEFAULTS.display.rightWidthPercent);
     setV('#cutTop',   DEFAULTS.display.cutTopPercent);
@@ -540,7 +540,7 @@ function collectSettings(){
         chipHeight:(+($('#chipH').value||100)/100),
         chipOverflowMode: ($('#chipOverflowMode')?.value || 'scale'),
         flamePct:   +($('#flamePct')?.value || 55),
-        flameGapPct:+($('#flameGap')?.value || 14),
+        flameGapScale:+($('#flameGap')?.value || 0.14),
         tileTextScale:+($('#tileTextScale').value||0.8),
         tileWeight:+($('#tileWeight').value||600)
       },
@@ -552,8 +552,8 @@ function collectSettings(){
       slides:{
         ...(settings.slides||{}),
         tileWidthPercent:+($('#tilePct')?.value || 45),
-        tileMinPct:+($('#tileMin')?.value || 25),
-        tileMaxPct:+($('#tileMax')?.value || 57),
+        tileMinScale:+($('#tileMin')?.value || 0.25),
+        tileMaxScale:+($('#tileMax')?.value || 0.57),
         showOverview: !!document.getElementById('ovShow')?.checked,
         overviewDurationSec: (() => {
   	const el = document.getElementById('ovSec') || document.getElementById('ovSecGlobal');

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -2,7 +2,7 @@
 // DEFAULTS + Wochentags-Helfer als Single Source of Truth
 
 export const DEFAULTS = {
-  slides:{ overviewDurationSec:10, saunaDurationSec:6, transitionMs:500, tileWidthPercent:45, tileMinPct:25, tileMaxPct:57 },
+  slides:{ overviewDurationSec:10, saunaDurationSec:6, transitionMs:500, tileWidthPercent:45, tileMinScale:0.25, tileMaxScale:0.57 },
   display:{ fit:'cover', baseW:1920, baseH:1080, rightWidthPercent:38, cutTopPercent:28, cutBottomPercent:12 },
   theme:{
     bg:'#E8DEBD', fg:'#5C3101', accent:'#5C3101',
@@ -24,7 +24,7 @@ export const DEFAULTS = {
     scale:1, h1Scale:1, h2Scale:1,
     overviewTitleScale:1, overviewHeadScale:0.9, overviewCellScale:0.8,
     tileTextScale:0.8, tileWeight:600, chipHeight:1,
-    chipOverflowMode:'scale', flamePct:55, flameGapPct:14
+    chipOverflowMode:'scale', flamePct:55, flameGapScale:0.14
   },
   h2:{ mode:'text', text:'Aufgusszeiten', showOnOverview:true },
   assets:{ flameImage:'/assets/img/flame_test.svg' },

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -21,15 +21,17 @@
   --chipHScale:1;
   --chipH:calc(var(--chipHBase)*var(--chipHScale));
   --chipFlamePct:.55;   /* Anteil der Chip-Höhe für Flammen */
-  --chipFlameGapFactor:0.14; /* Anteil der Chip-Höhe als Abstand */
-  --chipFlameGap:calc(var(--chipH) * var(--chipFlameGapFactor));
+  --chipFlameGapScale:0.14; /* Anteil der Chip-Höhe als Abstand */
+  --chipFlameGap:calc(var(--chipH) * var(--chipFlameGapScale));
   --ovAuto:1; /* overview-only autoscale factor */
 
   /* right panel shape */
   --rightW:38%; --cutTop:28%; --cutBottom:12%;
 
-  /* sauna tile clamp (JS sets --tileTargetPx and min/max via factors) */
-  --tileMinPx:480px; --tileMaxPx:1100px; --tileTargetPx:860px;
+  /* sauna tile clamp (JS sets --tileTargetPx and baseW) */
+  --baseW:1920px;
+  --tileMinScale:0.25; --tileMaxScale:0.57;
+  --tileTargetPx:860px;
   --flameSizePxOv:18; /* kleine Flames in Übersicht-Chips */
   --ovTitleScale:1; /* nur H1 der Übersicht */
   --flamesColW: calc(var(--flameSizePx)*1px*var(--scale)*3 + 24px);
@@ -137,7 +139,7 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 
 /* sauna tiles */
 .tile{display:grid; grid-template-columns:1fr auto; align-items:center; gap:calc(16px*var(--vwScale));
-  width: clamp(calc(var(--tileMinPx)*var(--vwScale)), var(--tileTargetPx), calc(var(--tileMaxPx)*var(--vwScale)));
+  width: clamp(calc(var(--baseW)*var(--tileMinScale)*var(--vwScale)), var(--tileTargetPx), calc(var(--baseW)*var(--tileMaxScale)*var(--vwScale)));
   padding:calc(14px*var(--vwScale)) calc(18px*var(--vwScale)); background:var(--cell);   border:calc(var(--tileBorderW)*var(--vwScale)) solid var(--tileBorder); border-radius:16px; color:var(--boxfg);
 }
 .title{font-size:calc(40px*var(--scale)*var(--tileTextScale)); font-weight:var(--tileWeight)}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -125,7 +125,7 @@ async function loadDeviceResolved(id){
   const f = settings?.fonts || {};
   setVars({
   '--chipFlamePct': Math.max(0.3, Math.min(1, (f.flamePct || 55) / 100)),
-  '--chipFlameGapFactor': Math.max(0, (f.flameGapPct ?? 14) / 100)
+  '--chipFlameGapScale': Math.max(0, (f.flameGapScale ?? 0.14))
 });
 // 'scale' = Text automatisch verkleinern, 'ellipsis' = auf „…“ kürzen
 document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
@@ -140,6 +140,7 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     if (typeof d.cutBottomPercent === 'number')  document.documentElement.style.setProperty('--cutBottom', d.cutBottomPercent + '%');
 
     const baseW = d.baseW || 1920;
+    document.documentElement.style.setProperty('--baseW', baseW + 'px');
     const updateVwScale = () => {
       const vw = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
       const s = Math.max(0.25, vw / baseW); // untere Schranke gegen Ultra-Klein
@@ -536,13 +537,11 @@ function renderHtmlSlide(html) {
     const avail = computeAvailContentWidth(container);
     const pct = (settings?.slides?.tileWidthPercent ?? 45) / 100;
     const target = Math.max(0, avail * pct);
-    const minPct = Math.max(0, (settings?.slides?.tileMinPct ?? 25) / 100);
-    const maxPct = Math.max(minPct, (settings?.slides?.tileMaxPct ?? 57) / 100);
-    const minPx = avail * minPct;
-    const maxPx = avail * maxPct;
+    const minScale = Math.max(0, settings?.slides?.tileMinScale ?? 0.25);
+    const maxScale = Math.max(minScale, settings?.slides?.tileMaxScale ?? 0.57);
     container.style.setProperty('--tileTargetPx', target + 'px');
-    container.style.setProperty('--tileMinPx', minPx + 'px');
-    container.style.setProperty('--tileMaxPx', maxPx + 'px');
+    container.style.setProperty('--tileMinScale', String(minScale));
+    container.style.setProperty('--tileMaxScale', String(maxScale));
   }
 
   // ---------- Sauna slide ----------

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -16,7 +16,7 @@
   "fonts": {
     "family": "-apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
     "scale": 1.00,
-    "flameGapPct": 14
+    "flameGapScale": 0.14
   },
   "display": {
     "rightWidthPercent": 38,
@@ -28,8 +28,8 @@
     "saunaDurationSec": 6,
     "transitionMs": 500,
     "tileWidthPercent": 45,
-    "tileMinPct": 25,
-    "tileMaxPct": 57,
+    "tileMinScale": 0.25,
+    "tileMaxScale": 0.57,
     "loop": true,
     "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"]
   },


### PR DESCRIPTION
## Summary
- Replace pixel-based tile min/max and flame gap settings with scalable factors
- Derive tile clamp values and chip flame spacing from viewport/base dimensions
- Adapt admin UI and settings handling to read/write new scale fields

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/HTMLSignage/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bb65fd0560832090b6bd7139a3e5ba