### PR TITLE
Add extension checks for URL thumbnail generation

### DIFF
--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -10,6 +10,17 @@ if (!is_string($url) || !preg_match('#^https?://#i', $url)) {
   exit;
 }
 
+if (!extension_loaded('curl')) {
+  error_log('url_thumb: curl extension not loaded');
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+if (!extension_loaded('gd')) {
+  error_log('url_thumb: gd extension not loaded');
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+
 $ch = curl_init($url);
 curl_setopt_array($ch, [
   CURLOPT_RETURNTRANSFER => true,


### PR DESCRIPTION
## Summary
- ensure url thumbnail API fails gracefully when `curl` or `gd` extensions are missing

## Testing
- `php -l webroot/admin/api/url_thumb.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdaf95ae288320bc7d2de6b581d854