### PR TITLE
refactor: rename image slides to media

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -340,7 +340,7 @@ table.tbl{ width:100%; border-collapse:separate; border-spacing:0; }
 .groupHead .legend, #extraTitle{ font-weight:800; }
 
 /* Spaltenköpfe + Zeilen – exakt gleiche Grid-Spalten */
-.sl-head, .saunarow, .imgrow{
+.sl-head, .saunarow, .mediarow{
   width:100%; display:grid; gap:var(--gap); align-items:center; grid-auto-rows:minmax(42px,auto);
 }
 .sl-head{ margin: 2px 0 6px; }
@@ -349,7 +349,7 @@ table.tbl{ width:100%; border-collapse:separate; border-spacing:0; }
 .sl-head.sl-saunas, .saunarow{
   grid-template-columns: var(--col-name) var(--col-prev) var(--col-dur) var(--col-btn) var(--col-btn) var(--col-del) var(--col-vis);
 }
-.sl-head.sl-images, .imgrow{
+.sl-head.sl-images, .mediarow{
   grid-template-columns: var(--col-name) var(--col-prev) var(--col-dur) var(--col-btn) var(--col-del) var(--col-after) var(--col-vis);
 }
 
@@ -358,7 +358,7 @@ body.mode-uniform #headSaunaDur, body.mode-uniform #headImgDur{ display:none; }
 body.mode-uniform .sl-head.sl-saunas, body.mode-uniform .saunarow{
   grid-template-columns: var(--col-name) var(--col-prev) var(--col-btn) var(--col-btn) var(--col-del) var(--col-vis);
 }
-body.mode-uniform .sl-head.sl-images, body.mode-uniform .imgrow{
+body.mode-uniform .sl-head.sl-images, body.mode-uniform .mediarow{
   grid-template-columns: var(--col-name) var(--col-prev) var(--col-btn) var(--col-del) var(--col-after) var(--col-vis);
 }
 body.mode-uniform .intSec{ display:none !important; }
@@ -375,23 +375,23 @@ body.mode-uniform #ovSec{ display:none !important; }
 }
 
 /* Checkbox-Spalte bündig */
-.saunarow input[type="checkbox"], .imgrow input[type="checkbox"]{ justify-self:center; }
+.saunarow input[type="checkbox"], .mediarow input[type="checkbox"]{ justify-self:center; }
 
 /* Upload/Default Buttons kompakt */
 .btn.icon{ width:28px; height:28px; }
 
 /* Kein Überlaufen der Grids in der Sidebar */
-.saunarow > *, .imgrow > *{ min-width:0; }
+.saunarow > *, .mediarow > *{ min-width:0; }
 
 /* --- Wunschanpassungen: Breiten innerhalb der Spalten ----------------------- */
 /* Sauna-Namen 20% schmaler (lässt innen Luft im Spaltenbereich) */
 .saunarow .input.name{ width:80%; }
 
-/* Bild-Slides: Name 30% schmaler */
-.imgrow .input.name{ width:50%; }
+/* Medien-Slides: Name 30% schmaler */
+.mediarow .input.name{ width:50%; }
 
-/* Bild-Slides: „Nach Slide“-Select 20% schmaler */
-.imgrow .sel-after{ width:70%; justify-self:start; min-width:120px; max-width:100%; }
+/* Medien-Slides: „Nach Slide“-Select 20% schmaler */
+.mediarow .sel-after{ width:70%; justify-self:start; min-width:120px; max-width:100%; }
 
 /* „Kein Aufguss“-Pillen – kleiner, mehr Abstand */
 .pills{ display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -156,11 +156,11 @@
   </div>
 </details>
 
-    <!-- Unterbox 3: Bild-Slides -->
+    <!-- Unterbox 3: Medien-Slides -->
     <details class="ac sub" id="boxImages">
 <summary>
-    <div class="ttl">▶<span class="chev">⮞</span> Bild-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnInterAdd2">Bild hinzufügen</button></div>
+    <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>
+    <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button></div>
   </summary>
 <small class="help">* Dauer nur sichtbar, wenn „Individuell pro Slide“ gewählt ist.</small>
   <div class="content">

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -1098,7 +1098,7 @@ function initCleanupInSystem(){
   if(!btn) return;
   btn.onclick = async ()=>{
     const delSauna = confirm('Sauna-Bilder löschen? OK = Ja, Abbrechen = Nein');
-    const delInter = confirm('Bild-Slides löschen? OK = Ja, Abbrechen = Nein');
+    const delInter = confirm('Medien-Slides löschen? OK = Ja, Abbrechen = Nein');
     const delFlame = confirm('Flammen-Bild löschen? OK = Ja, Abbrechen = Nein');
 
     const qs = new URLSearchParams({

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -1,6 +1,6 @@
 // /admin/js/ui/slides_master.js
 // ============================================================================
-// Master-Panel: Saunen (inkl. „Kein Aufguss“), Übersicht-Row, Bild-Slides,
+// Master-Panel: Saunen (inkl. „Kein Aufguss“), Übersicht-Row, Medien-Slides,
 // Dauer-Modus (einheitlich/individuell), Presets & Wochentage.
 // ----------------------------------------------------------------------------
 // Abhängigkeiten:
@@ -142,7 +142,7 @@ function deleteSaunaEverywhere(name){
     settings.slides.hiddenSaunas = settings.slides.hiddenSaunas.filter(n => n !== name);
   }
 
-  // 7) Verweise in Bild-Slides („Nach Slide“)
+  // 7) Verweise in Medien-Slides („Nach Slide“)
   (settings.interstitials || []).forEach(it => {
     const v = it.afterRef || '';
     if (v && v.startsWith('sauna:')){
@@ -611,7 +611,7 @@ function renderSaunaOffList(){
 }
 
 // ============================================================================
-// 6) Interstitial Images (Bild-Slides)
+// 6) Interstitial Media (Medien-Slides)
 // ============================================================================
 function usedAfterImageIds(exceptId){
   const settings = ctx.getSettings();
@@ -683,7 +683,7 @@ function interRow(i){
   const id = 'inter_' + i;
 
   const wrap = document.createElement('div');
-  wrap.className = 'imgrow';
+  wrap.className = 'mediarow';
   wrap.innerHTML = `
     <input id="n_${id}" class="input name" type="text" value="${escapeHtml(it.name || '')}" />
     <img id="p_${id}" class="prev" alt="" title=""/>
@@ -772,7 +772,7 @@ function renderInterstitialsPanel(hostId='interList2'){
   host.innerHTML = '';
   settings.interstitials.forEach((_, i) => host.appendChild(interRow(i)));
 
-  const add = document.getElementById('btnInterAdd2');
+  const add = document.getElementById('btnMediaAdd');
   if (add) add.onclick = () => {
     (settings.interstitials ||= []).push({
       id:'im_'+Math.random().toString(36).slice(2,9),
@@ -895,7 +895,7 @@ if (durPer) durPer.onchange = () => {
   }
 };
 
-  // Bild-Slides
+  // Medien-Slides
   renderInterstitialsPanel('interList2');
 
   // Reset & Add Sauna


### PR DESCRIPTION
## Summary
- rename Bild-Slides section to Medien-Slides in admin UI
- update JS to handle Medien-Slides and mediarow class
- switch CSS selectors/comments from imgrow to mediarow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3b476ac8320818e0848a01c2f52