### PR TITLE
Split admin nginx config into HTTP redirect and HTTPS service

### DIFF
--- a/config/nginx/signage-admin.conf
+++ b/config/nginx/signage-admin.conf
@@ -2,6 +2,15 @@ server {
   listen __ADMIN_PORT__;
   listen [::]:__ADMIN_PORT__;
   server_name _;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  server_name _;
+  ssl_certificate /path/to/fullchain.pem;
+  ssl_certificate_key /path/to/privkey.pem;
   root /var/www/signage;
   index index.html;
 
@@ -12,8 +21,6 @@ server {
   add_header X-Frame-Options SAMEORIGIN always;
   add_header Referrer-Policy no-referrer-when-downgrade always;
   add_header X-Served-By signage-admin always;
-
-  if ($scheme != "https") { return 301 https://$host$request_uri; }
 
   location = / { return 302 /admin/; }
   location = /admin { return 302 /admin/; }


### PR DESCRIPTION
## Summary
- Break admin configuration into separate HTTP redirect and HTTPS service blocks
- Add SSL certificate directives and remove inline scheme check

## Testing
- `apt-get update` *(fails: 403 Forbidden for Ubuntu repositories)*
- `nginx -t -c config/nginx/signage-admin.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68197898c8320a019d3526a9c2ca9