### PR TITLE
Support schedule overrides for devices

### DIFF
--- a/webroot/admin/api/device_resolve.php
+++ b/webroot/admin/api/device_resolve.php
@@ -75,11 +75,14 @@ $baseSchedule = read_json_file($docRoot . '/data/schedule.json');
 $baseScheduleVersion = intval($baseSchedule['version'] ?? 0);
 
 $overSettings = $dev['overrides']['settings'] ?? [];
+$overSchedule = $dev['overrides']['schedule'] ?? [];
 
 if (empty($dev['useOverrides'])) {
   $overSettings = [];
-} elseif (!is_array($overSettings)) {
-  $overSettings = [];
+  $overSchedule = [];
+} else {
+  if (!is_array($overSettings)) $overSettings = [];
+  if (!is_array($overSchedule)) $overSchedule = [];
 }
 
 
@@ -108,7 +111,13 @@ if (!empty($mergedSettings['presetAuto']) && !empty($mergedSettings['presets']) 
     $schedule = $preset;
   }
 }
-$schedule['version'] = $baseScheduleVersion;
+
+if ($dev['useOverrides'] && !empty($overSchedule)) {
+  $schedule = merge_r($schedule, $overSchedule);
+  $schedule['version'] = intval($overSchedule['version'] ?? 0);
+} else {
+  $schedule['version'] = $baseScheduleVersion;
+}
 
 // Version als einfache Cache-Bremse; nimmt höchste bekannte Version
 $mergedSettings['version'] = max(

--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -30,7 +30,10 @@ foreach (($db['devices'] ?? []) as $id => $d) {
     'name' => $d['name'] ?? $id,
     'lastSeenAt' => (int)($d['lastSeen'] ?? 0) ?: null,
     'useOverrides' => !empty($d['useOverrides']),
-    'overrides' => [ 'settings' => $d['overrides']['settings'] ?? (object)[] ]
+    'overrides' => [
+      'settings' => $d['overrides']['settings'] ?? (object)[],
+      'schedule' => $d['overrides']['schedule'] ?? (object)[]
+    ]
   ];
 
 }

--- a/webroot/admin/api/devices_save_override.php
+++ b/webroot/admin/api/devices_save_override.php
@@ -10,6 +10,7 @@ if (!$in || !isset($in['device']) || !is_array($in['settings'])) {
 }
 $devId = $in['device'];
 $set   = $in['settings'];
+$sch   = isset($in['schedule']) && is_array($in['schedule']) ? $in['schedule'] : null;
 
 $dev = devices_load();
 if (!isset($dev['devices'][$devId])) {
@@ -18,13 +19,23 @@ if (!isset($dev['devices'][$devId])) {
 
 // Version hochzählen (Signal für Clients)
 $set['version'] = intval($set['version'] ?? 0) + 1;
+if ($sch !== null) {
+  $sch['version'] = intval($sch['version'] ?? 0) + 1;
+}
 
 $dev['devices'][$devId]['overrides'] = $dev['devices'][$devId]['overrides'] ?? [];
 $dev['devices'][$devId]['overrides']['settings'] = $set;
+if ($sch !== null) {
+  $dev['devices'][$devId]['overrides']['schedule'] = $sch;
+}
 
 $dev['devices'][$devId]['useOverrides'] = true;
 
 if (!devices_save($dev)) {
   echo json_encode(['ok'=>false, 'error'=>'write-failed']); exit;
 }
-echo json_encode(['ok'=>true, 'version'=>$set['version']]);
+echo json_encode([
+  'ok'=>true,
+  'version'=>$set['version'],
+  'scheduleVersion'=> $sch['version'] ?? null
+]);

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -643,7 +643,7 @@ $('#btnSave')?.addEventListener('click', async ()=>{
       alert(j.ok ? 'Gespeichert (Global).' : ('Fehler: '+(j.error||'unbekannt')));
     } else {
       // Geräte-Override speichern
-      const payload = { device: currentDeviceCtx, settings: body.settings };
+      const payload = { device: currentDeviceCtx, settings: body.settings, schedule: body.schedule };
       const r=await fetch('/admin/api/devices_save_override.php',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) });
       const j=await r.json().catch(()=>({ok:false}));
       if (j.ok) {


### PR DESCRIPTION
## Summary
- Allow admin UI to send schedule data when saving device overrides
- Persist optional schedule overrides and propagate to clients
- Include schedule overrides in device listings and resolution responses

## Testing
- `node --check webroot/admin/js/app.js`
- `php -l webroot/admin/api/devices_save_override.php`
- `php -l webroot/admin/api/device_resolve.php`
- `php -l webroot/admin/api/devices_list.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd3b344f108320beb4441c2cd1ef59