### PR TITLE
Add favicon fallback and default icon for URL thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ structure:
 The installer applies secure defaults (basic auth for the admin interface,
 strict file permissions and PHP hardening) and ensures reproducible setup.
 
+## Requirements
+
+PHP extensions `curl` and `gd` must be enabled. On Debian/Ubuntu systems:
+
+```bash
+sudo apt-get install php-curl php-gd
+```
+
 ## Usage
 
 Run the installer as root:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,7 +43,7 @@ main(){
   log "Installing packages"
   export DEBIAN_FRONTEND=noninteractive
   apt-get update -y
-  apt-get install -y nginx php8.3-fpm php8.3-cli php8.3-xml php8.3-mbstring php8.3-curl jq unzip curl git rsync
+  apt-get install -y nginx php8.3-fpm php8.3-cli php8.3-xml php8.3-mbstring php8.3-curl php8.3-gd jq unzip curl git rsync
 
   log "Deploying application files"
   rsync -a webroot/ "$APP_DIR"/

--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -9,6 +9,13 @@ function fail($msg){
   exit;
 }
 
+function default_thumb($msg){
+  global $fallback;
+  error_log('url_thumb: '.$msg);
+  echo json_encode(['ok'=>true,'thumb'=>$fallback,'thumbFallback'=>true,'error'=>$msg]);
+  exit;
+}
+
 $raw = file_get_contents('php://input');
 $req = json_decode($raw, true);
 $url = $req['url'] ?? '';
@@ -17,10 +24,10 @@ if (!is_string($url) || !preg_match('#^https?://#i', $url)) {
 }
 
 if (!extension_loaded('curl')) {
-  fail('curl extension not loaded');
+  fail('curl extension not loaded; install php-curl');
 }
 if (!extension_loaded('gd')) {
-  fail('gd extension not loaded');
+  fail('gd extension not loaded; install php-gd');
 }
 
 $ch = curl_init($url);
@@ -34,10 +41,11 @@ $html = curl_exec($ch);
 if ($html === false) {
   $err = curl_error($ch);
   curl_close($ch);
-  fail('html curl error: '.$err);
+  default_thumb('html curl error: '.$err);
 }
 $baseUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL) ?: $url;
 curl_close($ch);
+$base = parse_url($baseUrl);
 
 $imgUrl = '';
 if (preg_match('/<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\']/i', $html, $m)) {
@@ -45,11 +53,13 @@ if (preg_match('/<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\
 } elseif (preg_match('/<link\s+[^>]*rel=["\'](?:shortcut )?icon["\'][^>]*href=["\']([^"\']+)["\']/i', $html, $m)) {
   $imgUrl = $m[1];
 }
+if (!$imgUrl && !empty($base['host'])) {
+  $imgUrl = 'https://'.$base['host'].'/favicon.ico';
+}
 if (!$imgUrl) {
-  fail('no image found');
+  default_thumb('no image found');
 }
 $imgUrl = html_entity_decode($imgUrl, ENT_QUOTES|ENT_HTML5, 'UTF-8');
-$base = parse_url($baseUrl);
 if (strpos($imgUrl, '//') === 0) {
   $imgUrl = $base['scheme'].':'.$imgUrl;
 } elseif (strpos($imgUrl, '/') === 0) {
@@ -70,7 +80,7 @@ $imgData = curl_exec($ch);
 if ($imgData === false) {
   $err = curl_error($ch);
   curl_close($ch);
-  fail('image curl error: '.$err);
+  default_thumb('image curl error: '.$err);
 }
 curl_close($ch);
 
@@ -80,7 +90,7 @@ if (!function_exists('imagecreatefromstring')) {
 
 $im = @imagecreatefromstring($imgData);
 if (!$im) {
-  fail('invalid image data');
+  default_thumb('invalid image data');
 }
 $dir = '/var/www/signage/assets/media/img/';
 if (!is_dir($dir)) { @mkdir($dir, 02775, true); @chown($dir,'www-data'); @chgrp($dir,'www-data'); }
@@ -88,7 +98,7 @@ $fname = 'preview_'.bin2hex(random_bytes(5)).'.jpg';
 $full = $dir.$fname;
 if (!imagejpeg($im, $full, 90)) {
   imagedestroy($im);
-  fail('failed to save image');
+  default_thumb('failed to save image');
 }
 imagedestroy($im);
 @chmod($full,0644); @chown($full,'www-data'); @chgrp($full,'www-data');


### PR DESCRIPTION
## Summary
- try page favicon when no thumbnail image is found
- return a clearly flagged default icon instead of errors
- document required PHP extensions and install PHP GD in installer

## Testing
- `php -l webroot/admin/api/url_thumb.php`
- `bash -n scripts/install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6a397c0688320b5bebba14dc392a0