### PR TITLE
Add PDF and external URL support for interstitial slides

### DIFF
--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -30,7 +30,8 @@ $allowed = [
 'image/png' => 'png',
 'image/jpeg'=> 'jpg',
 'image/webp'=> 'webp',
-'image/svg+xml' => 'svg'
+'image/svg+xml' => 'svg',
+'application/pdf' => 'pdf'
 ];
 if (!isset($allowed[$mime])) fail('unsupported-type: '.$mime);
 
@@ -41,7 +42,7 @@ if (!$orig) $orig = 'upload.' . $ext;
 if (!preg_match('/\.' . preg_quote($ext,'/') . '$/i', $orig)) $orig .= '.' . $ext;
 
 
-$baseDir = '/var/www/signage/assets/img/';
+$baseDir = ($ext === 'pdf') ? '/var/www/signage/assets/pdf/' : '/var/www/signage/assets/img/';
 if (!is_dir($baseDir)) { @mkdir($baseDir, 02775, true); @chown($baseDir,'www-data'); @chgrp($baseDir,'www-data'); }
 
 
@@ -55,5 +56,5 @@ if (!@move_uploaded_file($u['tmp_name'], $dest)) fail('move-failed', 500);
 @chmod($dest, 0644); @chown($dest,'www-data'); @chgrp($dest,'www-data');
 
 
-$publicPath = '/assets/img/' . basename($dest);
+$publicPath = ($ext === 'pdf' ? '/assets/pdf/' : '/assets/img/') . basename($dest);
 echo json_encode(['ok'=>true,'path'=>$publicPath]);

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -611,7 +611,7 @@ function renderSaunaOffList(){
 }
 
 // ============================================================================
