### PR TITLE
Default video slides to cover

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -202,7 +202,11 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     return cachedDisp;
   }
 
-  function chooseFit(mediaW, mediaH) {
+  function chooseFit(mediaW, mediaH, opts = {}) {
+    if (opts.type === 'video') {
+      const d = settings?.display || {};
+      return d.videoFit || 'cover';
+    }
     const disp = getDisplayRatio();
     const ratio = mediaW / mediaH;
     return ratio >= disp ? 'cover' : 'contain';
@@ -626,7 +630,11 @@ function renderVideo(src, opts = {}) {
   const fit = () => {
     const baseW = settings?.display?.baseW || 1920;
     const baseH = settings?.display?.baseH || 1080;
-    v.style.objectFit = chooseFit(v.videoWidth || baseW, v.videoHeight || baseH);
+    v.style.objectFit = chooseFit(
+      v.videoWidth || baseW,
+      v.videoHeight || baseH,
+      { type: 'video' }
+    );
   };
   if (v.readyState >= 1) fit(); else v.addEventListener('loadedmetadata', fit);
   v.src = src;

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -21,7 +21,8 @@
   "display": {
     "rightWidthPercent": 38,
     "cutTopPercent": 28,
-    "cutBottomPercent": 12
+    "cutBottomPercent": 12,
+    "videoFit": "cover"
   },
   "slides": {
     "overviewDurationSec": 10,


### PR DESCRIPTION
## Summary
- Default video slides to `object-fit: cover`
- Allow overriding video fit via `settings.display.videoFit`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c6dc209c8320a71bceb46bf89b07