### PR TITLE
Handle missing day presets in slides master

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -45,6 +45,11 @@ function setActiveDay(key, { loadPreset = true } = {}){
     ctx.setSchedule(cloned);
     renderGridUI();
     renderSlidesMaster();
+  } else if (loadPreset && key !== 'Opt') {
+    const emptySchedule = { saunas: ctx.getSchedule().saunas, rows: [] };
+    ctx.setSchedule(emptySchedule);
+    renderGridUI();
+    renderSlidesMaster();
   }
 }
 


### PR DESCRIPTION
## Summary
- add else branch in setActiveDay to create and set empty schedule when preset missing
- update UI after selecting day without preset

## Testing
- `node --check webroot/admin/js/ui/slides_master.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc12c3b2fc83209e89c6744cb979d3