### PR TITLE
Improve thumbnail handling

### DIFF
--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -5,7 +5,7 @@ $fallback = '/assets/img/thumb_fallback.svg';
 function fail($msg){
   global $fallback;
   error_log('url_thumb: '.$msg);
-  echo json_encode(['ok'=>false,'thumb'=>$fallback,'error'=>$msg]);
+  echo json_encode(['ok'=>false,'thumb'=>$fallback,'thumbFallback'=>true,'error'=>$msg]);
   exit;
 }
 
@@ -52,11 +52,9 @@ if (preg_match('/<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\
   $imgUrl = $m[1];
 } elseif (preg_match('/<link\s+[^>]*rel=["\'](?:shortcut )?icon["\'][^>]*href=["\']([^"\']+)["\']/i', $html, $m)) {
   $imgUrl = $m[1];
-}
-if (!$imgUrl && !empty($base['host'])) {
+} elseif (!empty($base['host'])) {
   $imgUrl = 'https://'.$base['host'].'/favicon.ico';
-}
-if (!$imgUrl) {
+} else {
   default_thumb('no image found');
 }
 $imgUrl = html_entity_decode($imgUrl, ENT_QUOTES|ENT_HTML5, 'UTF-8');


### PR DESCRIPTION
## Summary
- Verify ffmpeg availability before generating video thumbnails and expose stderr output via `errorDetail`
- Ensure URL thumb endpoint always returns a fallback icon and falls back to site favicon when no metadata is found

## Testing
- `php -l webroot/admin/api/upload.php`
- `php -l webroot/admin/api/url_thumb.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6aa53c9888320afa33e440e03a847