### PR TITLE
feat: allow custom thumbnails for media

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -649,6 +649,25 @@ function interRow(i){
   const $del   = wrap.querySelector('#x_'+id);
   const $en    = wrap.querySelector('#en_'+id);
 
+  if ($prev) $prev.onclick = () => {
+    if ($type?.value !== 'video' && $type?.value !== 'url') return;
+    const fi = document.createElement('input');
+    fi.type = 'file';
+    fi.accept = 'image/*';
+    fi.onchange = () => uploadGeneric(fi, (p) => {
+      if (!p) return;
+      const ts = Date.now();
+      const addV = (u) => {
+        const clean = stripCache(u);
+        return clean + (clean.includes('?') ? '&' : '?') + 'v=' + ts;
+      };
+      it.thumb = addV(p);
+      updatePrev(it.thumb);
+      renderSlidesMaster();
+    });
+    fi.click();
+  };
+
   // Werte
   if ($type) $type.value = it.type || 'image';
   if ($en) $en.checked = !!it.enabled;


### PR DESCRIPTION
## Summary
- enable click on media preview to upload custom thumbnail when type is video or url

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c703984df883208120686399966448