### PR TITLE
Add reliable URL thumbnails with error logging

### DIFF
--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -34,6 +34,7 @@ if (preg_match('/<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\
   $imgUrl = $m[1];
 }
 if (!$imgUrl) {
+  error_log('url_thumb: no image found at '.$url);
   echo json_encode(['ok'=>false,'thumb'=>$fallback]);
   exit;
 }
@@ -74,7 +75,12 @@ $dir = '/var/www/signage/assets/media/img/';
 if (!is_dir($dir)) { @mkdir($dir, 02775, true); @chown($dir,'www-data'); @chgrp($dir,'www-data'); }
 $fname = 'preview_'.bin2hex(random_bytes(5)).'.jpg';
 $full = $dir.$fname;
-imagejpeg($im, $full, 90);
+if (!imagejpeg($im, $full, 90)) {
+  error_log('url_thumb: failed to save image to '.$full);
+  imagedestroy($im);
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
 imagedestroy($im);
 @chmod($full,0644); @chown($full,'www-data'); @chgrp($full,'www-data');
 $public = '/assets/media/img/'.$fname;

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -803,30 +803,28 @@ function interRow(i){
       mb.title = 'URL';
       mb.onclick = () => {
         const val = prompt('URL:', it.url || '');
-        if (val) {
+        if (val !== null) {
           it.url = val.trim();
-          it.thumb = '';
-          updatePrev('');
-          fetch('/admin/api/url_thumb.php', {
-            method:'POST',
-            headers:{'Content-Type':'application/json'},
-            body: JSON.stringify({url: it.url})
-          }).then(r=>r.json()).then(j=>{
-            if (j && j.ok && j.thumb){
-              const t = j.thumb + '?v=' + Date.now();
-              it.thumb = t;
-              updatePrev(t);
+          it.thumb = FALLBACK_THUMB;
+          updatePrev(FALLBACK_THUMB);
+          if (it.url) {
+            fetch('/admin/api/url_thumb.php', {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({ url: it.url })
+            }).then(r => r.json()).then(j => {
+              if (j && j.ok && j.thumb) {
+                const t = j.thumb + '?v=' + Date.now();
+                it.thumb = t;
+                updatePrev(t);
+              }
               renderSlidesMaster();
-            } else {
-              it.thumb = FALLBACK_THUMB;
-              updatePrev(FALLBACK_THUMB);
+            }).catch(() => {
               renderSlidesMaster();
-            }
-          }).catch(()=>{
-            it.thumb = FALLBACK_THUMB;
-            updatePrev(FALLBACK_THUMB);
+            });
+          } else {
             renderSlidesMaster();
-          });
+          }
         }
       };
       $media.appendChild(mb);


### PR DESCRIPTION
## Summary
- Ensure URL slides always request a thumbnail and default to a fallback image
- Log missing images and save failures in `url_thumb.php`

## Testing
- `node --check webroot/admin/js/ui/slides_master.js`
- `php -l webroot/admin/api/url_thumb.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ef0899083209d7f62d6296af6c4