### PR TITLE
Add synced color picker for theme colors

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -493,6 +493,12 @@ body.mode-uniform #ovSec{ display:none !important; }
 .fieldset{ border:1px dashed var(--inbr); border-radius:12px; padding:10px 12px; }
 .fieldset > .legend{ opacity:.85; font-weight:700; margin-bottom:8px; }
 .color-item{ display:flex; align-items:center; gap:8px; }
+.color-item input[type="color"]{
+  width:32px; height:32px;
+  padding:0; border:0; background:none;
+}
+.color-item input[type="color"]::-webkit-color-swatch-wrapper{ padding:0; }
+.color-item input[type="color"]::-webkit-color-swatch{ border:0; border-radius:6px; }
 .swatch{ width:24px; height:24px; border-radius:6px; border:1px solid var(--inbr); }
 
 /* ---------- Footer ---------- */

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -350,6 +350,7 @@ function colorField(key,label,init){
     <div class="color-item">
       <div class="swatch" id="sw_${key}"></div>
       <input class="input" id="cl_${key}" type="text" value="${init}" placeholder="#RRGGBB">
+      <input type="color" id="cp_${key}" value="${init}">
     </div>`;
   return row;
 }
@@ -392,18 +393,31 @@ const host = $('#colorList');
 
   host.appendChild(A); host.appendChild(B); host.appendChild(C);
 
-  // Swatch-Vorschau & Reset
-  $$('#colorList input[type="text"]').forEach(inp=>{
-    const sw=$('#sw_'+inp.id.replace(/^cl_/,''));
-    const setPrev=v=> sw.style.background=v;
-    setPrev(inp.value);
-    inp.addEventListener('input',()=>{ if(/^#([0-9A-Fa-f]{6})$/.test(inp.value)) setPrev(inp.value); });
+  // Swatch-Vorschau & Synchronisation
+  $$('#colorList .color-item').forEach(item=>{
+    const txt = item.querySelector('input[type="text"]');
+    const pick = item.querySelector('input[type="color"]');
+    const sw = item.querySelector('.swatch');
+    const setVal = v=>{
+      const hex = v.startsWith('#') ? v : '#'+v;
+      sw.style.background = hex;
+      pick.value = hex.toLowerCase();
+      txt.value = hex.toUpperCase();
+    };
+    setVal(txt.value);
+    txt.addEventListener('input',()=>{ if(/^#([0-9A-Fa-f]{6})$/.test(txt.value)) setVal(txt.value); });
+    pick.addEventListener('input',()=> setVal(pick.value));
   });
-  $('#resetColors').onclick = ()=>{ 
-    $$('#colorList input[type="text"]').forEach(inp=>{
-      const k=inp.id.replace(/^cl_/,'');
-      inp.value=(DEFAULTS.theme[k]||'#FFFFFF');
-      const sw=$('#sw_'+k); if(sw) sw.style.background=inp.value;
+
+  $('#resetColors').onclick = ()=>{
+    $$('#colorList .color-item').forEach(item=>{
+      const txt = item.querySelector('input[type="text"]');
+      const pick = item.querySelector('input[type="color"]');
+      const k = txt.id.replace(/^cl_/,'');
+      const def = DEFAULTS.theme[k]||'#FFFFFF';
+      txt.value = def;
+      pick.value = def;
+      const sw = item.querySelector('.swatch'); if(sw) sw.style.background=def;
     });
     const bws=document.getElementById('bw_gridTableW');
     if(bws) bws.value = DEFAULTS.theme.gridTableW ?? 2;


### PR DESCRIPTION
## Summary
- add HTML color inputs synced with text fields in color settings and update swatch preview
- style color picker and remove default border

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ae96d7d48320a09fe93e3305ad4c