### PR TITLE
Improve thumbnail generation fallbacks and URL icon retrieval

### DIFF
--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -23,8 +23,10 @@ function makeVideoThumb($src, $fallback){
   $tpi = pathinfo($thumbDest); $tfname = $tpi['filename']; $ti = 0;
   while (file_exists($thumbDest)) { $ti++; $thumbDest = $tpi['dirname'].'/'.$tfname.'_'.$ti.'.jpg'; }
 
-  $ffmpeg = trim(shell_exec('command -v ffmpeg 2>&1'));
-  if (!$ffmpeg){
+  $o = []; $ret = 0;
+  exec('command -v ffmpeg 2>&1', $o, $ret);
+  $ffmpeg = trim($o[0] ?? '');
+  if ($ret !== 0 || !$ffmpeg){
     $detail = 'ffmpeg not installed';
     error_log(json_encode(['event'=>'ffmpeg-thumb-missing','src'=>$src,'ffmpeg'=>$ffmpeg,'detail'=>$detail]));
     return ['path'=>$fallback,'error'=>'ffmpeg not found','fallback'=>true,'detail'=>$detail];

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -360,11 +360,13 @@ function renderHighlightBox(){
 
   // Flammenbild
   $('#flameImg').value = settings.assets?.flameImage || DEFAULTS.assets.flameImage;
-  updateFlamePreview($('#flameImg').value);
+  const flameTf = settings.assets?.flameThumbFallback;
+  updateFlamePreview(flameTf ? THUMB_FALLBACK : $('#flameImg').value);
 
   $('#flameFile').onchange = ()=> uploadGeneric($('#flameFile'), (p, tp, err, tf)=>{
     settings.assets = settings.assets || {};
     settings.assets.flameImage = p;
+    settings.assets.flameThumbFallback = !!tf;
     $('#flameImg').value = p;
     updateFlamePreview(tf ? THUMB_FALLBACK : p);
   });
@@ -373,6 +375,7 @@ function renderHighlightBox(){
     const def = DEFAULTS.assets.flameImage;
     settings.assets = settings.assets || {};
     settings.assets.flameImage = def;
+    settings.assets.flameThumbFallback = false;
     $('#flameImg').value = def;
     updateFlamePreview(def);
   };


### PR DESCRIPTION
## Summary
- Ensure ffmpeg availability before generating video thumbnails and surface errors in responses
- Fetch OpenGraph or icon tags for URL thumbnails with fallback to site favicon
- Preserve thumbnail fallback state in admin UI to avoid repeated preview requests

## Testing
- `php -l webroot/admin/api/upload.php`
- `php -l webroot/admin/api/url_thumb.php`
- `node --check webroot/admin/js/app.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c6f87cac4c83208e7222e05d9c4280