### PR TITLE
Handle unresolved devices with explicit 404 in slideshow loader

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -54,7 +54,12 @@ async function loadDeviceResolved(id){
   const r = await fetch(`/pair/resolve?device=${encodeURIComponent(id)}&t=${Date.now()}`, {cache:'no-store'});
   if (!r.ok) throw new Error('device_resolve http '+r.status);
   const j = await r.json();
-  if (!j || j.ok === false || !j.settings || !j.schedule) {
+  if (!j || j.ok === false) {
+    const err = new Error('device_resolve not found');
+    err.status = 404;
+    throw err;
+  }
+  if (!j.settings || !j.schedule) {
     throw new Error('device_resolve payload invalid');
   }
   schedule = j.schedule;


### PR DESCRIPTION
## Summary
- Throw explicit 404 error in `loadDeviceResolved` when device lookup fails
- Preserve existing payload validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd55bc83e08320ba8042f79c141ae5