### PR TITLE
Center context badge in header and sanitize device name

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -311,8 +311,11 @@ body.device-mode .toggle.ind-active input:checked ~ .moon{ color:var(--btn-prima
 
 /* Badge für Geräte-Kontext */
 .ctx-badge{
+    position:absolute;
+    left:50%;
+    top:14px;
+    transform:translateX(-50%);
     display:inline-block;
-    margin-left:8px;
     padding:10px 16px;
     border-radius:12px;
     background:var(--btn-accent);

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -34,8 +34,9 @@ if (devicesPinned) document.body?.classList.add('devices-pinned');
 
 // --- Kontext-Badge (Header) im Modul-Scope ---
 function renderContextBadge(){
-  const h1 = document.querySelector('header h1');
-  if (!h1) return;
+  const header = document.querySelector('header');
+  const h1 = header?.querySelector('h1');
+  if (!header || !h1) return;
   let el = document.getElementById('ctxBadge');
   let tip = document.getElementById('ctxBadgeTip');
   if (!currentDeviceCtx){
@@ -47,10 +48,15 @@ function renderContextBadge(){
     el = document.createElement('span'); el.id='ctxBadge';
     el.className='ctx-badge';
     el.title = 'Klick ×, um zur globalen Ansicht zurückzukehren';
-    h1.after(el);
+    header.appendChild(el);
   }
-  el.innerHTML = `Kontext: ${currentDeviceName || currentDeviceCtx} <button id="ctxReset" title="Zurück zu Global">×</button>`;
-  el.querySelector('#ctxReset').onclick = ()=> exitDeviceContext();
+  el.textContent = `Kontext: ${currentDeviceName || currentDeviceCtx} `;
+  const resetBtn = document.createElement('button');
+  resetBtn.id = 'ctxReset';
+  resetBtn.title = 'Zurück zu Global';
+  resetBtn.textContent = '×';
+  resetBtn.onclick = () => exitDeviceContext();
+  el.appendChild(resetBtn);
   if (!tip){
     tip = document.createElement('small');
     tip.id = 'ctxBadgeTip';


### PR DESCRIPTION
## Summary
- Position device-context badge at header center and keep theme toggle next to title
- Render device name with `textContent` and attach reset button via `appendChild` to avoid XSS
- Add absolute positioning rules for `.ctx-badge`

## Testing
- `node --check webroot/admin/js/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b7c286ec8320b61bfcd96b5a2ff9