### PR TITLE
Add dependency checks and thumbnail fallbacks

### DIFF
--- a/webroot/admin/api/deps.php
+++ b/webroot/admin/api/deps.php
@@ -1,0 +1,16 @@
+<?php
+header('Content-Type: application/json; charset=UTF-8');
+
+function hasCommand($cmd){
+  if (!function_exists('shell_exec')) return false;
+  $out = @shell_exec('command -v '.escapeshellarg($cmd).' 2>&1');
+  return trim((string)$out) !== '';
+}
+
+$resp = [
+  'ffmpeg' => ['cli' => hasCommand('ffmpeg')],
+  'curl'   => ['cli' => hasCommand('curl'), 'extension' => extension_loaded('curl')],
+  'gd'     => ['extension' => extension_loaded('gd')]
+];
+
+echo json_encode($resp);


### PR DESCRIPTION
## Summary
- Add `deps.php` endpoint to report availability of ffmpeg, curl, and GD via shell and PHP extensions.
- Improve `upload.php` error reporting and ensure generic icon fallback for missing thumbnails.
- Expand `url_thumb.php` with detailed error logs and fallbacks to reduce network load.

## Testing
- `php -l webroot/admin/api/upload.php`
- `php -l webroot/admin/api/url_thumb.php`
- `php -l webroot/admin/api/deps.php`
- `php webroot/admin/api/deps.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6d7cc66ec83209f2218e20163e81b