### PR TITLE
Refine color picker behavior

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -516,15 +516,6 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
 #quickColor{width:52px;min-width:52px;padding:3px;border-radius:10px}
 #quickHex{text-transform:uppercase;width:10ch}
 #copyHex{white-space:nowrap}
-#colorTools.float{
-  position:fixed; right:16px; bottom:16px; z-index:999;
-  width:min(90vw, 1200px);
-  background:var(--card); border:1px solid var(--inbr); border-radius:12px;
-  box-shadow:var(--shadow); padding:12px;
-}
-#colorTools.float .pickerResizable{
-  width:100%; height:min(60vh, 700px); max-height:80vh; resize:both;
-}
 
 /* Ansicht-Menü (Header) */
 .menuwrap{ position:relative; }

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -430,7 +430,6 @@ function ensureColorTools(){
     <div class="legendRow">
       <div class="legend">Farb-Werkzeuge</div>
 <button class="btn sm ghost" id="togglePickerSize" title="Iframe Höhe expandieren/zusammenklappen">⛶</button>
-<button class="btn sm ghost" id="dockPicker" title="Als schwebendes Fenster anzeigen">⇱</button>
 
 </div>
 
@@ -457,8 +456,8 @@ function ensureColorTools(){
     </div>
   `;
 
-  // vor die Farbliste setzen
-  host.parentElement.insertBefore(box, host);
+  // hinter die Farbliste setzen
+  host.after(box);
 
   // Controls
   const $wrap = document.getElementById('pickerWrap');
@@ -474,21 +473,19 @@ const savedW = parseInt(localStorage.getItem('colorPickerW') || '0', 10);
 if (savedH >= 140) $wrap.style.height = savedH + 'px';
 if (savedW >= 260) $wrap.style.width  = savedW + 'px';
 
-  // expand/collapse
-$toggle.onclick = ()=>{
-  if (!box.classList.contains('exp')){
-    box.dataset.prevH = $wrap.clientHeight;
-    box.dataset.prevW = $wrap.clientWidth;
-    box.classList.add('exp');
-    $wrap.style.width = '100%';
-  } else {
-    box.classList.remove('exp');
-    const h = parseInt(box.dataset.prevH || '180', 10);
-    const w = parseInt(box.dataset.prevW || '0',   10);
-    $wrap.style.height = Math.max(140, h) + 'px';
-    if (w) $wrap.style.width = Math.max(260, w) + 'px';
-  }
-};
+  // expand/collapse und Reset auf Standardmaße
+  $toggle.onclick = () => {
+    if (!box.classList.contains('exp')) {
+      box.classList.add('exp');
+      $wrap.style.width = '100%';
+    } else {
+      box.classList.remove('exp');
+      $wrap.style.height = '180px';
+      $wrap.style.width = '100%';
+      localStorage.removeItem('colorPickerH');
+      localStorage.removeItem('colorPickerW');
+    }
+  };
 
 // Größe speichern (nur wenn nicht expanded)
 const ro = new ResizeObserver((entries)=>{
@@ -514,8 +511,6 @@ ro.observe($wrap);
     try { await navigator.clipboard.writeText(v); $st.textContent = 'kopiert'; setTimeout(()=> $st.textContent='', 1000); }
     catch { $qh.select(); document.execCommand?.('copy'); $st.textContent = 'kopiert'; setTimeout(()=> $st.textContent='', 1000); }
   };
-const $dock = document.getElementById('dockPicker');
-$dock.onclick = ()=> box.classList.toggle('float');
 }
 
 


### PR DESCRIPTION
## Summary
- insert color picker below color list
- remove float/dock option and associated styles
- reset picker to default size when collapsing

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/HTMLSignage/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bd3433078c8320a782d4059c849aa7