### PR TITLE
Clear media fields on slide type change

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -795,7 +795,14 @@ function interRow(i){
 
   // Events
   if ($name)  $name.onchange  = () => { it.name = ($name.value || '').trim(); renderSlidesMaster(); };
-  if ($type)  $type.onchange  = () => { it.type = $type.value; renderMediaField(); };
+  if ($type)  $type.onchange  = () => {
+    it.type = $type.value;
+    it.url = '';
+    it.thumb = '';
+    updatePrev('');
+    renderMediaField();
+    renderSlidesMaster();
+  };
   if ($after) $after.onchange = () => {
     const v = $after.value;
     if (v === 'img:' + it.id){


### PR DESCRIPTION
## Summary
- Reset URL and thumbnail when slide type changes, ensuring previews start blank.
- Refresh media field and slides master UI immediately after type selection.

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc15f487a88320ace73fa88f9164f2