### PR TITLE
Simplify upload callback interface

### DIFF
--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -1,3 +1,4 @@
+
 <?php
 // file: /var/www/signage/admin/api/upload.php
 // Zweck: Sicheren Upload von Medien nach /assets/media/ (Bilder, Videos)
@@ -65,7 +66,6 @@ if (!@move_uploaded_file($u['tmp_name'], $dest)) fail('move-failed', 500);
 $publicPath = '/assets/media/'.$subDir.'/' . basename($dest);
 // optional preview image (thumb)
 $thumbPath = null;
-$thumbFallback = false;
 if ($subDir === 'img'){
   $thumbPath = $publicPath;
 } elseif (isset($_FILES['thumb']) && is_uploaded_file($_FILES['thumb']['tmp_name'])) {
@@ -97,9 +97,6 @@ if ($subDir === 'img'){
 // final fallback to generic icon
 if (!$thumbPath){
   $thumbPath = $fallbackThumb;
-  $thumbFallback = true;
 }
 
-$resp = ['ok'=>true,'path'=>$publicPath,'thumb'=>$thumbPath];
-if ($thumbFallback) $resp['thumbFallback'] = true;
-echo json_encode($resp);
+echo json_encode(['ok'=>true,'path'=>$publicPath,'thumb'=>$thumbPath]);

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -363,12 +363,12 @@ function renderHighlightBox(){
   const flameTf = settings.assets?.flameThumbFallback;
   updateFlamePreview(flameTf ? THUMB_FALLBACK : $('#flameImg').value);
 
-  $('#flameFile').onchange = ()=> uploadGeneric($('#flameFile'), (p, tp, err, tf)=>{
+  $('#flameFile').onchange = ()=> uploadGeneric($('#flameFile'), (p, tp)=>{
     settings.assets = settings.assets || {};
     settings.assets.flameImage = p;
-    settings.assets.flameThumbFallback = !!tf;
+    settings.assets.flameThumbFallback = (tp === THUMB_FALLBACK);
     $('#flameImg').value = p;
-    updateFlamePreview(tf ? THUMB_FALLBACK : p);
+    updateFlamePreview(tp);
   });
 
   $('#resetFlame').onclick = ()=>{

--- a/webroot/admin/js/core/upload.js
+++ b/webroot/admin/js/core/upload.js
@@ -14,8 +14,8 @@ export function uploadGeneric(fileInput, onDone, thumbInput){
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb, j.error, j.thumbFallback);
-      else alert('Upload-Fehler: '+(j.error||''));
+      if (j.ok) onDone(j.path, j.thumb);
+      else alert('Upload-Fehler');
     }catch{
       alert('Upload fehlgeschlagen');
     }
@@ -35,8 +35,8 @@ export function uploadFile(file, onDone){
   xhr.onload = () => {
     try{
       const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb, j.error, j.thumbFallback);
-      else alert('Upload-Fehler: '+(j.error||''));
+      if (j.ok) onDone(j.path, j.thumb);
+      else alert('Upload-Fehler');
     }catch{
       alert('Upload fehlgeschlagen');
     }


### PR DESCRIPTION
## Summary
- remove thumbFallback flag and simplify upload API response
- update upload helpers to return only path and thumbnail
- adjust flame image uploader to new callback signature

## Testing
- `php -l webroot/admin/api/upload.php`
- `node --check webroot/admin/js/core/upload.js`
- `node --check webroot/admin/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c708eca81083209eef680aa4711003