### PR TITLE
Open HTML editor from slide preview

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -799,20 +799,18 @@ function interRow(i){
         }
       };
       $media.appendChild(inp);
-    } else if (t === 'html'){
-      const btn = document.createElement('button');
-      btn.className = 'btn sm ghost';
-      btn.textContent = 'HTML';
-      btn.onclick = () => {
-        window.open('/admin/html-editor.html?id=' + encodeURIComponent(it.id), '_blank', 'width=800,height=600');
-      };
-      $media.appendChild(btn);
     }
   };
 
   renderMediaField();
 
   // Events
+  if ($prev) $prev.onclick = () => {
+    const t = $type?.value || 'image';
+    if (t === 'html'){
+      window.open('/admin/html-editor.html?id=' + it.id, '_blank', 'width=800,height=600');
+    }
+  };
   if ($name)  $name.onchange  = () => { it.name = ($name.value || '').trim(); renderSlidesMaster(); };
   if ($type)  $type.onchange  = () => { it.type = $type.value; renderMediaField(); };
   if ($after) $after.onchange = () => {


### PR DESCRIPTION
## Summary
- Remove dedicated HTML editor button for interstitials
- Launch HTML editor by clicking preview image when slide type is HTML

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc05f5e18c83209da4233c4b32410c