### PR TITLE
Ensure slides use fresh URLs after upload

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -791,9 +791,12 @@ function interRow(i){
         fi.type = 'file';
         fi.accept = (t === 'video') ? 'video/*' : 'image/*';
         fi.onchange = () => uploadGeneric(fi, (p, tp) => {
-          it.url = p;
-          it.thumb = tp || (t === 'image' ? p : '');
+          const suffix = '?v=' + Date.now();
+          it.url = p + suffix;
+          const tv = tp || (t === 'image' ? p : '');
+          it.thumb = tv ? tv + suffix : '';
           updatePrev(it.thumb);
+          renderSlidesMaster();
         });
         fi.click();
       };


### PR DESCRIPTION
## Summary
- Append cache-busting query string to uploaded slide media URLs and thumbnails
- Trigger `renderSlidesMaster()` after uploads so UI reflects new paths

## Testing
- `node -c webroot/admin/js/ui/slides_master.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1d4917c88320b9099d85219b6f6f