### PR TITLE
Handle HTML slides without content and refresh master view after edit

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -31,7 +31,7 @@ window.addEventListener('message', (e) => {
     e.source?.postMessage({ type:'htmlInit', id:d.id, html: it?.html || '' }, '*');
   } else if (d.type === 'htmlSave'){
     const it = (ctx?.getSettings().interstitials || []).find(im => im.id === d.id);
-    if (it) it.html = d.html || '';
+    if (it) { it.html = d.html || ''; renderSlidesMaster(); }
   }
 });
 

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -196,7 +196,7 @@ function buildQueue() {
         if (it.url) media.push({ ...base, type: 'dash', src: it.url });
         break;
       case 'html':
-        if (it.html) media.push({ ...base, type: 'html', html: it.html });
+        media.push({ ...base, type: 'html', html: it.html });
         break;
       default:
         if (it.url) media.push({ ...base, type: 'image', src: it.url });
@@ -263,7 +263,7 @@ function buildQueue() {
 
       const node = { type: it.type, dwell, __id: it.id || null };
       if (it.src) node.src = it.src;
-      if (it.html) node.html = it.html;
+      if (it.type === 'html') node.html = it.html || '';
       if (it.url && it.type === 'url') node.url = it.url;
       queue.splice(insPos, 0, node);
     }
@@ -557,7 +557,7 @@ function renderVideo(src) {
 
 // ---------- Interstitial HTML slide ----------
 function renderHtml(html) {
-  const c = h('div', { class: 'container htmlslide fade show' });
+  const c = h('div', { class: 'container htmlslide fade show', style: 'display:block' });
   c.innerHTML = html || '';
   return c;
 }


### PR DESCRIPTION
## Summary
- Always include HTML interstitials in slideshow queue even without HTML content
- Ensure HTML slides render as visible containers
- Re-render master slides overview after saving HTML interstitial

## Testing
- `node --check webroot/assets/slideshow.js`
- `node --check webroot/admin/js/ui/slides_master.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0270d5248320bf572b836c1c4bb6