### PR TITLE
Improve media thumbnail generation and fallback handling

### DIFF
--- a/webroot/admin/api/url_thumb.php
+++ b/webroot/admin/api/url_thumb.php
@@ -2,104 +2,56 @@
 header('Content-Type: application/json; charset=UTF-8');
 $fallback = '/assets/img/thumb_fallback.svg';
 
-function fail($msg){
-  global $fallback;
-  error_log('url_thumb: '.$msg);
-  echo json_encode(['ok'=>false,'thumb'=>$fallback,'thumbFallback'=>true,'error'=>$msg]);
-  exit;
-}
-
-function default_thumb($msg){
-  global $fallback;
-  error_log('url_thumb: '.$msg);
-  echo json_encode(['ok'=>true,'thumb'=>$fallback,'thumbFallback'=>true,'error'=>$msg]);
-  exit;
-}
-
 $raw = file_get_contents('php://input');
 $req = json_decode($raw, true);
 $url = $req['url'] ?? '';
-if (!is_string($url) || !preg_match('#^https?://#i', $url)) {
-  fail('invalid-url');
+$parts = parse_url($url);
+$host = $parts['host'] ?? '';
+if (!$host) {
+  error_log('url_thumb: invalid-url '.$url);
+  echo json_encode(['ok'=>false,'thumb'=>$fallback,'thumbFallback'=>true,'error'=>'invalid-url']);
+  exit;
 }
 
-if (!extension_loaded('curl')) {
-  fail('curl extension not loaded; install php-curl');
-}
-if (!extension_loaded('gd')) {
-  fail('gd extension not loaded; install php-gd');
-}
+$imgUrl = 'https://'.$host.'/favicon.ico';
 
-$ch = curl_init($url);
-curl_setopt_array($ch, [
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_TIMEOUT => 5,
-  CURLOPT_USERAGENT => 'Mozilla/5.0'
-]);
-$html = curl_exec($ch);
-if ($html === false) {
-  $err = curl_error($ch);
+try {
+  if (!function_exists('curl_init')) throw new Exception('curl-missing');
+  $ch = curl_init($imgUrl);
+  curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_FOLLOWLOCATION => true,
+    CURLOPT_TIMEOUT => 5,
+    CURLOPT_USERAGENT => 'Mozilla/5.0'
+  ]);
+  $imgData = curl_exec($ch);
+  if ($imgData === false || curl_getinfo($ch, CURLINFO_HTTP_CODE) >= 400) {
+    $err = curl_error($ch);
+    curl_close($ch);
+    throw new Exception($err ?: 'download-failed');
+  }
   curl_close($ch);
-  default_thumb('html curl error: '.$err);
-}
-$baseUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL) ?: $url;
-curl_close($ch);
-$base = parse_url($baseUrl);
 
-$imgUrl = '';
-if (preg_match('/<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\']/i', $html, $m)) {
-  $imgUrl = $m[1];
-} elseif (preg_match('/<link\s+[^>]*rel=["\'](?:shortcut )?icon["\'][^>]*href=["\']([^"\']+)["\']/i', $html, $m)) {
-  $imgUrl = $m[1];
-} elseif (!empty($base['host'])) {
-  $imgUrl = 'https://'.$base['host'].'/favicon.ico';
-} else {
-  default_thumb('no image found');
-}
-$imgUrl = html_entity_decode($imgUrl, ENT_QUOTES|ENT_HTML5, 'UTF-8');
-if (strpos($imgUrl, '//') === 0) {
-  $imgUrl = $base['scheme'].':'.$imgUrl;
-} elseif (strpos($imgUrl, '/') === 0) {
-  $imgUrl = $base['scheme'].'://'.$base['host'].$imgUrl;
-} elseif (!preg_match('#^https?://#i', $imgUrl)) {
-  $path = isset($base['path']) ? preg_replace('#/[^/]*$#', '/', $base['path']) : '/';
-  $imgUrl = $base['scheme'].'://'.$base['host'].$path.$imgUrl;
-}
+  if (!function_exists('imagecreatefromstring')) throw new Exception('gd-missing');
+  $im = @imagecreatefromstring($imgData);
+  if (!$im) throw new Exception('invalid-image');
 
