### PR TITLE
Add URL preview thumbnail API and improve uploads

### DIFF
--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -86,7 +86,11 @@ if ($subDir === 'video' && !$thumbPath){
   $tpi = pathinfo($thumbDest); $tfname = $tpi['filename']; $ti=0;
   while (file_exists($thumbDest)) { $ti++; $thumbDest = $tpi['dirname'].'/'.$tfname.'_'.$ti.'.jpg'; }
   $cmd = 'ffmpeg -hide_banner -loglevel error -i '.escapeshellarg($dest).' -vf "thumbnail,scale=640:-1" -frames:v 1 '.escapeshellarg($thumbDest).' 2>&1';
-  @exec($cmd, $o, $ret);
+  $o=[]; $ret=0;
+  exec($cmd, $o, $ret);
+  if ($ret !== 0 || !file_exists($thumbDest)){
+    error_log('ffmpeg-thumb-failed: '.$cmd.'; output='.implode("\n", $o));
+  }
   if (file_exists($thumbDest)){
     @chmod($thumbDest,0644); @chown($thumbDest,'www-data'); @chgrp($thumbDest,'www-data');
     $thumbPath = '/assets/media/img/' . basename($thumbDest);

--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -1,0 +1,82 @@
+<?php
+header('Content-Type: application/json; charset=UTF-8');
+$fallback = '/assets/img/thumb_fallback.svg';
+
+$raw = file_get_contents('php://input');
+$req = json_decode($raw, true);
+$url = $req['url'] ?? '';
+if (!is_string($url) || !preg_match('#^https?://#i', $url)) {
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+
+$ch = curl_init($url);
+curl_setopt_array($ch, [
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_TIMEOUT => 5,
+  CURLOPT_USERAGENT => 'Mozilla/5.0'
+]);
+$html = curl_exec($ch);
+if ($html === false) {
+  error_log('url_thumb html curl error: '.curl_error($ch));
+  curl_close($ch);
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+$baseUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL) ?: $url;
+curl_close($ch);
+
+$imgUrl = '';
+if (preg_match('/<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\']/i', $html, $m)) {
+  $imgUrl = $m[1];
+} elseif (preg_match('/<link\s+[^>]*rel=["\'](?:shortcut )?icon["\'][^>]*href=["\']([^"\']+)["\']/i', $html, $m)) {
+  $imgUrl = $m[1];
+}
+if (!$imgUrl) {
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+$imgUrl = html_entity_decode($imgUrl, ENT_QUOTES|ENT_HTML5, 'UTF-8');
+$base = parse_url($baseUrl);
+if (strpos($imgUrl, '//') === 0) {
+  $imgUrl = $base['scheme'].':'.$imgUrl;
+} elseif (strpos($imgUrl, '/') === 0) {
+  $imgUrl = $base['scheme'].'://'.$base['host'].$imgUrl;
+} elseif (!preg_match('#^https?://#i', $imgUrl)) {
+  $path = isset($base['path']) ? preg_replace('#/[^/]*$#', '/', $base['path']) : '/';
+  $imgUrl = $base['scheme'].'://'.$base['host'].$path.$imgUrl;
+}
+
+$ch = curl_init($imgUrl);
+curl_setopt_array($ch, [
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_FOLLOWLOCATION => true,
+  CURLOPT_TIMEOUT => 5,
+  CURLOPT_USERAGENT => 'Mozilla/5.0'
+]);
+$imgData = curl_exec($ch);
+if ($imgData === false) {
+  error_log('url_thumb image curl error: '.curl_error($ch));
+  curl_close($ch);
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+curl_close($ch);
+
+$im = @imagecreatefromstring($imgData);
+if (!$im) {
+  error_log('url_thumb: invalid image data');
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+$dir = '/var/www/signage/assets/media/img/';
+if (!is_dir($dir)) { @mkdir($dir, 02775, true); @chown($dir,'www-data'); @chgrp($dir,'www-data'); }
+$fname = 'preview_'.bin2hex(random_bytes(5)).'.jpg';
+$full = $dir.$fname;
+imagejpeg($im, $full, 90);
+imagedestroy($im);
+@chmod($full,0644); @chown($full,'www-data'); @chgrp($full,'www-data');
+$public = '/assets/media/img/'.$fname;
+
+echo json_encode(['ok'=>true,'thumb'=>$public]);

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -763,6 +763,18 @@ function interRow(i){
           it.url = val.trim();
           it.thumb = '';
           updatePrev('');
+          fetch('/admin/api/url_thumb.php', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({url: it.url})
+          }).then(r=>r.json()).then(j=>{
+            const t = (j && j.ok && j.thumb) ? j.thumb : FALLBACK_THUMB;
+            it.thumb = t;
+            updatePrev(t);
+          }).catch(()=>{
+            it.thumb = FALLBACK_THUMB;
+            updatePrev(FALLBACK_THUMB);
+          });
         }
       };
       $media.appendChild(mb);


### PR DESCRIPTION
## Summary
- log ffmpeg thumbnail errors during video uploads
- add `admin/api/url_thumb.php` to generate thumbnails from external URLs
- fetch new thumbnail API in slide editor and handle fallback images

## Testing
- `php -l webroot/admin/api/upload.php`
- `php -l webroot/admin/api/url_thumb.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc0c653dbc8320be6b789292e84201