### PR TITLE
Add PDF and external URL support for interstitial slides

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -51,7 +51,12 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 /* interstitial image */
 .container.imgslide{padding:0}
 .container.htmlslide{padding:0}
+.container.pdfslide{padding:0}
+.container.urlslide{padding:0}
 .imgFill{position:absolute; inset:0; background-size:cover; background-position:center; background-repeat:no-repeat}
+
+.pdfFrame,.urlFrame{position:absolute; inset:0; width:100%; height:100%; border:0}
+.urlMsg{position:absolute; inset:0; display:flex; align-items:center; justify-content:center; background:#fff; color:#000;}
 
 /* layout */
 .container{position:relative; height:100%; padding:calc(32px*var(--vwScale)); display:flex; flex-direction:column; align-items:flex-start}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -178,12 +178,18 @@ function buildQueue() {
   if (showOverview) queue.push({ type: 'overview' });
   for (const s of visibleSaunas) queue.push({ type: 'sauna', sauna: s });
 
-  // Bilder & HTML-Slides vorbereiten
-  const imgsAll = Array.isArray(settings?.interstitials) ? settings.interstitials : [];
+  // Medien-Slides (Bild/PDF/URL) & HTML-Slides vorbereiten
+  const intersAll = Array.isArray(settings?.interstitials) ? settings.interstitials : [];
   const htmlAll = Array.isArray(settings?.htmlSlides) ? settings.htmlSlides : [];
-  const imgs = imgsAll.filter(it => it && it.enabled && it.url).map(it=>({...it, __kind:'image'}));
+  const inters = intersAll.filter(it => it && it.enabled).map(it => {
+    const t = it.type || 'image';
+    if (t === 'pdf' && it.pdf) return { ...it, __kind:'pdf' };
+    if (t === 'url' && it.url) return { ...it, __kind:'url' };
+    if (t === 'image' && it.url) return { ...it, __kind:'image' };
+    return null;
+  }).filter(Boolean);
   const htmls = htmlAll.filter(it => it && it.enabled && it.html).map(it=>({...it, __kind:'html'}));
-  const media = imgs.concat(htmls);
+  const media = inters.concat(htmls);
 
   // Hilfen
   const idxOverview = () => queue.findIndex(x => x.type === 'overview');
@@ -201,9 +207,9 @@ function buildQueue() {
         const io = idxOverview();
         insPos = (io >= 0) ? io + 1 : 0;
       } else if (String(ref).startsWith('img:')) {
-        // nach Bild: nur einfügen, wenn das Bild bereits platziert ist
+        // nach Slide: nur einfügen, wenn das Slide bereits platziert ist
         const prevId = String(ref).slice(4);
-        const prevIndex = queue.findIndex(x => x.type === 'image' && x.__id === prevId);
+        const prevIndex = queue.findIndex(x => ['image','pdf','url'].includes(x.type) && x.__id === prevId);
         if (prevIndex === -1) { postponed.push(it); continue; }
         insPos = prevIndex + 1;
       } else {
@@ -245,6 +251,8 @@ function buildQueue() {
 
       let node;
       if (it.__kind === 'html') node = { type:'html', html: it.html, dwell, __id: it.id || null };
+      else if (it.__kind === 'pdf') node = { type:'pdf', url: it.pdf, dwell, __id: it.id || null };
+      else if (it.__kind === 'url') node = { type:'url', url: it.url, dwell, __id: it.id || null };
       else node = { type:'image', url: it.url, dwell, __id: it.id || null };
       queue.splice(insPos, 0, node);
     }
@@ -521,6 +529,25 @@ function renderHtmlSlide(html) {
   return c;
 }
 
+function renderPdf(url) {
+  const iframe = h('iframe', { class: 'pdfFrame', src: url });
+  const c = h('div', { class: 'container pdfslide fade show' }, [iframe]);
+  return c;
+}
+
+function renderUrl(url) {
+  const iframe = h('iframe', { class: 'urlFrame', src: url });
+  const msg = h('div', { class: 'urlMsg' }, 'Lade…');
+  const c = h('div', { class: 'container urlslide fade show' }, [iframe, msg]);
+  let loaded = false;
+  const done = () => { loaded = true; msg.remove(); };
+  const err = () => { msg.textContent = 'Fehler beim Laden'; };
+  iframe.addEventListener('load', done, { once:true });
+  iframe.addEventListener('error', err, { once:true });
+  setTimeout(() => { if (!loaded) err(); }, 10000);
+  return c;
+}
+
   // ---------- Sauna tile sizing by unobscured width ----------
   function computeAvailContentWidth(container) {
     const cw = container.clientWidth;
@@ -635,7 +662,7 @@ function dwellMsForItem(item) {
     }
   }
 
-  if (item.type === 'image' || item.type === 'html') {
+    if (item.type === 'image' || item.type === 'html' || item.type === 'pdf' || item.type === 'url') {
     if (mode !== 'per') {
       const g = slides.globalDwellSec ?? slides.imageDurationSec ?? slides.saunaDurationSec ?? 6;
       return sec(g) * 1000;
@@ -665,6 +692,8 @@ if (key === lastKey && nextQueue.length > 1) {
     (item.type === 'overview') ? renderOverview() :
     (item.type === 'sauna')    ? renderSauna(item.sauna) :
     (item.type === 'html')     ? renderHtmlSlide(item.html) :
+    (item.type === 'pdf')      ? renderPdf(item.url) :
+    (item.type === 'url')      ? renderUrl(item.url) :
                                  renderImage(item.url);
 
   show(el);


### PR DESCRIPTION
## Summary
- extend interstitial editor with source selection (Image/PDF/URL), URL validation, and type-specific uploads
- support new `type` with `url`/`pdf` fields in interstitial data model
- render PDFs and external URLs in slideshow with simple load/error handling

## Testing
- `node --check webroot/admin/js/ui/slides_master.js`
- `node --check webroot/assets/slideshow.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bb7b34000883208cb638c2ae8f330d