### PR TITLE
feat: cache display ratio for media slides

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -16,6 +16,7 @@ let previewMode = IS_PREVIEW; // NEU: in Preview sofort aktiv (kein Pairing)
   let idx = 0;
   let slideTimer = 0, transTimer = 0;
   let onResizeCurrent = null;
+  let cachedDisp = null;
 
   const imgCache = new Set();
   function preloadImage(url){
@@ -152,6 +153,7 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
   }
 
   function applyDisplay() {
+    cachedDisp = null;
     const d = settings?.display || {};
     if (typeof d.rightWidthPercent === 'number') document.documentElement.style.setProperty('--rightW', d.rightWidthPercent + '%');
     if (typeof d.cutTopPercent === 'number')     document.documentElement.style.setProperty('--cutTop', d.cutTopPercent + '%');
@@ -166,6 +168,15 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     };
     updateVwScale();
     window.addEventListener('resize', updateVwScale, { passive:true });
+  }
+
+  function getDisplayRatio() {
+    if (cachedDisp !== null) return cachedDisp;
+    const d = settings?.display || {};
+    const baseW = d.baseW || 1920;
+    const baseH = d.baseH || 1080;
+    cachedDisp = baseW / baseH;
+    return cachedDisp;
   }
 
 // ---------- Slide queue ----------
@@ -554,7 +565,8 @@ onResizeCurrent = recalc;
 
 // ---------- Interstitial image slide ----------
 function renderImage(url) {
-  const c = h('div', { class: 'container imgslide fade show' }, [
+  const disp = getDisplayRatio();
+  const c = h('div', { class: 'container imgslide fade show', style: 'aspect-ratio:' + disp }, [
     h('div', { class: 'imgFill', style: 'background-image:url("'+url+'")' })
   ]);
   return c;
@@ -562,6 +574,7 @@ function renderImage(url) {
 
 // ---------- Interstitial video slide ----------
 function renderVideo(src, opts = {}) {
+  const disp = getDisplayRatio();
   const v = document.createElement('video');
   v.preload = 'auto';
   v.autoplay = true;
@@ -591,7 +604,7 @@ function renderVideo(src, opts = {}) {
     v.addEventListener('ended', () => { clearTimeout(slideTimer); done(); }, { once: true });
     v.addEventListener('error', () => { done(); }, { once: true });
   }
-  const c = h('div', { class: 'container videoslide fade show' });
+  const c = h('div', { class: 'container videoslide fade show', style: 'aspect-ratio:' + disp });
   c.appendChild(v);
   return c;
 }


### PR DESCRIPTION
## Summary
- add `getDisplayRatio()` helper that caches base width/height ratio from settings
- use `getDisplayRatio()` in `renderImage` and `renderVideo`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b284498c83208943e13c24b64137