### PR TITLE
feat: handle media uploads and cleanup

### DIFF
--- a/webroot/admin/api/cleanup_assets.php
+++ b/webroot/admin/api/cleanup_assets.php
@@ -1,23 +1,37 @@
 <?php
 header('Content-Type: application/json; charset=UTF-8');
-$assetsDir = '/var/www/signage/assets/img';
+$assetsDir = '/var/www/signage/assets/media';
 $settingsFile = '/var/www/signage/data/settings.json';
 
 if (!is_dir($assetsDir)) { echo json_encode(['ok'=>false,'error'=>'missing-assets-dir']); exit; }
 $cfg = is_file($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
 $keep = [];
-$keep[] = '/assets/img/right_default.svg';
-$keep[] = '/assets/img/flame_test.svg';
 
 if (!empty($cfg['assets']['flameImage'])) $keep[] = $cfg['assets']['flameImage'];
 if (!empty($cfg['assets']['rightImages']) && is_array($cfg['assets']['rightImages'])) {
   foreach($cfg['assets']['rightImages'] as $p){ if($p) $keep[]=$p; }
 }
+if (!empty($cfg['interstitials']) && is_array($cfg['interstitials'])) {
+  foreach($cfg['interstitials'] as $it){
+    if (!is_array($it)) continue;
+    foreach(['url','thumb'] as $k){
+      $p = $it[$k] ?? '';
+      if (is_string($p) && strpos($p,'/assets/') === 0) $keep[] = $p;
+    }
+  }
+}
 
 $keepReal = array_map(function($p){ return '/var/www/signage'. $p; }, array_unique($keep));
 
 $removed = [];
-$it = new DirectoryIterator($assetsDir);
-foreach ($it as $f){ if($f->isDot()||!$f->isFile()) continue; $full = $f->getPathname(); if (!in_array($full, $keepReal, true)) { @unlink($full); if(!file_exists($full)) $removed[] = str_replace('/var/www/signage','', $full); } }
+$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($assetsDir, FilesystemIterator::SKIP_DOTS));
+foreach ($it as $f){
+  if(!$f->isFile()) continue;
+  $full = $f->getPathname();
+  if (!in_array($full, $keepReal, true)){
+    @unlink($full);
+    if(!file_exists($full)) $removed[] = str_replace('/var/www/signage','', $full);
+  }
+}
 
 echo json_encode(['ok'=>true,'removed'=>$removed]);

--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -1,59 +1,53 @@
 <?php
 // file: /var/www/signage/admin/api/upload.php
-// Zweck: Sicheren Upload großer Bilder nach /assets/img/ (PNG/JPG/WebP/SVG)
+// Zweck: Sicheren Upload von Medien nach /assets/media/ (Bilder, Videos, MPD, HTML)
 // Hinweise: Nginx client_max_body_size & PHP upload_max_filesize/post_max_size müssen groß genug sein.
-
 
 header('Content-Type: application/json; charset=UTF-8');
 
-
 function fail($msg, $code=400){ http_response_code($code); echo json_encode(['ok'=>false,'error'=>$msg]); exit; }
-
 
 if ($_SERVER['REQUEST_METHOD']!=='POST') fail('method');
 if (!isset($_FILES['file'])) fail('nofile');
-
 
 $u = $_FILES['file'];
 if (!empty($u['error'])) fail('upload-error-'.$u['error']);
 if (!is_uploaded_file($u['tmp_name'])) fail('tmp-missing');
 
-
 // Limits (kann via PHP-INI/Nginx größer sein)
 $maxBytes = 256*1024*1024; // 256MB
 if (filesize($u['tmp_name']) > $maxBytes) fail('too-large (server limit)');
 
-
 $finfo = new finfo(FILEINFO_MIME_TYPE);
 $mime = $finfo->file($u['tmp_name']) ?: 'application/octet-stream';
 $allowed = [
-'image/png' => 'png',
-'image/jpeg'=> 'jpg',
-'image/webp'=> 'webp',
-'image/svg+xml' => 'svg'
+  'image/png'        => ['ext'=>'png',  'dir'=>'img'],
+  'image/jpeg'       => ['ext'=>'jpg',  'dir'=>'img'],
+  'image/webp'       => ['ext'=>'webp', 'dir'=>'img'],
+  'image/svg+xml'    => ['ext'=>'svg',  'dir'=>'img'],
+  'video/mp4'        => ['ext'=>'mp4',  'dir'=>'video'],
+  'application/dash+xml' => ['ext'=>'mpd', 'dir'=>'mpd'],
+  'text/html'        => ['ext'=>'html', 'dir'=>'html']
 ];
 if (!isset($allowed[$mime])) fail('unsupported-type: '.$mime);
 
+$ext = $allowed[$mime]['ext'];
+$subDir = $allowed[$mime]['dir'];
 
-$ext = $allowed[$mime];
 $orig = preg_replace('/[^A-Za-z0-9._-]/','_', $u['name']);
 if (!$orig) $orig = 'upload.' . $ext;
-if (!preg_match('/\.' . preg_quote($ext,'/') . '$/i', $orig)) $orig .= '.' . $ext;
+if (!preg_match('/\\.' . preg_quote($ext,'/') . '$/i', $orig)) $orig .= '.' . $ext;
 
-
-$baseDir = '/var/www/signage/assets/img/';
+$baseDir = '/var/www/signage/assets/media/'.$subDir.'/';
 if (!is_dir($baseDir)) { @mkdir($baseDir, 02775, true); @chown($baseDir,'www-data'); @chgrp($baseDir,'www-data'); }
-
 
 $dest = $baseDir . $orig;
 $pi = pathinfo($dest);
 $fname = $pi['filename']; $i=0;
 while (file_exists($dest)) { $i++; $dest = $pi['dirname'].'/'.$fname.'_'.$i.'.'.$ext; }
 
-
 if (!@move_uploaded_file($u['tmp_name'], $dest)) fail('move-failed', 500);
 @chmod($dest, 0644); @chown($dest,'www-data'); @chgrp($dest,'www-data');
 
-
-$publicPath = '/assets/img/' . basename($dest);
+$publicPath = '/assets/media/'.$subDir.'/' . basename($dest);
 echo json_encode(['ok'=>true,'path'=>$publicPath]);


### PR DESCRIPTION
## Summary
- Support uploading videos, MPD and HTML files, saving into type-specific `/assets/media` subdirectories.
- Expand asset cleanup to scan media subfolders and respect paths referenced in settings, including interstitials.

## Testing
- `php -l webroot/admin/api/upload.php`
- `php -l webroot/admin/api/cleanup_assets.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbf7b566308320afc92d8dc1015f30