### PR TITLE
Optimize image preloading

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -87,8 +87,7 @@ async function loadDeviceResolved(id){
   schedule = j.schedule;
   settings = j.settings;
   applyTheme(); applyDisplay(); maybeApplyPreset();
-  await preloadRightImages();
-  await preloadSlideImages();
+  await Promise.all([preloadRightImages(), preloadSlideImages()]);
   await buildQueue();
 }
 
@@ -104,8 +103,7 @@ async function loadDeviceResolved(id){
     applyTheme();
     applyDisplay();
     maybeApplyPreset();
-    await preloadRightImages();
-    await preloadSlideImages();
+    await Promise.all([preloadRightImages(), preloadSlideImages()]);
     await buildQueue();
   }
 


### PR DESCRIPTION
## Summary
- Parallelize right and slide image preloading in slideshow loader functions

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c1742d748320a02f3d31d45ec13a