### PR TITLE
Ensure empty grid for days without presets

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -50,6 +50,11 @@ function setActiveDay(key, { loadPreset = true } = {}){
     ctx.setSchedule(cloned);
     renderGridUI();
     renderSlidesMaster();
+  } else {
+    const empty = { saunas: ctx.getSchedule().saunas.slice(), rows: [] };
+    ctx.setSchedule(empty);
+    renderGridUI();
+    renderSlidesMaster();
   }
 }
 


### PR DESCRIPTION
## Summary
- When switching to a day without a preset, initialize an empty schedule using existing saunas and no rows

## Testing
- `node --check webroot/admin/js/ui/slides_master.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc1566807883208e96a83531f8103a