### PR TITLE
Expose active day key and auto-save presets

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -13,7 +13,7 @@
 import { $, $$, preloadImg, genId, deepClone } from './core/utils.js';
 import { DEFAULTS } from './core/defaults.js';
 import { initGridUI, renderGrid as renderGridUI } from './ui/grid.js';
-import { initSlidesMasterUI, renderSlidesMaster } from './ui/slides_master.js';
+import { initSlidesMasterUI, renderSlidesMaster, getActiveDayKey } from './ui/slides_master.js';
 import { initGridDayLoader } from './ui/grid_day_loader.js';
 import { uploadGeneric } from './core/upload.js';
 
@@ -545,6 +545,8 @@ function collectColors(){
 }
 
 function collectSettings(){
+  settings.presets ||= {};
+  settings.presets[getActiveDayKey()] = deepClone(schedule);
   return {
     schedule: { ...schedule },
     settings: {

--- a/webroot/admin/js/ui/grid_day_loader.js
+++ b/webroot/admin/js/ui/grid_day_loader.js
@@ -60,7 +60,7 @@ function ensureUI() {
     const key = sel.value;
     const preset = settings?.presets?.[key];
     if (!preset) {
-      alert(`Kein Preset für "${(DAY_LABELS && DAY_LABELS[key]) || key}" vorhanden.\nMit „Wochentag speichern“ kannst du eins anlegen.`);
+      alert(`Kein Preset für "${(DAY_LABELS && DAY_LABELS[key]) || key}" vorhanden.`);
       return;
     }
     // Preset ins aktuelle Schedule übernehmen (deep clone)

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -27,6 +27,11 @@ let wiredStatic = false;
 // ============================================================================
 let activeDayKey = 'Mon';
 
+// Exported getter to expose the currently active day
+export function getActiveDayKey(){
+  return activeDayKey;
+}
+
 function setActiveDay(key, { loadPreset = true } = {}){
   activeDayKey = key;
   localStorage.setItem('adminActiveDay', key);


### PR DESCRIPTION
## Summary
- expose activeDayKey via `getActiveDayKey` so other modules can access current weekday
- auto-save current schedule to presets for active day before exporting settings
- drop outdated alert hinting at manual 'Wochentag speichern'

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/HTMLSignage/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bc1365cc608320abca61bd5f64224d