### PR TITLE
Surface video thumbnail generation errors

### DIFF
--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -50,6 +50,7 @@ if (!@move_uploaded_file($u['tmp_name'], $dest)) fail('move-failed', 500);
 $publicPath = '/assets/media/'.$subDir.'/' . basename($dest);
 // optional or auto-generated preview image (thumb)
 $thumbPath = null;
+$thumbError = null;
 if ($subDir === 'img'){
   $thumbPath = $publicPath;
 } elseif (isset($_FILES['thumb']) && is_uploaded_file($_FILES['thumb']['tmp_name'])) {
@@ -91,6 +92,7 @@ if ($subDir === 'video' && !$thumbPath){
   $out = implode("\n", $o);
   if ($ret !== 0 || !file_exists($thumbDest)){
     error_log('ffmpeg-thumb-failed: cmd='.$cmd.'; ret='.$ret.'; dest='.$thumbDest.'; output='.$out);
+    $thumbError = 'thumbnail generation failed';
   } else {
     error_log('ffmpeg-thumb-success: cmd='.$cmd.'; ret='.$ret.'; dest='.$thumbDest.'; output='.$out);
   }
@@ -100,4 +102,6 @@ if ($subDir === 'video' && !$thumbPath){
   }
 }
 
-echo json_encode(['ok'=>true,'path'=>$publicPath,'thumb'=>$thumbPath]);
+$resp = ['ok'=>true,'path'=>$publicPath,'thumb'=>$thumbPath];
+if ($thumbError) $resp['error'] = $thumbError;
+echo json_encode($resp);

--- a/webroot/admin/js/core/upload.js
+++ b/webroot/admin/js/core/upload.js
@@ -14,7 +14,7 @@ export function uploadGeneric(fileInput, onDone, thumbInput){
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb);
+      if (j.ok) onDone(j.path, j.thumb, j.error);
       else alert('Upload-Fehler: '+(j.error||''));
     }catch{
       alert('Upload fehlgeschlagen');
@@ -35,7 +35,7 @@ export function uploadFile(file, onDone){
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb);
+      if (j.ok) onDone(j.path, j.thumb, j.error);
       else alert('Upload-Fehler: '+(j.error||''));
     }catch{
       alert('Upload fehlgeschlagen');

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -785,7 +785,7 @@ function interRow(i){
         const fi = document.createElement('input');
         fi.type = 'file';
         fi.accept = (t === 'video') ? 'video/*' : 'image/*';
-        fi.onchange = () => uploadGeneric(fi, (p, tp) => {
+        fi.onchange = () => uploadGeneric(fi, (p, tp, err) => {
           const suffix = '?v=' + Date.now();
           it.url = p + suffix;
           if (t === 'video') {
@@ -793,7 +793,7 @@ function interRow(i){
               it.thumb = tp + suffix;
             } else {
               it.thumb = FALLBACK_THUMB;
-              alert('Kein Thumbnail vom Server erhalten.');
+              if (err) alert(err);
             }
           } else {
             const tv = tp || p;


### PR DESCRIPTION
## Summary
- Include `error` field when ffmpeg fails to generate video thumbnails in upload API responses
- Forward error messages from upload helper to callbacks and display them in slides master UI

## Testing
- `php -l webroot/admin/api/upload.php`
- `node --check webroot/admin/js/core/upload.js`
- `node --check webroot/admin/js/ui/slides_master.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdb69b52e083209f265fdd6540b1fc