### PR TITLE
feat: support thumbnails for media uploads

### DIFF
--- a/webroot/admin/js/core/upload.js
+++ b/webroot/admin/js/core/upload.js
@@ -1,17 +1,20 @@
 // /admin/js/core/upload.js
 // Minimaler, wiederverwendbarer Uploader (wie dein bisheriger uploadGeneric)
 
-export function uploadGeneric(fileInput, onDone){
+export function uploadGeneric(fileInput, onDone, thumbInput){
   if(!fileInput.files || !fileInput.files[0]) return;
   const fd = new FormData();
   fd.append('file', fileInput.files[0]);
+  if (thumbInput && thumbInput.files && thumbInput.files[0]) {
+    fd.append('thumb', thumbInput.files[0]);
+  }
 
   const xhr = new XMLHttpRequest();
   xhr.open('POST','/admin/api/upload.php');
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path);
+      if (j.ok) onDone(j.path, j.thumb);
       else alert('Upload-Fehler: '+(j.error||''));
     }catch{
       alert('Upload fehlgeschlagen');

--- a/webroot/assets/img/thumb_fallback.svg
+++ b/webroot/assets/img/thumb_fallback.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" preserveAspectRatio="xMidYMid slice">
+  <rect width="160" height="90" fill="#ccc"/>
+  <line x1="0" y1="0" x2="160" y2="90" stroke="#888" stroke-width="10"/>
+  <line x1="160" y1="0" x2="0" y2="90" stroke="#888" stroke-width="10"/>
+</svg>


### PR DESCRIPTION
## Summary
- allow `upload.php` to accept optional thumbnail images and return their paths
- update generic uploader and interstitial editor to handle thumbnails with fallback image
- add default placeholder thumbnail asset

## Testing
- `php -l webroot/admin/api/upload.php`
- `node --check webroot/admin/js/core/upload.js`
- `node --check webroot/admin/js/ui/slides_master.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf90857cc83209e65122d5df6883f