-$ch = curl_init($imgUrl);
-curl_setopt_array($ch, [
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_FOLLOWLOCATION => true,
-  CURLOPT_TIMEOUT => 5,
-  CURLOPT_USERAGENT => 'Mozilla/5.0'
-]);
-$imgData = curl_exec($ch);
-if ($imgData === false) {
-  $err = curl_error($ch);
-  curl_close($ch);
-  default_thumb('image curl error: '.$err);
-}
-curl_close($ch);
-
-if (!function_exists('imagecreatefromstring')) {
-  fail('gd-missing');
-}
-
-$im = @imagecreatefromstring($imgData);
-if (!$im) {
-  default_thumb('invalid image data');
-}
-$dir = '/var/www/signage/assets/media/img/';
-if (!is_dir($dir)) { @mkdir($dir, 02775, true); @chown($dir,'www-data'); @chgrp($dir,'www-data'); }
-$fname = 'preview_'.bin2hex(random_bytes(5)).'.jpg';
-$full = $dir.$fname;
-if (!imagejpeg($im, $full, 90)) {
+  $dir = '/var/www/signage/assets/media/img/';
+  if (!is_dir($dir)) { @mkdir($dir, 02775, true); @chown($dir,'www-data'); @chgrp($dir,'www-data'); }
+  $fname = 'preview_'.bin2hex(random_bytes(5)).'.jpg';
+  $full = $dir.$fname;
+  if (!imagejpeg($im, $full, 90)) {
+    imagedestroy($im);
+    throw new Exception('save-failed');
+  }
   imagedestroy($im);
-  default_thumb('failed to save image');
+  @chmod($full,0644); @chown($full,'www-data'); @chgrp($full,'www-data');
+  $public = '/assets/media/img/'.$fname;
+  echo json_encode(['ok'=>true,'thumb'=>$public]);
+  exit;
+} catch (Exception $e) {
+  error_log('url_thumb: '.$e->getMessage());
+  echo json_encode(['ok'=>true,'thumb'=>$fallback,'thumbFallback'=>true,'error'=>$e->getMessage()]);
+  exit;
 }
-imagedestroy($im);
-@chmod($full,0644); @chown($full,'www-data'); @chgrp($full,'www-data');
-$public = '/assets/media/img/'.$fname;
 
-echo json_encode(['ok'=>true,'thumb'=>$public]);

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -19,6 +19,7 @@ import { uploadGeneric } from './core/upload.js';
 
 const SLIDESHOW_ORIGIN = window.SLIDESHOW_ORIGIN || location.origin;
 const OFFLINE_AFTER_MIN = 10;
+const THUMB_FALLBACK = '/assets/img/thumb_fallback.svg';
 
 // Lokaler Speicher mit Fallback bei DOMException (z.B. QuotaExceeded)
 const LS_MEM = {};
@@ -354,11 +355,11 @@ function renderHighlightBox(){
   $('#flameImg').value = settings.assets?.flameImage || DEFAULTS.assets.flameImage;
   updateFlamePreview($('#flameImg').value);
 
-  $('#flameFile').onchange = ()=> uploadGeneric($('#flameFile'), (p)=>{
+  $('#flameFile').onchange = ()=> uploadGeneric($('#flameFile'), (p, tp, err, tf)=>{
     settings.assets = settings.assets || {};
     settings.assets.flameImage = p;
     $('#flameImg').value = p;
-    updateFlamePreview(p);
+    updateFlamePreview(tf ? THUMB_FALLBACK : p);
   });
 
   $('#resetFlame').onclick = ()=>{

--- a/webroot/admin/js/core/upload.js
+++ b/webroot/admin/js/core/upload.js
@@ -14,7 +14,7 @@ export function uploadGeneric(fileInput, onDone, thumbInput){
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb, j.error);
+      if (j.ok) onDone(j.path, j.thumb, j.error, j.thumbFallback);
       else alert('Upload-Fehler: '+(j.error||''));
     }catch{
       alert('Upload fehlgeschlagen');
@@ -35,7 +35,7 @@ export function uploadFile(file, onDone){
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb, j.error);
+      if (j.ok) onDone(j.path, j.thumb, j.error, j.thumbFallback);
       else alert('Upload-Fehler: '+(j.error||''));
     }catch{
       alert('Upload fehlgeschlagen');


### PR DESCRIPTION
## Summary
- Centralize video thumbnail creation in `makeVideoThumb` with a single ffmpeg call and structured error reporting.
- Simplify URL thumbnail logic to fetch `https://$host/favicon.ico` and return a fallback icon on failure.
- Show a generic thumbnail icon on `thumbFallback` during uploads and URL imports instead of surfacing errors.

## Testing
- `php -l webroot/admin/api/upload.php`
- `php -l webroot/admin/api/url_thumb.php`
- `node --check webroot/admin/js/app.js`
- `node --check webroot/admin/js/core/upload.js`
- `node --check webroot/admin/js/ui/slides_master.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6cd0444548320a65780fd1e6434cd