### PR TITLE
Force cover fit for all slideshow media

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -219,13 +219,7 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
   }
 
   function chooseFit(mediaW, mediaH, opts = {}) {
-    if (opts.type === 'video') {
-      const d = settings?.display || {};
-      return d.videoFit || 'cover';
-    }
-    const disp = getDisplayRatio();
-    const ratio = mediaW / mediaH;
-    return ratio >= disp ? 'cover' : 'contain';
+    return 'cover';
   }
 
 // ---------- Slide queue ----------

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -21,8 +21,7 @@
   "display": {
     "rightWidthPercent": 38,
     "cutTopPercent": 28,
-    "cutBottomPercent": 12,
-    "videoFit": "cover"
+    "cutBottomPercent": 12
   },
   "slides": {
     "overviewDurationSec": 10,


### PR DESCRIPTION
## Summary
- Simplify slideshow `chooseFit` to always use `cover` for images and videos
- Drop `display.videoFit` from default settings

## Testing
- `node - <<'NODE'
const chooseFit = (mediaW, mediaH, opts = {}) => 'cover';
console.log('landscape img:', chooseFit(1920,1080));
console.log('portrait img:', chooseFit(1080,1920));
console.log('landscape video:', chooseFit(1920,1080,{type:'video'}));
console.log('portrait video:', chooseFit(1080,1920,{type:'video'}));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c6d7091f24832080ddec497f99017b