### PR TITLE
Use media type prefix in interstitial option labels

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -663,7 +663,11 @@ function interAfterOptionsHTML(currentId){
   const imgOpts = (settings.interstitials || [])
     .filter(x => x && x.id && x.id !== currentId)
     .filter(x => !used.has('img:' + x.id))
-    .map(x => `<option value="img:${x.id}">${escapeHtml('Bild: ' + (x.name || x.id))}</option>`);
+    .map(x => {
+      const prefixMap = { image: 'Bild', video: 'Video', url: 'URL' };
+      const prefix = (prefixMap[x.type] || 'Bild') + ': ';
+      return `<option value="img:${x.id}">${escapeHtml(prefix + (x.name || x.id))}</option>`;
+    });
 
   return [...opts, ...saunaOpts, ...imgOpts].join('');
 }


### PR DESCRIPTION
## Summary
- Derive label prefixes from interstitial type and apply when rendering "Nach Slide" options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2590c1588320a93eb5907b5ec83e