### PR TITLE
Add server-side URL proxy for slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ and prints the URLs and configuration paths when finished.
 Environment variables such as `SIGNAGE_PUBLIC_PORT`, `SIGNAGE_ADMIN_PORT`,
 `SIGNAGE_ADMIN_USER` and `SIGNAGE_ADMIN_PASS` can still be set to override
 the defaults.
+
+## URL slides
+
+External pages can be embedded as slides. A small proxy endpoint
+(`webroot/admin/api/url_proxy.php`) fetches the target URL, removes common
+cookie/consent overlays and returns the cleaned HTML. When needed, the
+iframe can be sandboxed to prevent pop‑ups or other interactions. Sites with
+strict Content‑Security‑Policy headers or heavy JavaScript dependencies may
+still not render correctly even through the proxy.

--- a/webroot/admin/api/url_proxy.php
+++ b/webroot/admin/api/url_proxy.php
@@ -1,0 +1,48 @@
+<?php
+// /admin/api/url_proxy.php – simple proxy to fetch remote pages and strip cookie banners
+header('Content-Type: text/html; charset=UTF-8');
+header('Cache-Control: no-store');
+
+$url = $_GET['url'] ?? '';
+if (!$url || !preg_match('~^https?://~i', $url)) {
+    http_response_code(400);
+    echo 'missing or invalid url';
+    exit;
+}
+
+$ctxOpts = [
+    'http' => [
+        'method' => 'GET',
+        'timeout' => 10,
+        'header' => "User-Agent: HTMLSignage\r\n",
+        'follow_location' => 1,
+        'ignore_errors' => true,
+    ],
+    'https' => [
+        'method' => 'GET',
+        'timeout' => 10,
+        'header' => "User-Agent: HTMLSignage\r\n",
+        'follow_location' => 1,
+        'ignore_errors' => true,
+    ],
+];
+
+$context = stream_context_create($ctxOpts);
+$html = @file_get_contents($url, false, $context);
+if ($html === false) {
+    http_response_code(502);
+    echo 'failed to load url';
+    exit;
+}
+
+// remove simple cookie/consent overlays
+$patterns = [
+    '/<script[^>]*cookie[^>]*>.*?<\/script>/is',
+    '/<(?:div|section|aside)[^>]*(?:id|class)="[^"]*(cookie|consent)[^"]*"[^>]*>.*?<\/[^>]+>/is',
+    '/<div[^>]*data-consent[^>]*>.*?<\/div>/is',
+];
+foreach ($patterns as $p) {
+    $html = preg_replace($p, '', $html);
+}
+
+echo $html;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -552,12 +552,16 @@ function renderVideo(src, opts = {}) {
 }
 
 // ---------- Interstitial external URL slide ----------
-function renderUrl(src) {
-  const f = h('iframe', {
-    src,
+function renderUrl(src, sandbox) {
+  const proxied = '/admin/api/url_proxy.php?url=' + encodeURIComponent(src);
+  const attrs = {
+    src: proxied,
     class: 'urlFill',
     style: 'border:0'
-  });
+  };
+  const sb = sandbox || (settings?.slides?.urlSandbox ? 'allow-scripts allow-same-origin' : null);
+  if (sb) attrs.sandbox = sb;
+  const f = h('iframe', attrs);
   const c = h('div', { class: 'container urlslide fade show' }, [f]);
   return c;
 }
@@ -707,7 +711,7 @@ if (key === lastKey && nextQueue.length > 1) {
     (item.type === 'sauna')    ? renderSauna(item.sauna) :
     (item.type === 'image')    ? renderImage(item.src) :
     (item.type === 'video')    ? renderVideo(item.src, item) :
-    (item.type === 'url')      ? renderUrl(item.url) :
+    (item.type === 'url')      ? renderUrl(item.url, item.sandbox) :
                                  renderImage(item.src || item.url);
 
   show(el);


### PR DESCRIPTION
## Summary
- add `url_proxy.php` endpoint that fetches remote pages and strips common cookie banners
- route URL slides through proxy and optionally sandbox iframe to block popups
- document limitations of URL slide proxy in README

## Testing
- `php -l webroot/admin/api/url_proxy.php`
- `node --check webroot/assets/slideshow.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd3515c320832082b6930af8f9eaad