### PR TITLE
feat: persist settings draft

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -152,6 +152,23 @@ async function loadAll(){
     if (draft) schedule = JSON.parse(draft);
   } catch {}
 
+  try {
+    const draft = localStorage.getItem('settingsDraft');
+    if (draft) {
+      const parsed = JSON.parse(draft);
+      (function merge(t, s) {
+        for (const k of Object.keys(s)) {
+          if (s[k] && typeof s[k] === 'object' && !Array.isArray(s[k])) {
+            t[k] = t[k] && typeof t[k] === 'object' ? t[k] : {};
+            merge(t[k], s[k]);
+          } else {
+            t[k] = s[k];
+          }
+        }
+      })(settings, parsed);
+    }
+  } catch {}
+
   // Defaults mergen (defensiv)
   settings.slides        = { ...DEFAULTS.slides,   ...(settings.slides||{}) };
   settings.display       = { ...DEFAULTS.display,  ...(settings.display||{}) };
@@ -619,20 +636,24 @@ $('#btnSave')?.addEventListener('click', async ()=>{
     body.settings.version = (Date.now()/1000|0);
     const r=await fetch('/admin/api/save.php',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body) });
     const j=await r.json().catch(()=>({ok:false}));
-    if (j.ok){
-      baseSettings = deepClone(body.settings);
-      localStorage.removeItem('scheduleDraft');
+      if (j.ok){
+        baseSettings = deepClone(body.settings);
+        localStorage.removeItem('scheduleDraft');
+        localStorage.removeItem('settingsDraft');
+      }
+      alert(j.ok ? 'Gespeichert (Global).' : ('Fehler: '+(j.error||'unbekannt')));
+    } else {
+      // Geräte-Override speichern
+      const payload = { device: currentDeviceCtx, settings: body.settings };
+      const r=await fetch('/admin/api/devices_save_override.php',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) });
+      const j=await r.json().catch(()=>({ok:false}));
+      if (j.ok) {
+        localStorage.removeItem('scheduleDraft');
+        localStorage.removeItem('settingsDraft');
+      }
+      alert(j.ok ? ('Gespeichert für Gerät: '+currentDeviceName) : ('Fehler: '+(j.error||'unbekannt')));
     }
-    alert(j.ok ? 'Gespeichert (Global).' : ('Fehler: '+(j.error||'unbekannt')));
-  } else {
-    // Geräte-Override speichern
-    const payload = { device: currentDeviceCtx, settings: body.settings };
-    const r=await fetch('/admin/api/devices_save_override.php',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) });
-    const j=await r.json().catch(()=>({ok:false}));
-    if (j.ok) localStorage.removeItem('scheduleDraft');
-    alert(j.ok ? ('Gespeichert für Gerät: '+currentDeviceName) : ('Fehler: '+(j.error||'unbekannt')));
-  }
-});
+  });
 
 // --- Dock ----------------------------------------------------------
 let _dockTimer = 0;
@@ -642,6 +663,7 @@ function dockPushDebounced(){
   clearTimeout(_dockTimer);
   _dockTimer = setTimeout(()=> dockSend(false), 250);
 }
+window.dockPushDebounced = dockPushDebounced;
 function dockSend(reload){
   const frame = document.getElementById('dockPane')?.querySelector('#dockFrame');
   if (!frame || !frame.contentWindow) return;

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -88,6 +88,8 @@ function initWeekdayUI(){
     const s = ctx.getSettings();
     s.presets ||= {};
     s.presets[activeDayKey] = JSON.parse(JSON.stringify(ctx.getSchedule()));
+    localStorage.setItem('settingsDraft', JSON.stringify(ctx.getSettings()));
+    if (typeof window.dockPushDebounced === 'function') window.dockPushDebounced();
     alert('Wochentag gespeichert: ' + (DAY_LABELS[activeDayKey] || activeDayKey));
   };
 }


### PR DESCRIPTION
## Summary
- Store updated settings in `settingsDraft` when saving weekday presets
- Load and merge `settingsDraft` alongside `scheduleDraft`
- Clear `settingsDraft` from local storage after successful save
- Refresh preview immediately after saving a weekday preset to reflect unsaved changes

## Testing
- `npm test` *(fails: ENOENT package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bc180827308320b564eb98f8d7c0bd