### PR TITLE
Improve ffmpeg logging and video thumbnail fallback

### DIFF
--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -88,8 +88,11 @@ if ($subDir === 'video' && !$thumbPath){
   $cmd = 'ffmpeg -hide_banner -loglevel error -i '.escapeshellarg($dest).' -vf "thumbnail,scale=640:-1" -frames:v 1 '.escapeshellarg($thumbDest).' 2>&1';
   $o=[]; $ret=0;
   exec($cmd, $o, $ret);
+  $out = implode("\n", $o);
   if ($ret !== 0 || !file_exists($thumbDest)){
-    error_log('ffmpeg-thumb-failed: '.$cmd.'; output='.implode("\n", $o));
+    error_log('ffmpeg-thumb-failed: cmd='.$cmd.'; ret='.$ret.'; dest='.$thumbDest.'; output='.$out);
+  } else {
+    error_log('ffmpeg-thumb-success: cmd='.$cmd.'; ret='.$ret.'; dest='.$thumbDest.'; output='.$out);
   }
   if (file_exists($thumbDest)){
     @chmod($thumbDest,0644); @chown($thumbDest,'www-data'); @chgrp($thumbDest,'www-data');

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -788,8 +788,17 @@ function interRow(i){
         fi.onchange = () => uploadGeneric(fi, (p, tp) => {
           const suffix = '?v=' + Date.now();
           it.url = p + suffix;
-          const tv = tp || (t === 'image' ? p : '');
-          it.thumb = tv ? tv + suffix : '';
+          if (t === 'video') {
+            if (tp) {
+              it.thumb = tp + suffix;
+            } else {
+              it.thumb = FALLBACK_THUMB;
+              alert('Kein Thumbnail vom Server erhalten.');
+            }
+          } else {
+            const tv = tp || p;
+            it.thumb = tv ? tv + suffix : '';
+          }
           updatePrev(it.thumb);
           renderSlidesMaster();
         });


### PR DESCRIPTION
## Summary
- Log ffmpeg return code and output for easier debugging when generating video thumbnails
- Handle missing thumbnails on video upload by applying a fallback and notifying the user

## Testing
- `php -l webroot/admin/api/upload.php`
- `node --check webroot/admin/js/ui/slides_master.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdab6b5e188320889bae7432c53e4c