### PR TITLE
Fix videoslide container sizing and cover video

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -51,7 +51,12 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 /* interstitial image */
 .container.imgslide{padding:0}
 .container.videoslide,
-.container.urlslide{padding:0}
+.container.urlslide{
+  padding:0;
+  display:block;
+  width:100%;
+  height:100%;
+}
 .imgFill{position:absolute; inset:0; background-size:cover; background-position:center; background-repeat:no-repeat}
 
 .urlFill,
@@ -59,6 +64,7 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
   width:100%;
   height:100%;
   display:block;
+  object-fit:cover;
 }
 
 /* layout */


### PR DESCRIPTION
## Summary
- Override flex layout for video and URL slide containers so they fill the viewport
- Ensure videos use `object-fit: cover` for proper scaling across aspect ratios

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e9b81b448320a23e8ba364eb480d