### PR TITLE
refactor: reuse useOverrides flag in device resolve

### DIFF
--- a/webroot/admin/api/device_resolve.php
+++ b/webroot/admin/api/device_resolve.php
@@ -112,7 +112,8 @@ if (!empty($mergedSettings['presetAuto']) && !empty($mergedSettings['presets']) 
   }
 }
 
-if ($dev['useOverrides'] && !empty($overSchedule)) {
+$useOverrides = !empty($dev['useOverrides']);
+if ($useOverrides && !empty($overSchedule)) {
   $schedule = merge_r($schedule, $overSchedule);
   $schedule['version'] = intval($overSchedule['version'] ?? 0);
 } else {
@@ -120,7 +121,7 @@ if ($dev['useOverrides'] && !empty($overSchedule)) {
 }
 
 // Version als Cache-Bremse; bei aktivem Override nur dessen Version nutzen
-if ($dev['useOverrides'] && array_key_exists('version', $overSettings)) {
+if ($useOverrides && array_key_exists('version', $overSettings)) {
   $mergedSettings['version'] = intval($overSettings['version']);
 } else {
   $mergedSettings['version'] = intval($baseSettings['version'] ?? 0);


### PR DESCRIPTION
## Summary
- reuse `useOverrides` flag to simplify override checks

## Testing
- `php -l webroot/admin/api/device_resolve.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb36ea49c83208ff56487c66e2a01