### PR TITLE
Style video and URL slides

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -50,7 +50,16 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 
 /* interstitial image */
 .container.imgslide{padding:0}
+.container.videoslide,
+.container.urlslide{padding:0}
 .imgFill{position:absolute; inset:0; background-size:cover; background-position:center; background-repeat:no-repeat}
+
+.urlFill,
+.container.videoslide video{
+  width:100%;
+  height:100%;
+  display:block;
+}
 
 /* layout */
 .container{position:relative; height:100%; padding:calc(32px*var(--vwScale)); display:flex; flex-direction:column; align-items:flex-start}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -535,7 +535,7 @@ function renderVideo(src) {
   v.loop = true;
   v.muted = true;
   v.playsInline = true;
-  v.setAttribute('style', 'width:100%;height:100%;object-fit:contain');
+  v.setAttribute('style', 'object-fit:cover');
   v.src = src;
   v.addEventListener('canplay', () => v.play());
   v.addEventListener('error', (e) => {
@@ -553,7 +553,7 @@ function renderUrl(src) {
   const f = h('iframe', {
     src,
     class: 'urlFill',
-    style: 'width:100%;height:100%;border:0'
+    style: 'border:0'
   });
   const c = h('div', { class: 'container urlslide fade show' }, [f]);
   return c;


### PR DESCRIPTION
## Summary
- Add `videoslide` and `urlslide` container styles with zero padding and make embedded media fill the slide.
- Render videos using `object-fit: cover`.
- Simplify URL slide iframe styling and ensure it uses the `urlslide` container.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0e1b5efc83208cbf9d551df58044