### PR TITLE
Improve thumbnail error handling

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -793,7 +793,7 @@ function interRow(i){
               it.thumb = tp + suffix;
             } else {
               it.thumb = FALLBACK_THUMB;
-              if (err) alert(err);
+              alert(err || 'Kein Thumbnail vom Server erhalten');
             }
           } else {
             const tv = tp || p;
@@ -826,9 +826,13 @@ function interRow(i){
                 const t = j.thumb + '?v=' + Date.now();
                 it.thumb = t;
                 updatePrev(t);
+              } else {
+                const msg = j?.error || 'Kein Thumbnail gefunden (og:image?)';
+                alert('Thumbnail-Fehler: ' + msg);
               }
               renderSlidesMaster();
             }).catch(() => {
+              alert('Thumbnail-Fehler: Netzwerkproblem');
               renderSlidesMaster();
             });
           } else {


### PR DESCRIPTION
## Summary
- add detailed error responses in `url_thumb.php`
- surface thumbnail errors in `slides_master.js` for video uploads and external URLs

## Testing
- `php -m | grep -E 'curl|gd'`
- `ffmpeg -version` *(fails: command not found)*
- `node --check webroot/admin/js/ui/slides_master.js`
- `php -l webroot/admin/api/url_thumb.php`
- `php webroot/admin/api/url_thumb.php <<'EOF'
{"url":"invalid"}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c67cfb5e0083208b2f4992ec773627