### PR TITLE
Preserve device override mode when saving overrides

### DIFF
--- a/webroot/admin/api/devices_save_override.php
+++ b/webroot/admin/api/devices_save_override.php
@@ -32,8 +32,6 @@ if ($sch !== null) {
 
 $dev['devices'][$devId]['overrides']['settings'] = $set;
 
-$dev['devices'][$devId]['useOverrides'] = true;
-
 if (!devices_save($dev)) {
   echo json_encode(['ok'=>false, 'error'=>'write-failed']); exit;
 }


### PR DESCRIPTION
## Summary
- Avoid forcing `useOverrides` to `true` when saving device overrides so current mode is preserved

## Testing
- `php -l webroot/admin/api/devices_save_override.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd5f1ed8d88320a79f000ed560b6b3