### PR TITLE
Handle interstitial asset paths in export/import

### DIFF
--- a/webroot/admin/api/export.php
+++ b/webroot/admin/api/export.php
@@ -35,7 +35,15 @@ if ($include && $incSettings) {
   if (!empty($settings['assets']['rightImages']) && is_array($settings['assets']['rightImages'])) {
     foreach ($settings['assets']['rightImages'] as $p) if ($p) $paths[] = $p;
   }
-  $paths = array_values(array_unique(array_filter($paths, fn($p)=>is_string($p) && str_starts_with($p,'/assets/img/'))));
+  if (!empty($settings['interstitials']) && is_array($settings['interstitials'])) {
+    foreach ($settings['interstitials'] as $it) {
+      if (!is_array($it)) continue;
+      foreach ($it as $v) {
+        if (is_string($v) && str_starts_with($v, '/assets/')) $paths[] = $v;
+      }
+    }
+  }
+  $paths = array_values(array_unique(array_filter($paths, fn($p)=>is_string($p) && str_starts_with($p,'/assets/'))));
   $blobs = [];
   $base = '/var/www/signage';
   $fi = new finfo(FILEINFO_MIME_TYPE);

--- a/webroot/admin/api/import.php
+++ b/webroot/admin/api/import.php
@@ -57,6 +57,16 @@ if ($writeAssets && !empty($j['blobs']) && is_array($j['blobs'])) {
       if (isset($pathMap[$p])) $settings['assets']['rightImages'][$k] = $pathMap[$p];
     }
   }
+  if (!empty($settings['interstitials']) && is_array($settings['interstitials'])) {
+    foreach ($settings['interstitials'] as $i=>$it) {
+      if (!is_array($it)) continue;
+      foreach ($it as $k=>$v) {
+        if (is_string($v) && isset($pathMap[$v])) {
+          $settings['interstitials'][$i][$k] = $pathMap[$v];
+        }
+      }
+    }
+  }
 }
 
 // bump versions (nur wenn vorhanden & aktiviert)


### PR DESCRIPTION
## Summary
- include interstitial media paths when exporting blobs
- remap interstitial asset paths when importing exported data

## Testing
- `php -l webroot/admin/api/export.php`
- `php -l webroot/admin/api/import.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7a950e0832096ffec7005f03a81