-// 6) Interstitial Images (Bild-Slides)
+// 6) Interstitial Slides (Bild/PDF/URL)
 // ============================================================================
 function usedAfterImageIds(exceptId){
   const settings = ctx.getSettings();
@@ -644,7 +644,7 @@ function interAfterOptionsHTML(currentId){
     .map(x => {
       const val = 'img:' + x.id;
       const taken = used.has(x.id);
-      const label = 'Bild: ' + (x.name || x.id) + (taken ? ' (belegt)' : '');
+      const label = 'Slide: ' + (x.name || x.id) + (taken ? ' (belegt)' : '');
       return `<option value="${val}"${taken ? ' disabled' : ''}>${escapeHtml(label)}</option>`;
     });
 
@@ -680,6 +680,8 @@ function applyAfterSelect(it, value){
 function interRow(i){
   const settings = ctx.getSettings();
   const it = settings.interstitials[i];
+  // Legacy migration: earlier versions stored external URLs in `url`
+  if (it.type === 'url' && it.link == null && it.url){ it.link = it.url; it.url = ''; }
   const id = 'inter_' + i;
 
   const wrap = document.createElement('div');
@@ -688,7 +690,13 @@ function interRow(i){
     <input id="n_${id}" class="input name" type="text" value="${escapeHtml(it.name || '')}" />
     <img id="p_${id}" class="prev" alt="" title=""/>
     <input id="sec_${id}" class="input num3 dur intSec" type="number" min="1" max="60" step="1" />
-    <button class="btn sm ghost icon" id="f_${id}" title="Upload">⤴︎</button>
+    <select id="t_${id}" class="input srcSel">
+      <option value="image">Bild</option>
+      <option value="pdf">PDF</option>
+      <option value="url">URL</option>
+    </select>
+    <button class="btn sm ghost icon" id="f_${id}" title="Datei wählen">⤴︎</button>
+    <input id="u_${id}" class="input urlInput" type="text" placeholder="https://..." readonly style="display:none" />
     <button class="btn sm ghost icon" id="x_${id}" title="Entfernen">✕</button>
     <select id="a_${id}" class="input sel-after">${interAfterOptionsHTML(it.id)}</select>
     <input id="en_${id}" type="checkbox" />
@@ -697,7 +705,9 @@ function interRow(i){
   const $name  = wrap.querySelector('#n_'+id);
   const $prev  = wrap.querySelector('#p_'+id);
   const $sec   = wrap.querySelector('#sec_'+id);
+  const $type  = wrap.querySelector('#t_'+id);
   const $up    = wrap.querySelector('#f_'+id);
+  const $url   = wrap.querySelector('#u_'+id);
   const $del   = wrap.querySelector('#x_'+id);
   const $after = wrap.querySelector('#a_'+id);
   const $en    = wrap.querySelector('#en_'+id);
@@ -711,8 +721,41 @@ function interRow(i){
   }
   if ($after) $after.value = getAfterSelectValue(it, it.id);
 
-  if (it.url){
-    preloadImg(it.url).then(r => { if (r.ok){ $prev.src = it.url; $prev.title = `${r.w}×${r.h}`; } });
+  if ($type) $type.value = it.type || 'image';
+  const faviconFor = u => {
+    try { const uu = new URL(u); return 'https://www.google.com/s2/favicons?sz=64&domain_url=' + encodeURIComponent(uu.origin); }
+    catch { return '/assets/img/url_placeholder.svg'; }
+  };
+  if ($type && $url && $up && $prev){
+    const applyType = () => {
+      const t = $type.value;
+      it.type = t;
+      if (t === 'url') {
+        $url.style.display = '';
+        $up.style.display = 'none';
+        $url.value = it.link || '';
+        $prev.style.display = '';
+        $prev.src = it.link ? faviconFor(it.link) : '/assets/img/url_placeholder.svg';
+        $prev.title = it.link || '';
+      } else if (t === 'pdf') {
+        $url.style.display = 'none';
+        $up.style.display = '';
+        $prev.style.display = '';
+        $prev.src = '/assets/img/pdf_placeholder.svg';
+        $prev.title = it.pdf ? it.pdf.split('/').pop() : '';
+      } else {
+        $url.style.display = 'none';
+        $up.style.display = '';
+        if (it.url){
+          $prev.style.display = '';
+          preloadImg(it.url).then(r=>{ if(r.ok){ $prev.src = it.url; $prev.title = `${r.w}×${r.h}`; } else { $prev.src = it.url; } });
+        } else {
+          $prev.style.display = 'none';
+        }
+      }
+    };
+    applyType();
+    $type.onchange = () => { it.type = $type.value; applyType(); };
   }
 
   // Uniform-Mode blendet Dauer-Feld aus
@@ -724,7 +767,7 @@ function interRow(i){
   if ($after) $after.onchange = () => {
     const v = $after.value;
     if (v === 'img:' + it.id){
-      alert('Ein Bild kann nicht nach sich selbst kommen.');
+      alert('Ein Slide kann nicht nach sich selbst kommen.');
       $after.value = 'overview';
       applyAfterSelect(it, 'overview');
       return;
@@ -733,7 +776,7 @@ function interRow(i){
       const used = usedAfterImageIds(it.id);
       const targetId = v.slice(4);
       if (used.has(targetId)){
-        alert('Dieses Bild ist bereits als „Nach Bild“ gewählt.');
+        alert('Dieses Slide ist bereits als „Nach Slide“ gewählt.');
         $after.value = 'overview';
         applyAfterSelect(it, 'overview');
         return;
@@ -746,14 +789,32 @@ function interRow(i){
   if ($en)  $en.onchange  = () => { it.enabled = !!$en.checked; };
   if ($sec) $sec.onchange = () => { it.dwellSec = Math.max(1, Math.min(60, +$sec.value || 6)); };
 
+  if ($url){
+    $url.onclick = () => {
+      const v = prompt('URL eingeben', it.link || 'https://');
+      if (v !== null){
+        try{ const u = new URL(v); it.link = u.href; $url.value = it.link; $prev.src = faviconFor(it.link); $prev.style.display = ''; $prev.title = it.link; }
+        catch { alert('Ungültige URL'); }
+      }
+    };
+  }
+
   if ($up){
     $up.onclick = () => {
       const fi = document.createElement('input');
-      fi.type='file'; fi.accept='image/*';
-      fi.onchange = () => uploadGeneric(fi, (p) => {
-        it.url = p;
-        preloadImg(p).then(r => { if (r.ok){ $prev.src = p; $prev.title = `${r.w}×${r.h}`; } });
-      });
+      fi.type = 'file';
+      fi.accept = ($type && $type.value === 'pdf') ? 'application/pdf' : 'image/*';
+      fi.onchange = () => {
+        const f = fi.files && fi.files[0];
+        if (f){
+          if ($type.value === 'pdf' && f.type !== 'application/pdf'){ alert('Nur PDF-Dateien unterstützt.'); return; }
+          if ($type.value === 'image' && !/^image\//.test(f.type)){ alert('Nur Bilddateien unterstützt.'); return; }
+        }
+        uploadGeneric(fi, (p) => {
+          if ($type.value === 'pdf'){ it.pdf = p; $prev.style.display = ''; $prev.src = '/assets/img/pdf_placeholder.svg'; $prev.title = p.split('/').pop(); }
+          else { it.url = p; preloadImg(p).then(r=>{ if(r.ok){ $prev.src = p; $prev.title = `${r.w}×${r.h}`; } }); }
+        });
+      };
       fi.click();
     };
   }
@@ -822,7 +883,10 @@ function renderInterstitialsPanel(hostId='interList2'){
       id:'im_'+Math.random().toString(36).slice(2,9),
       name:'',
       enabled:true,
+      type:'image',
       url:'',
+      pdf:'',
+      link:'',
       after:'overview',
       dwellSec:6
     });

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -51,7 +51,12 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 /* interstitial image */
 .container.imgslide{padding:0}
 .container.htmlslide{padding:0}
+.container.pdfslide{padding:0}
+.container.urlslide{padding:0}
 .imgFill{position:absolute; inset:0; background-size:cover; background-position:center; background-repeat:no-repeat}
+
+.pdfFrame,.urlFrame{position:absolute; inset:0; width:100%; height:100%; border:0}
+.pdfMsg,.urlMsg{position:absolute; inset:0; display:flex; align-items:center; justify-content:center; background:#fff; color:#000;}
 
 /* layout */
 .container{position:relative; height:100%; padding:calc(32px*var(--vwScale)); display:flex; flex-direction:column; align-items:flex-start}

--- a/webroot/assets/img/pdf_placeholder.svg
+++ b/webroot/assets/img/pdf_placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="42"><rect width="60" height="42" fill="#ddd"/><text x="30" y="26" font-family="sans-serif" font-size="16" text-anchor="middle" fill="#555">PDF</text></svg>

--- a/webroot/assets/img/url_placeholder.svg
+++ b/webroot/assets/img/url_placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="42"><rect width="60" height="42" fill="#ddd"/><text x="30" y="26" font-family="sans-serif" font-size="16" text-anchor="middle" fill="#555">URL</text></svg>

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -178,12 +178,18 @@ function buildQueue() {
   if (showOverview) queue.push({ type: 'overview' });
   for (const s of visibleSaunas) queue.push({ type: 'sauna', sauna: s });
 
-  // Bilder & HTML-Slides vorbereiten
-  const imgsAll = Array.isArray(settings?.interstitials) ? settings.interstitials : [];
+  // Medien-Slides (Bild/PDF/URL) & HTML-Slides vorbereiten
+  const intersAll = Array.isArray(settings?.interstitials) ? settings.interstitials : [];
   const htmlAll = Array.isArray(settings?.htmlSlides) ? settings.htmlSlides : [];
-  const imgs = imgsAll.filter(it => it && it.enabled && it.url).map(it=>({...it, __kind:'image'}));
+  const inters = intersAll.filter(it => it && it.enabled).map(it => {
+    const t = it.type || 'image';
+    if (t === 'pdf' && it.pdf) return { ...it, __kind:'pdf', url: it.pdf };
+    if (t === 'url' && it.link) return { ...it, __kind:'url', url: it.link };
+    if (t === 'image' && it.url) return { ...it, __kind:'image', url: it.url };
+    return null;
+  }).filter(Boolean);
   const htmls = htmlAll.filter(it => it && it.enabled && it.html).map(it=>({...it, __kind:'html'}));
-  const media = imgs.concat(htmls);
+  const media = inters.concat(htmls);
 
   // Hilfen
   const idxOverview = () => queue.findIndex(x => x.type === 'overview');
@@ -201,9 +207,9 @@ function buildQueue() {
         const io = idxOverview();
         insPos = (io >= 0) ? io + 1 : 0;
       } else if (String(ref).startsWith('img:')) {
-        // nach Bild: nur einfügen, wenn das Bild bereits platziert ist
+        // nach Slide: nur einfügen, wenn das Slide bereits platziert ist
         const prevId = String(ref).slice(4);
-        const prevIndex = queue.findIndex(x => x.type === 'image' && x.__id === prevId);
+        const prevIndex = queue.findIndex(x => ['image','pdf','url'].includes(x.type) && x.__id === prevId);
         if (prevIndex === -1) { postponed.push(it); continue; }
         insPos = prevIndex + 1;
       } else {
@@ -245,6 +251,8 @@ function buildQueue() {
 
       let node;
       if (it.__kind === 'html') node = { type:'html', html: it.html, dwell, __id: it.id || null };
+      else if (it.__kind === 'pdf') node = { type:'pdf', url: it.url, dwell, __id: it.id || null };
+      else if (it.__kind === 'url') node = { type:'url', url: it.url, dwell, __id: it.id || null };
       else node = { type:'image', url: it.url, dwell, __id: it.id || null };
       queue.splice(insPos, 0, node);
     }
@@ -521,6 +529,42 @@ function renderHtmlSlide(html) {
   return c;
 }
 
+function renderPdf(url) {
+  const iframe = h('iframe', { class: 'pdfFrame', src: url });
+  const msg = h('div', { class: 'pdfMsg' }, 'Lade…');
+  const c = h('div', { class: 'container pdfslide fade show' }, [iframe, msg]);
+  let loaded = false;
+  const done = () => { loaded = true; msg.remove(); };
+  const err = () => { msg.textContent = 'Fehler beim Laden'; };
+  iframe.addEventListener('load', () => {
+    try {
+      const doc = iframe.contentDocument;
+      if (doc && doc.body && doc.body.childElementCount) done(); else err();
+    } catch { done(); }
+  }, { once:true });
+  iframe.addEventListener('error', err, { once:true });
+  setTimeout(() => { if (!loaded) err(); }, 10000);
+  return c;
+}
+
+function renderUrl(url) {
+  const iframe = h('iframe', { class: 'urlFrame', src: url });
+  const msg = h('div', { class: 'urlMsg' }, 'Lade…');
+  const c = h('div', { class: 'container urlslide fade show' }, [iframe, msg]);
+  let loaded = false;
+  const done = () => { loaded = true; msg.remove(); };
+  const err = () => { msg.textContent = 'Fehler beim Laden'; };
+  iframe.addEventListener('load', () => {
+    try {
+      const doc = iframe.contentDocument;
+      if (doc && doc.body && doc.body.childElementCount) done(); else err();
+    } catch { done(); }
+  }, { once:true });
+  iframe.addEventListener('error', err, { once:true });
+  setTimeout(() => { if (!loaded) err(); }, 10000);
+  return c;
+}
+
   // ---------- Sauna tile sizing by unobscured width ----------
   function computeAvailContentWidth(container) {
     const cw = container.clientWidth;
@@ -635,7 +679,7 @@ function dwellMsForItem(item) {
     }
   }
 
-  if (item.type === 'image' || item.type === 'html') {
+    if (item.type === 'image' || item.type === 'html' || item.type === 'pdf' || item.type === 'url') {
     if (mode !== 'per') {
       const g = slides.globalDwellSec ?? slides.imageDurationSec ?? slides.saunaDurationSec ?? 6;
       return sec(g) * 1000;
@@ -665,6 +709,8 @@ if (key === lastKey && nextQueue.length > 1) {
     (item.type === 'overview') ? renderOverview() :
     (item.type === 'sauna')    ? renderSauna(item.sauna) :
     (item.type === 'html')     ? renderHtmlSlide(item.html) :
+    (item.type === 'pdf')      ? renderPdf(item.url) :
+    (item.type === 'url')      ? renderUrl(item.url) :
                                  renderImage(item.url);
 
   show(el);


### PR DESCRIPTION
## Summary
- extend interstitial editor with source selection (Image/PDF/URL), URL validation, and type-specific uploads
- support new `type` with `url`/`pdf` fields in interstitial data model
- render PDFs and external URLs in slideshow with simple load/error handling

## Testing
- `node --check webroot/admin/js/ui/slides_master.js`
- `node --check webroot/assets/slideshow.js`
- `php -l webroot/admin/api/upload.php`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bb7b34000883208cb638c2ae8f330d