### PR TITLE
Use devices_load in device status API and adjust admin fetch

### DIFF
--- a/webroot/admin/api/devices_status.php
+++ b/webroot/admin/api/devices_status.php
@@ -1,10 +1,9 @@
 <?php
 // /var/www/signage/admin/api/devices_status.php
+require_once __DIR__ . '/devices_store.php';
 header('Content-Type: application/json; charset=UTF-8');
 
-$fn = __DIR__ . '/../../data/devices.json';
-$state = json_decode(@file_get_contents($fn), true);
-if (!$state) $state = ['version'=>1, 'devices'=>[], 'pairings'=>[]];
+$state = devices_load();
 
 $pairings = array_values($state['pairings'] ?? []);
 // neuestes NICHT beanspruchtes Pairing finden


### PR DESCRIPTION
## Summary
- load device database via devices_store.php in `devices_status.php`
- fetch device status through `/admin/api/devices_status.php` with fallback to `devices.json`
- warn in console if neither API nor fallback is reachable

## Testing
- `php -l webroot/admin/api/devices_status.php`
- `node --check webroot/admin/js/app.js && echo "Node check passed" || echo "Node check failed"`

------
https://chatgpt.com/codex/tasks/task_e_68c6edfaddac8320a7678244d174c438