### PR TITLE
Ensure after-select dropdowns refresh and retain selection

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -710,6 +710,15 @@ function applyAfterSelect(it, value){
     const img = (settings.interstitials || []).find(im => im && im.id === id);
     it.after = img ? (img.name || '') : '';
   }
+
+  // Refresh all "Nach Slide" selects so that used slides are hidden
+  $$('.sel-after').forEach(sel => {
+    const idx = +sel.id.replace('a_inter_', '');
+    const current = (settings.interstitials || [])[idx];
+    if (!current) return;
+    sel.innerHTML = interAfterOptionsHTML(current.id);
+    sel.value = getAfterSelectValue(current, current.id);
+  });
 }
 
 function interRow(i){
@@ -848,7 +857,6 @@ function interRow(i){
       }
     }
     applyAfterSelect(it, v);
-    renderSlidesMaster();
   };
 
   if ($en)  $en.onchange  = () => { it.enabled = !!$en.checked; };


### PR DESCRIPTION
## Summary
- Refresh all `.sel-after` dropdowns after changing an interstitial's follow-up slide
- Preserve the active dropdown's current selection while other options update
- Stop re-rendering the whole slides panel on after-select change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1c83651c8320af2ef96592e32638