### PR TITLE
Add optional wait-for-video slide option

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -97,6 +97,8 @@
 <div class="kv"><label>Auto je Wochentag <span class="tip" title="Lädt beim Start automatisch das Preset des aktuellen Wochentags.">❔</span></label><input id="presetAuto" type="checkbox"></div>
 <div class="help">Wenn aktiv, wird beim Öffnen und beim Wechsel des Tabs automatisch das Preset des aktuellen Wochentags geladen (falls vorhanden).</div>
 
+<div class="kv"><label>Weiter erst nach Video-Ende</label><input id="waitForVideo" type="checkbox"></div>
+
     <!-- Unterbox 1: Saunen & Übersicht -->
     <details class="ac sub" open id="boxSaunas">
       <summary><div class="ttl">▶<span class="chev">⮞</span> Saunen & Übersicht</div>

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -865,6 +865,12 @@ export function renderSlidesMaster(){
     autoEl.onchange = () => { settings.presetAuto = !!autoEl.checked; };
   }
 
+  const waitEl = $('#waitForVideo');
+  if (waitEl){
+    waitEl.checked = !!settings.slides?.waitForVideo;
+    waitEl.onchange = () => { (settings.slides ||= {}).waitForVideo = !!waitEl.checked; };
+  }
+
 // === Dauer-Modus (Uniform vs. Individuell) ===
 const perMode = (settings.slides?.durationMode === 'per');
 
@@ -964,6 +970,7 @@ if (durPer) durPer.onchange = () => {
     settings.slides.transitionMs = 500;
     settings.slides.durationMode = 'uniform';
     settings.slides.globalDwellSec = 6;
+    settings.slides.waitForVideo = false;
     settings.slides.hiddenSaunas = [];
     settings.slides.saunaDurations = {};
     renderSlidesMaster();

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -528,12 +528,12 @@ function renderImage(url) {
 }
 
 // ---------- Interstitial video slide ----------
-function renderVideo(src) {
+function renderVideo(src, opts = {}) {
   const v = document.createElement('video');
   v.preload = 'auto';
   v.autoplay = true;
-  v.loop = true;
-  v.muted = true;
+  if (opts.muted !== undefined) v.muted = !!opts.muted;
+  else v.muted = true;
   v.playsInline = true;
   v.setAttribute('style', 'object-fit:cover');
   v.src = src;
@@ -543,6 +543,9 @@ function renderVideo(src) {
     const fallback = h('div', { class: 'video-error', style: 'padding:1em;color:#fff;text-align:center' }, 'Video konnte nicht geladen werden');
     if (v.parentNode) v.parentNode.replaceChild(fallback, v);
   });
+  if (settings?.slides?.waitForVideo) {
+    v.addEventListener('ended', () => { idx++; step(); });
+  }
   const c = h('div', { class: 'container videoslide fade show' });
   c.appendChild(v);
   return c;
@@ -703,14 +706,16 @@ if (key === lastKey && nextQueue.length > 1) {
     (item.type === 'overview') ? renderOverview() :
     (item.type === 'sauna')    ? renderSauna(item.sauna) :
     (item.type === 'image')    ? renderImage(item.src) :
-    (item.type === 'video')    ? renderVideo(item.src) :
+    (item.type === 'video')    ? renderVideo(item.src, item) :
     (item.type === 'url')      ? renderUrl(item.url) :
                                  renderImage(item.src || item.url);
 
   show(el);
-lastKey = key;
-  const dwell = dwellMsForItem(item);
-  slideTimer = setTimeout(() => hide(() => { idx++; step(); }), dwell);
+  lastKey = key;
+  if (!(settings?.slides?.waitForVideo && item.type === 'video')) {
+    const dwell = dwellMsForItem(item);
+    slideTimer = setTimeout(() => hide(() => { idx++; step(); }), dwell);
+  }
 }
 
 //Showpairing

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -31,6 +31,7 @@
     "tileMinScale": 0.25,
     "tileMaxScale": 0.57,
     "loop": true,
+    "waitForVideo": false,
     "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"]
   },
   "assets": {


### PR DESCRIPTION
## Summary
- add `waitForVideo` slide setting and admin checkbox
- stop looping videos and allow optional muting
- advance slideshow after video end when configured

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0f8ce9708320b19947f4acc7e51d