### PR TITLE
Add HTTPS server block and redirect

### DIFF
--- a/config/nginx/signage-slideshow.conf
+++ b/config/nginx/signage-slideshow.conf
@@ -2,7 +2,18 @@ server {
   listen __PUBLIC_PORT__ default_server;
   listen [::]:__PUBLIC_PORT__ default_server;
   server_name _;
+
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl default_server;
+  listen [::]:443 ssl default_server;
+  server_name _;
   root /var/www/signage;
+
+  ssl_certificate     /etc/nginx/ssl/signage-slideshow.crt;
+  ssl_certificate_key /etc/nginx/ssl/signage-slideshow.key;
 
   add_header Cache-Control "no-store" always;
   add_header X-Served-By signage-slideshow always;
@@ -14,6 +25,8 @@ server {
     add_header Cache-Control "no-store, must-revalidate" always;
     try_files $uri =404;
   }
-# Pairing/Device-API – ohne Auth, gleicher Origin (Port 80)
-include /etc/nginx/snippets/signage-pairing.conf;
+
+  # Pairing/Device-API – ohne Auth, gleicher Origin
+  include /etc/nginx/snippets/signage-pairing.conf;
 }
+


### PR DESCRIPTION
## Summary
- add HTTP->HTTPS redirect server block for slideshow
- add dedicated HTTPS server block with cert paths mirroring existing config

## Testing
- `nginx -t -c config/nginx/signage-slideshow.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68212227c8320bad126d95ccf8d9f