### PR TITLE
Reuse pairing codes across tabs and sessions

### DIFF
--- a/webroot/admin/api/devices_begin.php
+++ b/webroot/admin/api/devices_begin.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json; charset=UTF-8');
 require_once __DIR__.'/devices_store.php';
+session_start();
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -16,10 +17,30 @@ if (strtolower($_SERVER['HTTP_X_PAIR_REQUEST'] ?? '') !== '1') {
 $db = devices_load();
 dev_gc($db);
 
+$ip = $_SERVER['REMOTE_ADDR'] ?? '';
+$sess = session_id();
+$now = time();
+
+// Prüfen, ob für diese IP/Session bereits ein offenes Pairing existiert
+foreach (($db['pairings'] ?? []) as $p) {
+  $age = $now - (int)($p['created'] ?? $now);
+  if ($age < 900 && empty($p['deviceId']) &&
+      (($p['ip'] ?? null) === $ip || ($sess && ($p['session'] ?? null) === $sess))) {
+    echo json_encode(['ok'=>true,'code'=>$p['code']]);
+    exit;
+  }
+}
+
 $code = dev_gen_code($db);
 if (!$code) { http_response_code(500); echo json_encode(['ok'=>false,'error'=>'code-gen']); exit; }
 
-$db['pairings'][$code] = ['code'=>$code, 'created'=>time(), 'deviceId'=>null];
+$db['pairings'][$code] = [
+  'code'=>$code,
+  'created'=>$now,
+  'deviceId'=>null,
+  'ip'=>$ip,
+  'session'=>$sess,
+];
 devices_save($db);
 
 echo json_encode(['ok'=>true,'code'=>$code]);

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -709,7 +709,7 @@ async function createDevicesPane(){
         <div id="devPairedList" class="kv"></div>
       </div>
 
-      <small class="mut">Tipp: Rufe auf dem TV die Standard-URL auf – es erscheint ein Pairing-Code.</small>
+      <small class="mut">Tipp: Rufe auf dem TV die Standard-URL auf – es erscheint ein Pairing-Code. Codes werden nach 15 Minuten Inaktivität neu erzeugt.</small>
     </div>`;
 
   host?.insertBefore(card, host.firstChild);

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -946,8 +946,8 @@ function showPairing(){
 
   (async ()=>{
     try {
-      // Bestehenden Code (Session) wiederverwenden – verhindert neuen Code bei Refresh
-      let st = null; try { st = JSON.parse(sessionStorage.getItem('pairState')||'null'); } catch {}
+      // Bestehenden Code (localStorage) wiederverwenden – Tabs teilen den Code
+      let st = null; try { st = JSON.parse(localStorage.getItem('pairState')||'null'); } catch {}
       let code = (st && st.code && (Date.now() - (st.createdAt||0) < 15*60*1000)) ? st.code : null;
 
       if (!code) {
@@ -960,7 +960,7 @@ function showPairing(){
         const j0 = await r.json();
         if (!j0 || !j0.code) throw new Error('begin payload');
         code = j0.code;
-        sessionStorage.setItem('pairState', JSON.stringify({ code, createdAt: Date.now() }));
+        localStorage.setItem('pairState', JSON.stringify({ code, createdAt: Date.now() }));
       }
 
       const el = document.getElementById('code');
@@ -973,7 +973,7 @@ function showPairing(){
           const jj = await rr.json();
           if (jj && jj.paired && jj.deviceId){
             clearInterval(timer);
-            try{ sessionStorage.removeItem('pairState'); }catch{}
+            try{ localStorage.removeItem('pairState'); }catch{}
             ls.set('deviceId', jj.deviceId);
             location.replace('/?device='+encodeURIComponent(jj.deviceId));
           }


### PR DESCRIPTION
## Summary
- persist pairing state in localStorage so multiple tabs reuse the same code
- reuse existing pairing codes on `/pair/begin` when the same client requests again
- note in device overview that pairing codes renew after 15 minutes of inactivity

## Testing
- `node --check webroot/assets/slideshow.js`
- `node --check webroot/admin/js/app.js`
- `php -l webroot/admin/api/devices_begin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6d32efad883209b078fa1ab7eaa74