### PR TITLE
Remove obsolete device context button

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -38,11 +38,9 @@ function renderContextBadge(){
   if (!h1) return;
   let el = document.getElementById('ctxBadge');
   let tip = document.getElementById('ctxBadgeTip');
-  let modeBtn = document.getElementById('ctxDeviceMode');
   if (!currentDeviceCtx){
     if (el) el.remove();
     if (tip) tip.remove();
-    if (modeBtn) modeBtn.remove();
     return;
   }
   if (!el){
@@ -59,21 +57,6 @@ function renderContextBadge(){
     el.after(tip);
   }
   tip.textContent = 'Tipp: Klick auf × um zur globalen Ansicht zurückzukehren.';
-
-  if (!modeBtn){
-    modeBtn = document.createElement('button');
-    modeBtn.id = 'ctxDeviceMode';
-    modeBtn.className = 'btn sm';
-    tip.after(modeBtn);
-  }
-  modeBtn.textContent = 'Individuellen Plan aktivieren';
-  modeBtn.onclick = ()=>{
-    fetch('/admin/api/devices_set_mode.php', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ device: currentDeviceCtx, mode: 'device' })
-    }).catch(()=>{});
-  };
 }
 
 // --- e) Kontext-Wechsel-Funktionen (Modul-Scope) ---


### PR DESCRIPTION
## Summary
- drop inactive ctxDeviceMode button in renderContextBadge
- remove DOM references to ctxDeviceMode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b9da8d08320a6d5526c608172a0