### PR TITLE
Add video end transition and fallback timeout

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -559,7 +559,15 @@ function renderVideo(src, opts = {}) {
     if (v.parentNode) v.parentNode.replaceChild(fallback, v);
   });
   if (settings?.slides?.waitForVideo) {
-    v.addEventListener('ended', () => { idx++; step(); });
+    const done = () => {
+      if (done.called) return;
+      done.called = true;
+      slideTimer = 0;
+      hide(() => { idx++; step(); });
+    };
+    const maxMs = Math.max(1000, dwellMsForItem(opts));
+    slideTimer = setTimeout(done, maxMs);
+    v.addEventListener('ended', () => { clearTimeout(slideTimer); done(); }, { once: true });
   }
   const c = h('div', { class: 'container videoslide fade show' });
   c.appendChild(v);


### PR DESCRIPTION
## Summary
- ensure video slides fade out before advancing after playback ends
- add timeout fallback to progress if a video never emits `ended`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd50f3239c832099c816570b300efc