### PR TITLE
Keep admin header actions right-aligned

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -111,6 +111,7 @@ header .header-title{
   align-items:center;
   gap:12px;
   flex-wrap:wrap;
+  flex:1;
 }
 
 .header-actions{

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -8,28 +8,28 @@
 </head>
 <body class="theme-light">
   <header>
-    <div class="row header-title">
+    <div class="header-title">
       <h1>Anzeigensteuerung – Admin</h1>
       <label class="toggle" title="Hell/Dunkel">
         <input type="checkbox" id="themeMode">
         <span id="themeLabel">Dunkel</span>
       </label>
-      <div class="header-actions">
-        <!-- Ansicht-Menü -->
-        <button class="btn" id="btnDevices">Geräte</button>
-        <div class="menuwrap" id="viewMenuWrap">
-          <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
-            Ansicht: <span id="viewMenuLabel">Grid</span> ▾
-          </button>
-          <div class="dropdown" id="viewMenu" role="menu" hidden>
-            <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
-            <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
-          </div>
+    </div>
+    <div class="header-actions">
+      <!-- Ansicht-Menü -->
+      <button class="btn" id="btnDevices">Geräte</button>
+      <div class="menuwrap" id="viewMenuWrap">
+        <button class="btn" id="viewMenuBtn" aria-haspopup="menu" aria-expanded="false">
+          Ansicht: <span id="viewMenuLabel">Grid</span> ▾
+        </button>
+        <div class="dropdown" id="viewMenu" role="menu" hidden>
+          <button class="dd-item" role="menuitemradio" data-view="grid" aria-checked="true">▦ Grid</button>
+          <button class="dd-item" role="menuitemradio" data-view="preview" aria-checked="false">▶ Vorschau</button>
         </div>
-        <button class="btn" id="btnHelp">Hilfe</button>
-        <button class="btn" id="btnOpen">Slideshow öffnen</button>
-        <button class="btn primary" id="btnSave">Speichern</button>
       </div>
+      <button class="btn" id="btnHelp">Hilfe</button>
+      <button class="btn" id="btnOpen">Slideshow öffnen</button>
+      <button class="btn primary" id="btnSave">Speichern</button>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Separate header action buttons from the title to prevent wrapping
- Make header title flex-grow and keep actions pushed to the right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a95d826883208f2e782d5220d5d0