### PR TITLE
Remove duplicate admin details sections

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -299,72 +299,11 @@
         </div>
 </details>
 
-<!-- Fußnoten -->
-<details class="ac" id="boxFootnotes">
-  <summary>
-    <div class="ttl">▶<span class="chev">⮞</span> Fußnoten</div>
-    <div class="actions"><button class="btn sm" id="fnAdd">Hinzufügen</button></div>
-  </summary>
-  <div class="content">
-    <div id="fnList"></div>
-    <div class="subh">Darstellung</div>
-    <div class="kv">
-      <label>Fußnoten-Layout</label>
-      <select id="footnoteLayout" class="input">
-        <option value="one-line" selected>Möglichst einzeilig</option>
-        <option value="multi">Mehrzeilig</option>
-        <option value="stacked">Untereinander (jede Zeile)</option>
-      </select>
-    </div>
-  </div>
-</details>
-
-<!-- Bild-Slides -->
-<details class="ac" id="boxImages">
-  <summary>
-    <div class="ttl">▶<span class="chev">⮞</span> Bild-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnInterAdd2">Bild hinzufügen</button></div>
-  </summary>
-  <small class="help">* Dauer nur sichtbar, wenn „Individuell pro Slide“ gewählt ist.</small>
-  <div class="content">
-    <div class="sl-head sl-images">
-      <span class="col-name">Name</span>
-      <span class="col-prev">Preview</span>
-      <span class="col-dur" id="headImgDur">Dauer (s)</span>
-      <span class="col-up">Upload</span>
-      <span class="col-del">✕</span>
-      <span class="col-after">Nach Slide</span>
-      <span class="col-vis">Anzeigen</span>
-    </div>
-    <div id="interList2"></div>
-  </div>
-</details>
-
-<!-- HTML-Slides -->
-<details class="ac" id="boxHtml">
-  <summary>
-    <div class="ttl">▶<span class="chev">⮞</span> HTML-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnHtmlAdd">HTML hinzufügen</button></div>
-  </summary>
-  <div class="content">
-    <div class="sl-head sl-html">
-      <span class="col-name">Name</span>
-      <span class="col-prev">Preview</span>
-      <span class="col-edit">Bearbeiten</span>
-      <span class="col-dur" id="headHtmlDur">Dauer (s)</span>
-      <span class="col-del">✕</span>
-      <span class="col-after">Nach Slide</span>
-      <span class="col-vis">Anzeigen</span>
-    </div>
-    <div id="htmlList"></div>
-  </div>
-</details>
-
-      <details class="ac">
-        <summary>
-          <div class="ttl">▶<span class="chev">⮞</span> Farben (Übersicht & Zeitspalte)</div>
-          <div class="actions"><button class="btn sm ghost" id="resetColors">Standardwerte</button></div>
-        </summary>
+        <details class="ac">
+          <summary>
+            <div class="ttl">▶<span class="chev">⮞</span> Farben (Übersicht & Zeitspalte)</div>
+            <div class="actions"><button class="btn sm ghost" id="resetColors">Standardwerte</button></div>
+          </summary>
         <div class="content color-cols" id="colorList"></div>
       </details>
 


### PR DESCRIPTION
## Summary
- remove redundant `boxFootnotes`, `boxImages` and `boxHtml` detail sections from admin index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7b2d474c8320a58edf21d5c74d95