### PR TITLE
Handle leftover slideshow media after multi-pass insert

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -263,6 +263,22 @@ function buildQueue() {
     remaining = postponed;
   }
 
+  if (remaining.length) {
+    console.warn('Unplaced media items, appending to end:', remaining);
+    let insPos = idxOverview();
+    insPos = (insPos >= 0) ? insPos + 1 : queue.length;
+    for (const it of remaining) {
+      const dwell = Number.isFinite(+it.dwellSec)
+        ? +it.dwellSec
+        : (settings?.slides?.imageDurationSec ?? settings?.slides?.saunaDurationSec ?? 6);
+
+      const node = { type: it.type, dwell, __id: it.id || null };
+      if (it.src) node.src = it.src;
+      if (it.url && it.type === 'url') node.url = it.url;
+      queue.splice(insPos++, 0, node);
+    }
+  }
+
   // Falls nichts bleibt, notfalls Übersicht zeigen
   if (!queue.length && showOverview) queue.push({ type: 'overview' });
 


### PR DESCRIPTION
## Summary
- Detect unplaced slideshow media items after multi-pass queue insertion
- Append remaining media near the overview or end and log a console warning

## Testing
- `node --check webroot/assets/slideshow.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4f9445b88320acb6943611d33dbd