### PR TITLE
Add cache-busting for slide preview images

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -731,8 +731,9 @@ function interRow(i){
   const FALLBACK_THUMB = '/assets/img/thumb_fallback.svg';
   const updatePrev = (src) => {
     if (!src){ $prev.src = FALLBACK_THUMB; $prev.title = ''; return; }
-    preloadImg(src).then(r => {
-      if (r.ok){ $prev.src = src; $prev.title = `${r.w}×${r.h}`; }
+    const url = src + '?v=' + Date.now();
+    preloadImg(url).then(r => {
+      if (r.ok){ $prev.src = url; $prev.title = `${r.w}×${r.h}`; }
       else { $prev.src = FALLBACK_THUMB; $prev.title = ''; }
     });
   };


### PR DESCRIPTION
## Summary
- Append a timestamp to slide preview image URLs to avoid stale caches
- Preload images using the same timestamped URL

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc171148d08320899960e0bec83b86