### PR TITLE
Remove ffmpeg dependency check from admin deps API

### DIFF
--- a/webroot/admin/api/deps.php
+++ b/webroot/admin/api/deps.php
@@ -8,7 +8,6 @@ function hasCommand($cmd){
 }
 
 $resp = [
-  'ffmpeg' => ['cli' => hasCommand('ffmpeg')],
   'curl'   => ['cli' => hasCommand('curl'), 'extension' => extension_loaded('curl')],
   'gd'     => ['extension' => extension_loaded('gd')]
 ];


### PR DESCRIPTION
## Summary
- simplify dependency API by dropping ffmpeg check

## Testing
- `php -l webroot/admin/api/deps.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7070798b4832087de194ef71e661b