### PR TITLE
Remove cookie overlays from URL slides

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -585,6 +585,21 @@ function renderUrl(src) {
     class: 'urlFill',
     style: 'border:0'
   });
+  f.addEventListener('load', () => {
+    try {
+      const doc = f.contentWindow.document;
+      const selectors = ['[id*="cookie"]', '.cookie-banner', '.cc-window', '.cookie-consent'];
+      if (Array.isArray(settings?.popupSelectors)) {
+        selectors.push(...settings.popupSelectors);
+      }
+      doc.querySelectorAll(selectors.join(',')).forEach(el => {
+        if (typeof el.remove === 'function') el.remove();
+        else el.style.display = 'none';
+      });
+    } catch (e) {
+      /* ignore cross-origin */
+    }
+  });
   const c = h('div', { class: 'container urlslide fade show' }, [f]);
   return c;
 }

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -44,5 +44,6 @@
     },
     "flameImage": "/assets/img/flame_test.svg"
   },
+  "popupSelectors": [],
   "footnote": "* Nur am Fr und Sa"
 }


### PR DESCRIPTION
## Summary
- inject cookie overlay remover for iframe URL slides
- allow custom popup selectors via `settings.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdab74c54c83209243e0f06f5c477a