### PR TITLE
Add admin header title and vertical toggle

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -110,6 +110,14 @@ header .header-title{
   display:flex;
   align-items:center;
   gap:12px;
+  flex-wrap:wrap;
+}
+
+.header-actions{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  margin-left:auto;
 }
 
 body.device-mode header{
@@ -238,20 +246,40 @@ details[open] .chev{ transform: rotate(90deg); }
 
 /* Toggle */
 .toggle{
-  display:flex; align-items:center; gap:8px;
-  border:1px solid var(--ghost-border); padding:7px 10px; border-radius:12px; background:var(--panel);
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:8px;
+  border:1px solid var(--ghost-border);
+  padding:10px 7px;
+  border-radius:12px;
+  background:var(--panel);
 }
 .toggle input{
-  appearance:none; width:28px; height:16px; border-radius:999px; background:#94a3b8; position:relative; outline:0;
+  appearance:none;
+  writing-mode:vertical-lr;
+  width:16px;
+  height:28px;
+  border-radius:999px;
+  background:#94a3b8;
+  position:relative;
+  outline:0;
 }
 .theme-dark .toggle input{ background:#4b5563; }
 .toggle input:checked{ background:#22c55e; }
 .toggle input::after{
-  content:''; position:absolute; top:2px; left:2px; width:12px; height:12px;
-  border-radius:50%; background:#fff; transition:left .15s;
+  content:'';
+  position:absolute;
+  top:2px;
+  left:2px;
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  background:#fff;
+  transition:top .15s;
 }
 
-.toggle input:checked::after{ left:14px; }
+.toggle input:checked::after{ top:14px; }
 
 .toggle.ind-active{
   border-color:var(--btn-accent);

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -9,24 +9,27 @@
 <body class="theme-light">
   <header>
     <div class="row header-title">
+      <h1>Anzeigensteuerung – Admin</h1>
       <label class="toggle" title="Hell/Dunkel">
         <input type="checkbox" id="themeMode">
         <span id="themeLabel">Dunkel</span>
       </label>
-<!-- Ansicht-Menü -->
-<button class="btn" id="btnDevices">Geräte</button>
-<div class="menuwrap" id="viewMenuWrap">
-  <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
-    Ansicht: <span id="viewMenuLabel">Grid</span> ▾
-  </button>
-  <div class="dropdown" id="viewMenu" role="menu" hidden>
-    <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
-    <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
-  </div>
-</div>
-      <button class="btn" id="btnHelp">Hilfe</button>
-      <button class="btn" id="btnOpen">Slideshow öffnen</button>
-      <button class="btn primary" id="btnSave">Speichern</button>
+      <div class="header-actions">
+        <!-- Ansicht-Menü -->
+        <button class="btn" id="btnDevices">Geräte</button>
+        <div class="menuwrap" id="viewMenuWrap">
+          <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
+            Ansicht: <span id="viewMenuLabel">Grid</span> ▾
+          </button>
+          <div class="dropdown" id="viewMenu" role="menu" hidden>
+            <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
+            <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
+          </div>
+        </div>
+        <button class="btn" id="btnHelp">Hilfe</button>
+        <button class="btn" id="btnOpen">Slideshow öffnen</button>
+        <button class="btn primary" id="btnSave">Speichern</button>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Add "Anzeigensteuerung – Admin" headline and group header actions to the right of it
- Convert theme toggle to a vertical slider and style new header actions wrapper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c69de5e83083208c24a6c8152ad3b1