### PR TITLE
Reset slideshow lastKey when rebuilding queue

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -268,6 +268,7 @@ function buildQueue() {
 
   nextQueue.splice(0, nextQueue.length, ...queue);
   idx = 0;
+  lastKey = null;
 }
 
   // ---------- DOM helpers ----------
@@ -844,7 +845,7 @@ console.error('[bootstrap] resolve failed:', e);
           if (newSchedVer !== lastSchedVer || newSetVer !== lastSetVer) {
             schedule = j.schedule; settings = j.settings;
             lastSchedVer = newSchedVer; lastSetVer = newSetVer;
-            applyTheme(); applyDisplay(); maybeApplyPreset(); buildQueue();
+            applyTheme(); applyDisplay(); maybeApplyPreset(); buildQueue(); lastKey = null;
             clearTimers(); idx = idx % Math.max(1, nextQueue.length); step();
           }
         } else {
@@ -852,7 +853,7 @@ console.error('[bootstrap] resolve failed:', e);
           const cf = await loadJSON('/data/settings.json');
           if (s.version !== lastSchedVer || cf.version !== lastSetVer) {
             schedule=s; settings=cf; lastSchedVer=s.version; lastSetVer=cf.version;
-            applyTheme(); applyDisplay(); maybeApplyPreset(); buildQueue();
+            applyTheme(); applyDisplay(); maybeApplyPreset(); buildQueue(); lastKey = null;
             clearTimers(); idx = idx % Math.max(1, nextQueue.length); step();
           }
         }


### PR DESCRIPTION
## Summary
- Reset `lastKey` whenever the slide queue is rebuilt
- Clear `lastKey` on live-update rebuilds before restarting the slideshow

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4df4a1748320a94a5d9893d5a19e