### PR TITLE
Enforce unique afterRef selections for media slides

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -13,7 +13,7 @@
 import { $, $$, preloadImg, genId, deepClone } from './core/utils.js';
 import { DEFAULTS } from './core/defaults.js';
 import { initGridUI, renderGrid as renderGridUI } from './ui/grid.js';
-import { initSlidesMasterUI, renderSlidesMaster, getActiveDayKey } from './ui/slides_master.js';
+import { initSlidesMasterUI, renderSlidesMaster, getActiveDayKey, validateUniqueAfterRefs } from './ui/slides_master.js';
 import { initGridDayLoader } from './ui/grid_day_loader.js';
 import { uploadGeneric } from './core/upload.js';
 
@@ -611,6 +611,10 @@ function collectSettings(){
 $('#btnOpen')?.addEventListener('click', ()=> window.open(SLIDESHOW_ORIGIN + '/', '_blank'));
 
 $('#btnSave')?.addEventListener('click', async ()=>{
+  if (!validateUniqueAfterRefs()){
+    alert('Fehler: Mehrfachzuweisung bei "Nach Slide".');
+    return;
+  }
   const body = collectSettings();
 
   if (!currentDeviceCtx){


### PR DESCRIPTION
## Summary
- prevent multiple interstitial slides from using the same `afterRef`
- hide already referenced images in "Nach Slide" dropdowns
- block saving when duplicates are detected

## Testing
- `node --check webroot/admin/js/ui/slides_master.js`
- `node --check webroot/admin/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc17ca32f48320b5a5936566b15a1a