### PR TITLE
Add dedicated devices view button

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -537,6 +537,7 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
 #copyHex{white-space:nowrap}
 
 /* Ansicht-Menü (Header) */
+#btnDevices, #viewMenuWrap{ flex-shrink:0; }
 .menuwrap{ position:relative; }
 .dropdown{
   position:absolute; top:calc(100% + 6px); left:0; z-index:80;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -15,6 +15,7 @@
         <span id="themeLabel">Dunkel</span>
       </label>
 <!-- Ansicht-Menü -->
+<button class="btn" id="btnDevices">Geräte</button>
 <div class="menuwrap" id="viewMenuWrap">
   <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
     Ansicht: <span id="viewMenuLabel">Grid</span> ▾
@@ -22,7 +23,6 @@
   <div class="dropdown" id="viewMenu" role="menu" hidden>
     <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
     <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
-    <button class="dd-item" role="menuitemradio" data-view="devices" aria-checked="false">🖥 Geräte</button>
   </div>
 </div>
       <button class="btn" id="btnHelp">Hilfe</button>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -976,17 +976,21 @@ function destroyDockPane(){
   }
 }
 
-function viewLabel(v){ return v==='preview' ? 'Vorschau' : v==='devices' ? 'Geräte' : 'Grid'; }
+function viewLabel(v){
+  return v === 'preview' ? 'Vorschau' : 'Grid';
+}
 
 async function showView(v){
   currentView = v;
   localStorage.setItem('adminView', v);
 
   const labelEl = document.getElementById('viewMenuLabel');
-  if (labelEl) labelEl.textContent = viewLabel(v);
-  document.querySelectorAll('#viewMenu .dd-item').forEach(it=>{
-    it.setAttribute('aria-checked', it.dataset.view === v ? 'true' : 'false');
-  });
+  if (labelEl && v !== 'devices') labelEl.textContent = viewLabel(v);
+  if (v !== 'devices'){
+    document.querySelectorAll('#viewMenu .dd-item').forEach(it=>{
+      it.setAttribute('aria-checked', it.dataset.view === v ? 'true' : 'false');
+    });
+  }
 
   const gridCard = document.getElementById('gridPane');
   if (!gridCard) return;
@@ -1061,6 +1065,9 @@ function initViewMenu(){
     if (e.key === '2') { await showView('preview'); closeMenu(); }
     if (e.key === '3') { await showView('devices'); closeMenu(); }
   });
+
+  const btnDevices = document.getElementById('btnDevices');
+  if (btnDevices) btnDevices.onclick = ()=> showView('devices');
 
   document.getElementById('viewMenuLabel').textContent = viewLabel(currentView);
   // Initial zeichnen


### PR DESCRIPTION
## Summary
- Move devices option out of the view dropdown and add a dedicated **Geräte** button.
- Update view switching logic to handle devices without dropdown entry and wire up the new button.
- Ensure devices button and view menu align properly in the header.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c67d0121248320993f7af40576a65e