### PR TITLE
feat: use icon for URL media field

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -803,8 +803,9 @@ function interRow(i){
       $media.appendChild(mb);
     } else if (t === 'url'){
       const mb = document.createElement('button');
-      mb.className = 'btn sm ghost';
-      mb.textContent = 'URL';
+      mb.className = 'btn sm ghost icon';
+      mb.textContent = '🔗';
+      mb.title = 'URL';
       mb.onclick = () => {
         const val = prompt('URL:', it.url || '');
         if (val) {


### PR DESCRIPTION
## Summary
- replace URL text button in media field with link icon and tooltip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc22c742f88320b2acedeafde6c270