### PR TITLE
Check GD function availability in thumbnail generator

### DIFF
--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -76,6 +76,12 @@ if ($imgData === false) {
 }
 curl_close($ch);
 
+if (!function_exists('imagecreatefromstring')) {
+  error_log('url_thumb: gd-missing');
+  echo json_encode(['ok'=>false,'thumb'=>$fallback]);
+  exit;
+}
+
 $im = @imagecreatefromstring($imgData);
 if (!$im) {
   error_log('url_thumb: invalid image data');


### PR DESCRIPTION
## Summary
- Ensure `imagecreatefromstring` is available before creating URL thumbnails
- Log `gd-missing` and return fallback thumbnail when GD function is unavailable

## Testing
- `php -l webroot/admin/api/url_thumb.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb5606ec48320ab497c106b9f6bcd