### PR TITLE
Wrap context badge with flex container

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -345,11 +345,16 @@ body.device-mode .toggle.ind-active input:not(:checked) ~ .sun,
 body.device-mode .toggle.ind-active input:checked ~ .moon{ color:var(--btn-primary); }
 
 /* Badge für Geräte-Kontext */
-.ctx-badge{
+.ctx-wrap{
     position:absolute;
     left:50%;
     top:14px;
     transform:translateX(-50%);
+    display:flex;
+    gap:8px;
+    align-items:center;
+}
+.ctx-badge{
     display:inline-block;
     padding:10px 16px;
     border-radius:12px;

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -37,18 +37,24 @@ function renderContextBadge(){
   const header = document.querySelector('header');
   const h1 = header?.querySelector('h1');
   if (!header || !h1) return;
+  let wrap = header.querySelector('.ctx-wrap');
   let el = document.getElementById('ctxBadge');
   let tip = document.getElementById('ctxBadgeTip');
   if (!currentDeviceCtx){
-    if (el) el.remove();
-    if (tip) tip.remove();
+    if (wrap) wrap.remove();
     return;
   }
+  if (!wrap){
+    wrap = document.createElement('div');
+    wrap.className = 'ctx-wrap';
+    header.appendChild(wrap);
+  }
   if (!el){
-    el = document.createElement('span'); el.id='ctxBadge';
-    el.className='ctx-badge';
+    el = document.createElement('span');
+    el.id = 'ctxBadge';
+    el.className = 'ctx-badge';
     el.title = 'Klick ×, um zur globalen Ansicht zurückzukehren';
-    header.appendChild(el);
+    wrap.appendChild(el);
   }
   el.textContent = `Kontext: ${currentDeviceName || currentDeviceCtx} `;
   const resetBtn = document.createElement('button');
@@ -60,7 +66,7 @@ function renderContextBadge(){
   if (!tip){
     tip = document.createElement('small');
     tip.id = 'ctxBadgeTip';
-    el.after(tip);
+    wrap.appendChild(tip);
   }
   tip.textContent = 'Tipp: Klick auf × um zur globalen Ansicht zurückzukehren.';
 }


### PR DESCRIPTION
## Summary
- Wrap context badge and tip in a new `.ctx-wrap` container for unified positioning
- Add flex styling for `.ctx-wrap` and remove absolute positioning from `.ctx-badge`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c5c30bac8320adaf2016f108ba2b