### PR TITLE
Respect override versions for device settings and schedule

### DIFF
--- a/webroot/admin/api/device_resolve.php
+++ b/webroot/admin/api/device_resolve.php
@@ -119,11 +119,12 @@ if ($dev['useOverrides'] && !empty($overSchedule)) {
   $schedule['version'] = $baseScheduleVersion;
 }
 
-// Version als einfache Cache-Bremse; nimmt höchste bekannte Version
-$mergedSettings['version'] = max(
-  intval($baseSettings['version'] ?? 0),
-  intval($overSettings['version'] ?? 0)
-);
+// Version als Cache-Bremse; bei aktivem Override nur dessen Version nutzen
+if ($dev['useOverrides'] && array_key_exists('version', $overSettings)) {
+  $mergedSettings['version'] = intval($overSettings['version']);
+} else {
+  $mergedSettings['version'] = intval($baseSettings['version'] ?? 0);
+}
 
 // --- Antwort ----------------------------------------------------------------
 

--- a/webroot/admin/api/devices_save_override.php
+++ b/webroot/admin/api/devices_save_override.php
@@ -18,16 +18,19 @@ if (!isset($dev['devices'][$devId])) {
 }
 
 // Version hochzählen (Signal für Clients)
-$set['version'] = intval($set['version'] ?? 0) + 1;
-if ($sch !== null) {
-  $sch['version'] = intval($sch['version'] ?? 0) + 1;
-}
-
 $dev['devices'][$devId]['overrides'] = $dev['devices'][$devId]['overrides'] ?? [];
-$dev['devices'][$devId]['overrides']['settings'] = $set;
+
+// Versionsnummern getrennt führen und erhöhen
+$currSetVer = intval($dev['devices'][$devId]['overrides']['settings']['version'] ?? 0);
+$set['version'] = $currSetVer + 1;
+
 if ($sch !== null) {
+  $currSchVer = intval($dev['devices'][$devId]['overrides']['schedule']['version'] ?? 0);
+  $sch['version'] = $currSchVer + 1;
   $dev['devices'][$devId]['overrides']['schedule'] = $sch;
 }
+
+$dev['devices'][$devId]['overrides']['settings'] = $set;
 
 $dev['devices'][$devId]['useOverrides'] = true;
 

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -825,6 +825,7 @@ console.error('[bootstrap] resolve failed:', e);
   step();
 
   // Live-Reload: bei Device NUR resolve pollen
+  // Polling beibehalten, da Versionsänderungen zuverlässig erkannt werden
   if (!previewMode) {
     let lastSchedVer = schedule?.version || 0;
     let lastSetVer   = settings?.version || 0;


### PR DESCRIPTION
## Summary
- Use override-specific versions when resolving device settings and schedule
- Maintain independent version counters for settings and schedule overrides
- Document retained polling in slideshow

## Testing
- `php -l webroot/admin/api/device_resolve.php`
- `php -l webroot/admin/api/devices_save_override.php`
- `node --check webroot/assets/slideshow.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd3bf2df548320b9198053586b3241