### PR TITLE
feat: add session-based admin login

### DIFF
--- a/config/nginx/signage-admin.conf
+++ b/config/nginx/signage-admin.conf
@@ -13,26 +13,41 @@ server {
   add_header Referrer-Policy no-referrer-when-downgrade always;
   add_header X-Served-By signage-admin always;
 
-  auth_basic "Restricted";
-  auth_basic_user_file /etc/nginx/.signage_admin;
+  if ($scheme != "https") { return 301 https://$host$request_uri; }
 
   location = / { return 302 /admin/; }
   location = /admin { return 302 /admin/; }
+
+  location = /admin/login.html { try_files $uri =404; }
+  location = /admin/css/login.css { try_files $uri =404; }
+  location = /admin/js/login.js { try_files $uri =404; }
+
   location /admin/ {
+    auth_request /admin/api/login.php;
+    error_page 401 =302 /admin/login.html;
     try_files $uri $uri/ /admin/index.html;
   }
 
   location = /favicon.ico { access_log off; log_not_found off; return 204; }
 
-  location ~ ^/admin/api/.*\.php$ {
+  location = /admin/api/login.php {
     include snippets/fastcgi-php.conf;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_pass unix:__PHP_SOCK__;
   }
-location ^~ /data/ {
-  add_header Cache-Control "no-store, must-revalidate" always;
-  auth_basic off;                       # WICHTIG: ohne Login
-  try_files $uri =404;
-}
-include /etc/nginx/snippets/signage-pairing.conf;
+
+  location ~ ^/admin/api/.*\.php$ {
+    auth_request /admin/api/login.php;
+    include snippets/fastcgi-php.conf;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_pass unix:__PHP_SOCK__;
+  }
+
+  location ^~ /data/ {
+    add_header Cache-Control "no-store, must-revalidate" always;
+    auth_basic off;                       # WICHTIG: ohne Login
+    try_files $uri =404;
+  }
+
+  include /etc/nginx/snippets/signage-pairing.conf;
 }

--- a/webroot/admin/api/login.php
+++ b/webroot/admin/api/login.php
@@ -1,0 +1,55 @@
+<?php
+if (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] !== 'on') {
+    http_response_code(400);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['error' => 'https-required']);
+    exit;
+}
+
+session_set_cookie_params([
+    'secure' => true,
+    'httponly' => true,
+    'samesite' => 'Strict'
+]);
+session_start();
+header('Content-Type: application/json; charset=UTF-8');
+
+$defaultUser = 'admin';
+$defaultHash = '$2y$12$/cyMQfwFihzIBnvH0ve/u.sbpUK.iZsRuUZXvDBxBw.dIxneEp.Qq';
+$user = getenv('SIGNAGE_ADMIN_USER') ?: $defaultUser;
+$hash = getenv('SIGNAGE_ADMIN_PASS_HASH') ?: $defaultHash;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = $_POST['token'] ?? '';
+    if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'csrf']);
+        exit;
+    }
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if ($username === $user && password_verify($password, $hash)) {
+        session_regenerate_id(true);
+        $_SESSION['authenticated'] = true;
+        unset($_SESSION['csrf_token']);
+        echo json_encode(['ok' => 1]);
+    } else {
+        http_response_code(401);
+        echo json_encode(['error' => 'invalid']);
+    }
+    exit;
+}
+
+if (!empty($_GET['token'])) {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    echo json_encode(['token' => $_SESSION['csrf_token']]);
+    exit;
+}
+
+if (!empty($_SESSION['authenticated'])) {
+    http_response_code(204);
+} else {
+    http_response_code(401);
+}

--- a/webroot/admin/css/login.css
+++ b/webroot/admin/css/login.css
@@ -1,0 +1,45 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  font-family: sans-serif;
+}
+
+.login-card {
+  background: #fff;
+  padding: 2rem;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  max-width: 320px;
+  width: 100%;
+  border-radius: 4px;
+}
+
+.login-card h1 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.login-card form {
+  display: flex;
+  flex-direction: column;
+}
+
+.login-card input {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.login-card button {
+  padding: 0.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.error {
+  color: #c00;
+  text-align: center;
+}

--- a/webroot/admin/js/login.js
+++ b/webroot/admin/js/login.js
@@ -1,0 +1,29 @@
+async function fetchToken(){
+  const r = await fetch('api/login.php?token=1', {credentials: 'include'});
+  if(r.ok){
+    const data = await r.json();
+    document.getElementById('token').value = data.token;
+  }
+}
+
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const body = new URLSearchParams();
+  body.set('username', document.getElementById('username').value);
+  body.set('password', document.getElementById('password').value);
+  body.set('token', document.getElementById('token').value);
+  const r = await fetch('api/login.php', {
+    method: 'POST',
+    body,
+    credentials: 'include',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+  });
+  if(r.ok){
+    window.location.href = '/admin/';
+  } else {
+    document.getElementById('error').textContent = 'Login fehlgeschlagen';
+    fetchToken();
+  }
+});
+
+fetchToken();

--- a/webroot/admin/login.html
+++ b/webroot/admin/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Admin Login</title>
+  <link rel="stylesheet" href="css/login.css">
+</head>
+<body>
+  <div class="login-card">
+    <h1>Anmelden</h1>
+    <form id="loginForm">
+      <input type="text" id="username" placeholder="Benutzername" required>
+      <input type="password" id="password" placeholder="Passwort" required>
+      <input type="hidden" id="token">
+      <button type="submit">Anmelden</button>
+    </form>
+    <div id="error" class="error"></div>
+  </div>
+  <script src="js/login.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add responsive admin login page with JS form submission
- introduce PHP login endpoint with sessions, CSRF token, and hashed password
- replace nginx basic auth with session-based auth_request and HTTPS redirect

## Testing
- `php -l webroot/admin/api/login.php`
- `nginx -t -c config/nginx/signage-admin.conf` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c67cedf2cc8320a000ac3cc2bd7411