### PR TITLE
Place theme toggle before heading

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -99,11 +99,18 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 header{
   position:sticky; top:0; z-index:60;
   display:flex; justify-content:space-between; align-items:center; gap:12px;
+  flex-wrap:wrap;
   padding:14px 16px; border-bottom:1px solid var(--border);
   background: color-mix(in oklab, var(--panel) 85%, transparent);
   backdrop-filter: blur(8px);
 }
 h1{ margin:0; font-size:16px; letter-spacing:.3px; }
+
+header .header-title{
+  display:flex;
+  align-items:center;
+  gap:12px;
+}
 
 body.device-mode header{
   background: var(--btn-primary);

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -8,23 +8,25 @@
 </head>
 <body class="theme-light">
   <header>
-    <h1>Aufguss – Admin</h1>
-    <div class="row">
+    <div class="row header-title">
       <label class="toggle" title="Hell/Dunkel">
         <input type="checkbox" id="themeMode">
         <span id="themeLabel">Dunkel</span>
       </label>
-<!-- Ansicht-Menü -->
-<div class="menuwrap" id="viewMenuWrap">
-  <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
-    Ansicht: <span id="viewMenuLabel">Grid</span> ▾
-  </button>
-  <div class="dropdown" id="viewMenu" role="menu" hidden>
-    <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
-    <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
-    <button class="dd-item" role="menuitemradio" data-view="devices" aria-checked="false">🖥 Geräte</button>
-  </div>
-</div>
+      <h1>Aufguss – Admin</h1>
+    </div>
+    <div class="row">
+      <!-- Ansicht-Menü -->
+      <div class="menuwrap" id="viewMenuWrap">
+        <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
+          Ansicht: <span id="viewMenuLabel">Grid</span> ▾
+        </button>
+        <div class="dropdown" id="viewMenu" role="menu" hidden>
+          <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
+          <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
+          <button class="dd-item" role="menuitemradio" data-view="devices" aria-checked="false">🖥 Geräte</button>
+        </div>
+      </div>
       <button class="btn" id="btnHelp">Hilfe</button>
       <button class="btn" id="btnOpen">Slideshow öffnen</button>
       <button class="btn primary" id="btnSave">Speichern</button>


### PR DESCRIPTION
## Summary
- Move dark/light toggle before "Aufguss – Admin" heading
- Flex header title group and allow wrap for mobile responsiveness

## Testing
- `npx --yes htmlhint webroot/admin/index.html` *(fails: 403 Forbidden)*
- `npx --yes stylelint webroot/admin/css/admin.css` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c67cdff3fc83208cb54b8084187832