### PR TITLE
Use icons for theme toggle

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -247,19 +247,20 @@ details[open] .chev{ transform: rotate(90deg); }
 /* Toggle */
 .toggle{
   display:flex;
-  flex-direction:column;
+  flex-direction:row;
   align-items:center;
-  gap:8px;
+  gap:4px;
   border:1px solid var(--ghost-border);
   padding:10px 7px;
   border-radius:12px;
   background:var(--panel);
 }
 .toggle input{
+  order:1;
   appearance:none;
   writing-mode:vertical-lr;
   width:16px;
-  height:28px;
+  height:20px;
   border-radius:999px;
   background:#94a3b8;
   position:relative;
@@ -270,7 +271,7 @@ details[open] .chev{ transform: rotate(90deg); }
 .toggle input::after{
   content:'';
   position:absolute;
-  top:2px;
+  top:1px;
   left:2px;
   width:12px;
   height:12px;
@@ -279,20 +280,33 @@ details[open] .chev{ transform: rotate(90deg); }
   transition:top .15s;
 }
 
-.toggle input:checked::after{ top:14px; }
+.toggle input:checked::after{ top:7px; }
+
+.toggle svg{
+  width:16px;
+  height:16px;
+  color:var(--muted);
+}
+.toggle .sun{ order:0; }
+.toggle .moon{ order:2; }
+
+.toggle input:not(:checked) ~ .sun,
+.toggle input:checked ~ .moon{ color:var(--fg); }
 
 .toggle.ind-active{
   border-color:var(--btn-accent);
   background:color-mix(in oklab,var(--btn-accent) 10%,var(--panel));
 }
 .toggle.ind-active input:checked{ background:var(--btn-accent); }
-.toggle.ind-active span[data-mode-label]{ color:var(--btn-accent); font-weight:700; }
+.toggle.ind-active input:not(:checked) ~ .sun,
+.toggle.ind-active input:checked ~ .moon{ color:var(--btn-accent); }
 body.device-mode .toggle.ind-active{
   border-color:var(--btn-primary);
   background:color-mix(in oklab,var(--btn-primary) 10%,var(--panel));
 }
 body.device-mode .toggle.ind-active input:checked{ background:var(--btn-primary); }
-body.device-mode .toggle.ind-active span[data-mode-label]{ color:var(--btn-primary); }
+body.device-mode .toggle.ind-active input:not(:checked) ~ .sun,
+body.device-mode .toggle.ind-active input:checked ~ .moon{ color:var(--btn-primary); }
 
 /* Badge für Geräte-Kontext */
 .ctx-badge{

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -12,7 +12,22 @@
       <h1>Anzeigensteuerung – Admin</h1>
       <label class="toggle" title="Hell/Dunkel">
         <input type="checkbox" id="themeMode">
-        <span id="themeLabel">Dunkel</span>
+        <svg class="sun" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="12" cy="12" r="4" fill="currentColor"/>
+          <g stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="12" y1="2" x2="12" y2="4"/>
+            <line x1="12" y1="20" x2="12" y2="22"/>
+            <line x1="4.93" y1="4.93" x2="6.34" y2="6.34"/>
+            <line x1="17.66" y1="17.66" x2="19.07" y2="19.07"/>
+            <line x1="2" y1="12" x2="4" y2="12"/>
+            <line x1="20" y1="12" x2="22" y2="12"/>
+            <line x1="4.93" y1="19.07" x2="6.34" y2="17.66"/>
+            <line x1="17.66" y1="6.34" x2="19.07" y2="4.93"/>
+          </g>
+        </svg>
+        <svg class="moon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"/>
+        </svg>
       </label>
       <div class="header-actions">
         <!-- Ansicht-Menü -->

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -1028,12 +1028,10 @@ function initBackupButtons(){
 // ============================================================================
 function initThemeToggle(){
   const cb = document.getElementById('themeMode');
-  const label = document.getElementById('themeLabel');
 
   const apply = (mode) => {
     document.body.classList.toggle('theme-light', mode === 'light');
     document.body.classList.toggle('theme-dark',  mode === 'dark');
-    label.textContent = (mode === 'light') ? 'Hell' : 'Dunkel';
     localStorage.setItem('adminTheme', mode);
   };
 


### PR DESCRIPTION
## Summary
- Replace text theme label with sun/moon icons in admin header
- Adjust toggle layout and size to work without text
- Remove obsolete label handling in theme toggle script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a876d5d883209734a3041698539c