### PR TITLE
Use explicit section keys in import API

### DIFF
--- a/webroot/admin/api/import.php
+++ b/webroot/admin/api/import.php
@@ -18,7 +18,9 @@ $writeAssets   = !empty($_POST['writeAssets']) || !empty($_GET['writeAssets']);
 $writeSettings = isset($_POST['writeSettings']) ? ($_POST['writeSettings']==='1') : true;
 $writeSchedule = isset($_POST['writeSchedule']) ? ($_POST['writeSchedule']==='1') : true;
 $settings = $j['settings'] ?? null; $schedule = $j['schedule'] ?? null;
-if (!$settings && !$schedule) fail('missing-sections');
+$hasSettings = array_key_exists('settings', $j);
+$hasSchedule = array_key_exists('schedule', $j);
+if (!$hasSettings && !$hasSchedule) fail('missing-sections');
 
 $base = '/var/www/signage';
 $assetsDir = $base.'/assets/img';


### PR DESCRIPTION
## Summary
- Ensure `import` API validates presence of `settings` and `schedule` using `array_key_exists`

## Testing
- `php -l webroot/admin/api/import.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb706a2788320b93bc685e0e264ea