### PR TITLE
Handle thumbnail cache-busting failures

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -659,19 +659,15 @@ function interRow(i){
   }
 
   const FALLBACK_THUMB = '/assets/img/thumb_fallback.svg';
-  const stripCache = (u = '') => {
-    const [base, q] = u.split('?', 2);
-    if (!q) return u;
-    const params = q.split('&').filter(p => !p.startsWith('v='));
-    return params.length ? base + '?' + params.join('&') : base;
-  };
+  const stripCache = (u = '') => u.split('?')[0];
   const updatePrev = (src) => {
     if (!src){ $prev.src = FALLBACK_THUMB; $prev.title = ''; return; }
     src = stripCache(src);
-    const url = src + (src.includes('?') ? '&' : '?') + 'v=' + Date.now();
+    if (src === FALLBACK_THUMB){ $prev.src = FALLBACK_THUMB; $prev.title=''; return; }
+    const url = src + '?v=' + Date.now();
     preloadImg(url).then(r => {
       if (r.ok){ $prev.src = url; $prev.title = `${r.w}×${r.h}`; }
-      else { $prev.src = FALLBACK_THUMB; $prev.title = ''; }
+      else { $prev.src = FALLBACK_THUMB; $prev.title = ''; it.thumb = FALLBACK_THUMB; }
     });
   };
   updatePrev(it.thumb);


### PR DESCRIPTION
## Summary
- Strip all query parameters before adding cache-busting for slide thumbnails
- After a missing thumbnail (404) set the entry to a static fallback and stop further cache-busted reloads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f05a03a08320811204c60eaadad3