### PR TITLE
feat: add drag-and-drop WYSIWYG editor

### DIFF
--- a/webroot/admin/html-editor.html
+++ b/webroot/admin/html-editor.html
@@ -5,27 +5,121 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>HTML Slide Editor</title>
 <link rel="stylesheet" href="/admin/css/admin.css">
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.jsdelivr.net/npm/interactjs@1.10.11/dist/interact.min.js"></script>
 <style>
 body{padding:16px;}
-#editor{border:1px solid var(--border);min-height:60vh;padding:8px;border-radius:8px;background:var(--input-bg);color:var(--input-fg);}
-#toolbar{margin-bottom:8px;display:flex;gap:6px;}
+#canvas{border:1px solid var(--border);min-height:60vh;border-radius:8px;background:var(--input-bg);color:var(--input-fg);position:relative;overflow:hidden;}
+#toolbar{margin-bottom:8px;display:flex;gap:6px;align-items:center;}
+.textbox{min-width:60px;min-height:20px;padding:4px;}
 </style>
 </head>
 <body>
 <div id="toolbar">
-<button class="btn sm" id="boldBtn">B</button>
-<button class="btn sm" id="imgBtn">Bild</button>
+  <button class="btn sm" id="addTextBtn">Text</button>
+  <button class="btn sm" id="imgBtn">Bild</button>
+  <label style="display:flex;align-items:center;gap:4px;">BG <input type="color" id="bgColor" value="#ffffff"></label>
 </div>
-<div id="editor" contenteditable="true"></div>
+<div id="canvas"></div>
 <div class="row" style="margin-top:8px;gap:8px;">
-<button class="btn primary" id="saveBtn">Speichern</button>
-<button class="btn" onclick="window.close()">Schließen</button>
+  <button class="btn primary" id="saveBtn">Speichern</button>
+  <button class="btn" onclick="window.close()">Schließen</button>
 </div>
-<script>
-'use strict';
+<input type="file" id="imgInput" accept="image/*" style="display:none">
+
+<script type="module">
+import { uploadFile } from './js/core/upload.js';
+
 const params = new URLSearchParams(location.search);
 const id = params.get('id');
-const editor = document.getElementById('editor');
+const canvas = document.getElementById('canvas');
+const imgInput = document.getElementById('imgInput');
+const bgInput = document.getElementById('bgColor');
+
+function initDragResize(el){
+  interact(el).draggable({
+    onmove(event){
+      const target = event.target;
+      const x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+      const y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+      target.style.transform = `translate(${x}px, ${y}px)`;
+      target.setAttribute('data-x', x);
+      target.setAttribute('data-y', y);
+    }
+  }).resizable({
+    edges:{left:true,right:true,bottom:true,top:true},
+    onmove(event){
+      const target = event.target;
+      let x = parseFloat(target.getAttribute('data-x')) || 0;
+      let y = parseFloat(target.getAttribute('data-y')) || 0;
+      Object.assign(target.style, {
+        width: event.rect.width + 'px',
+        height: event.rect.height + 'px'
+      });
+      x += event.deltaRect.left;
+      y += event.deltaRect.top;
+      target.style.transform = `translate(${x}px, ${y}px)`;
+      target.setAttribute('data-x', x);
+      target.setAttribute('data-y', y);
+    }
+  });
+}
+
+function initTextbox(el){
+  el.classList.add('textbox');
+  el.setAttribute('contenteditable','true');
+  el.style.position = 'absolute';
+  initDragResize(el);
+  tinymce.init({
+    target: el,
+    inline: true,
+    menubar: false,
+    plugins: 'lists image',
+    toolbar: 'bold italic | bullist numlist | forecolor backcolor | image',
+    images_upload_handler: (blobInfo, success, failure) => {
+      uploadFile(blobInfo.blob(), (path) => success(path));
+    }
+  });
+}
+
+function initImage(el){
+  el.style.position = 'absolute';
+  el.style.maxWidth = '100%';
+  initDragResize(el);
+}
+
+document.getElementById('addTextBtn').onclick = () => {
+  const box = document.createElement('div');
+  box.textContent = 'Text';
+  canvas.appendChild(box);
+  initTextbox(box);
+};
+
+document.getElementById('imgBtn').onclick = () => imgInput.click();
+
+imgInput.onchange = () => {
+  const file = imgInput.files[0];
+  if(!file) return;
+  uploadFile(file, (path) => {
+    const img = document.createElement('img');
+    img.src = path;
+    canvas.appendChild(img);
+    initImage(img);
+    imgInput.value = '';
+  });
+};
+
+bgInput.oninput = () => {
+  canvas.style.backgroundColor = bgInput.value;
+};
+
+document.getElementById('saveBtn').onclick = () => {
+  tinymce.remove();
+  if (window.opener) {
+    window.opener.postMessage({ type: 'htmlSave', id, html: canvas.innerHTML }, '*');
+  }
+  window.close();
+};
 
 window.addEventListener('DOMContentLoaded', () => {
   if (window.opener) {
@@ -36,23 +130,12 @@ window.addEventListener('DOMContentLoaded', () => {
 window.addEventListener('message', (e) => {
   const d = e.data;
   if (d && d.type === 'htmlInit' && d.id === id) {
-    editor.innerHTML = d.html || '';
+    canvas.innerHTML = d.html || '';
+    canvas.querySelectorAll('.textbox').forEach(initTextbox);
+    canvas.querySelectorAll('img').forEach(initImage);
   }
 });
-
-document.getElementById('boldBtn').onclick = () => document.execCommand('bold');
-
-document.getElementById('imgBtn').onclick = () => {
-  const url = prompt('Bild-URL:');
-  if (url) document.execCommand('insertImage', false, url);
-};
-
-document.getElementById('saveBtn').onclick = () => {
-  if (window.opener) {
-    window.opener.postMessage({ type: 'htmlSave', id, html: editor.innerHTML }, '*');
-  }
-  window.close();
-};
 </script>
 </body>
 </html>
+

--- a/webroot/admin/js/core/upload.js
+++ b/webroot/admin/js/core/upload.js
@@ -23,3 +23,24 @@ export function uploadGeneric(fileInput, onDone, thumbInput){
   xhr.onerror = () => alert('Netzwerkfehler beim Upload');
   xhr.send(fd);
 }
+
+// Direkter Upload von File-Objekten (z.B. aus WYSIWYG-Editoren)
+export function uploadFile(file, onDone){
+  if(!file) return;
+  const fd = new FormData();
+  fd.append('file', file);
+
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST','/admin/api/upload.php');
+  xhr.onload = () => {
+    try{
+      const j = JSON.parse(xhr.responseText||'{}');
+      if (j.ok) onDone(j.path, j.thumb);
+      else alert('Upload-Fehler: '+(j.error||''));
+    }catch{
+      alert('Upload fehlgeschlagen');
+    }
+  };
+  xhr.onerror = () => alert('Netzwerkfehler beim Upload');
+  xhr.send(fd);
+}


### PR DESCRIPTION
## Summary
- replace simple HTML editor with TinyMCE-based WYSIWYG including draggable/resizable text boxes, image upload, and background color picker
- extend upload helper with `uploadFile` for direct image uploads from the editor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc04decff48320836635e4d1d1b84c