### PR TITLE
Drop media 'after' selector

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -46,7 +46,7 @@
   /* Slides: Spaltenbreiten (gemeinsam für Header & Zeilen) */
   --col-name:minmax(140px,0.9fr);
   --col-type:8ch;
-  --col-prev:64px; --col-dur:70px; --col-btn:28px; --col-del:28px; --col-vis:22px; --col-after:minmax(150px,1fr);
+  --col-prev:64px; --col-dur:70px; --col-btn:28px; --col-del:28px; --col-vis:22px;
 
   /* Preview-Größe */
   --prev-w:60px; --prev-h:42px;
@@ -463,7 +463,7 @@ table.tbl{ width:100%; border-collapse:separate; border-spacing:0; }
   grid-template-columns: var(--col-name) var(--col-prev) var(--col-dur) var(--col-btn) var(--col-btn) var(--col-del) var(--col-vis);
 }
 .sl-head.sl-images, .mediarow{
-  grid-template-columns: var(--col-name) var(--col-type) var(--col-prev) var(--col-dur) var(--col-btn) var(--col-del) var(--col-after) var(--col-vis);
+  grid-template-columns: var(--col-name) var(--col-type) var(--col-prev) var(--col-dur) var(--col-btn) var(--col-del) var(--col-vis);
 }
 
 /* Uniform-Modus: Dauer-Spalte komplett entfernen (Header + Rows) */
@@ -472,7 +472,7 @@ body.mode-uniform .sl-head.sl-saunas, body.mode-uniform .saunarow{
   grid-template-columns: var(--col-name) var(--col-prev) var(--col-btn) var(--col-btn) var(--col-del) var(--col-vis);
 }
 body.mode-uniform .sl-head.sl-images, body.mode-uniform .mediarow{
-  grid-template-columns: var(--col-name) var(--col-type) var(--col-prev) var(--col-btn) var(--col-del) var(--col-after) var(--col-vis);
+  grid-template-columns: var(--col-name) var(--col-type) var(--col-prev) var(--col-btn) var(--col-del) var(--col-vis);
 }
 body.mode-uniform .intSec{ display:none !important; }
 body.mode-uniform #ovSec{ display:none !important; }
@@ -503,8 +503,6 @@ body.mode-uniform #ovSec{ display:none !important; }
 /* Medien-Slides: Name 30% schmaler */
 .mediarow .input.name{ width:50%; }
 
-/* Medien-Slides: „Nach Slide“-Select 20% schmaler */
-.mediarow .sel-after{ width:70%; justify-self:start; min-width:120px; max-width:100%; }
 
 /* „Kein Aufguss“-Pillen – kleiner, mehr Abstand */
 .pills{ display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -190,7 +190,6 @@
     <span class="col-dur" id="headImgDur">Dauer (s)</span>
     <span class="col-up">Upload</span>
     <span class="col-del">✕</span>
-    <span class="col-after">Nach Slide</span>
     <span class="col-vis">Anzeigen</span>
   </div>
     <div id="interList2"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -13,7 +13,7 @@
 import { $, $$, preloadImg, genId, deepClone } from './core/utils.js';
 import { DEFAULTS } from './core/defaults.js';
 import { initGridUI, renderGrid as renderGridUI } from './ui/grid.js';
-import { initSlidesMasterUI, renderSlidesMaster, getActiveDayKey, validateUniqueAfterRefs } from './ui/slides_master.js';
+import { initSlidesMasterUI, renderSlidesMaster, getActiveDayKey } from './ui/slides_master.js';
 import { initGridDayLoader } from './ui/grid_day_loader.js';
 import { uploadGeneric } from './core/upload.js';
 
@@ -221,9 +221,7 @@ async function loadAll(){
         type: it.type || 'image',
         url: it.url || '',
         thumb: it.thumb || it.url || '',
-        after: it.after || 'overview',
-        dwellSec: Number.isFinite(it.dwellSec) ? it.dwellSec : 6,
-        afterRef: it.afterRef || undefined
+        dwellSec: Number.isFinite(it.dwellSec) ? it.dwellSec : 6
       }))
     : [];
   settings.presets       = settings.presets || {};
@@ -577,7 +575,7 @@ function collectSettings(){
       display:{ ...(settings.display||{}), fit: 'auto', baseW:1920, baseH:1080,
         rightWidthPercent:+($('#rightW').value||38), cutTopPercent:+($('#cutTop').value||28), cutBottomPercent:+($('#cutBottom').value||12) },
       footnotes: settings.footnotes,
-      interstitials: settings.interstitials || [],
+      interstitials: (settings.interstitials || []).map(({after, afterRef, ...rest}) => rest),
       presets: settings.presets || {},
       presetAuto: !!document.getElementById('presetAuto')?.checked
     }
@@ -588,10 +586,6 @@ function collectSettings(){
 $('#btnOpen')?.addEventListener('click', ()=> window.open(SLIDESHOW_ORIGIN + '/', '_blank'));
 
 $('#btnSave')?.addEventListener('click', async ()=>{
-  if (!validateUniqueAfterRefs()){
-    alert('Fehler: Mehrfachzuweisung bei "Nach Slide".');
-    return;
-  }
   const body = collectSettings();
 
   if (!currentDeviceCtx){


### PR DESCRIPTION
## Summary
- remove `Nach Slide` column and all afterRef handling from media list UI
- clean saved interstitial objects of legacy `after`/`afterRef` fields
- simplify slideshow media insertion to always place media after overview

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d581c0a48320b0088ff3a4a62c0c