### PR TITLE
feat: highlight individual mode with badge and sidebar

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -105,14 +105,35 @@ header{
 h1{ margin:0; font-size:16px; letter-spacing:.3px; }
 
 body.device-mode header{
+  /* Neutraler Header, keine Vollflächige Farbänderung */
+  background: color-mix(in oklab, var(--panel) 85%, transparent);
+  color: var(--fg);
+}
+
+/* Seitenleiste zur Kennzeichnung des individuellen Modus */
+body.device-mode::before{
+  content: "";
+  position:fixed;
+  top:0; left:0; bottom:0;
+  width:6px;
+  background:var(--btn-primary);
+  animation:modePulse 2s ease-in-out infinite;
+  z-index:70;
+}
+
+@keyframes modePulse{
+  0%,100%{opacity:1;}
+  50%{opacity:.5;}
+}
+
+body.device-mode #ctxBadge{
   background: var(--btn-primary);
   color: var(--btn-primary-fg);
-}
-body.device-mode #ctxBadge{
-  background: var(--btn-primary-fg);
-  color: var(--btn-primary);
-  font-size:20px;
-  padding:12px 20px;
+  font-size:16px;
+  padding:10px 16px;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
 }
 
 /* ---------- Layout: Main + Rightbar ---------- */
@@ -247,7 +268,8 @@ details[open] .chev{ transform: rotate(90deg); }
 
 /* Badge für Geräte-Kontext */
 .ctx-badge{
-    display:inline-block;
+    display:inline-flex;
+    align-items:center;
     margin-left:8px;
     padding:10px 16px;
     border-radius:12px;
@@ -255,7 +277,9 @@ details[open] .chev{ transform: rotate(90deg); }
     color:var(--btn-accent-fg);
     font-size:18px;
     font-weight:700;
+    gap:6px;
 }
+.ctx-badge .ctx-icon{ font-size:20px; }
 .ctx-badge button{
   margin-left:6px;
   border:none;

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -44,12 +44,17 @@ function renderContextBadge(){
     return;
   }
   if (!el){
-    el = document.createElement('span'); el.id='ctxBadge';
+    el = document.createElement('span');
+    el.id='ctxBadge';
     el.className='ctx-badge';
-    el.title = 'Klick ×, um zur globalen Ansicht zurückzukehren';
+    el.setAttribute('role','status');
+    el.setAttribute('aria-label','Individueller Modus aktiv');
+    el.title = 'Individueller Modus';
     h1.after(el);
   }
-  el.innerHTML = `Kontext: ${currentDeviceName || currentDeviceCtx} <button id="ctxReset" title="Zurück zu Global">×</button>`;
+  el.innerHTML = `<span class="ctx-icon" aria-hidden="true">⚙️</span>`+
+    `<span class="ctx-text">Individueller Modus aktiv: ${currentDeviceName || currentDeviceCtx}</span>`+
+    ` <button id="ctxReset" class="ctx-reset" title="Zurück zur globalen Ansicht" aria-label="Zurück zur globalen Ansicht">×</button>`;
   el.querySelector('#ctxReset').onclick = ()=> exitDeviceContext();
   if (!tip){
     tip = document.createElement('small');


### PR DESCRIPTION
## Summary
- keep admin header neutral and show animated sidebar when individual device mode is active
- redesign context badge with icon, tooltip and ARIA attributes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7b352880832099b89d2d34b841e1