### PR TITLE
use fetch for admin uploads

### DIFF
--- a/webroot/admin/js/core/upload.js
+++ b/webroot/admin/js/core/upload.js
@@ -1,7 +1,7 @@
 // /admin/js/core/upload.js
 // Minimaler, wiederverwendbarer Uploader (wie dein bisheriger uploadGeneric)
 
-export function uploadGeneric(fileInput, onDone, thumbInput){
+export async function uploadGeneric(fileInput, onDone, thumbInput){
   if(!fileInput.files || !fileInput.files[0]) return;
   const fd = new FormData();
   fd.append('file', fileInput.files[0]);
@@ -9,38 +9,34 @@ export function uploadGeneric(fileInput, onDone, thumbInput){
     fd.append('thumb', thumbInput.files[0]);
   }
 
-  const xhr = new XMLHttpRequest();
-  xhr.open('POST','/admin/api/upload.php');
-  xhr.onload = () => {
-    try{
-      const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb);
-      else alert('Upload-Fehler');
-    }catch{
-      alert('Upload fehlgeschlagen');
-    }
-  };
-  xhr.onerror = () => alert('Netzwerkfehler beim Upload');
-  xhr.send(fd);
+  try {
+    const r = await fetch('/admin/api/upload.php', {
+      method: 'POST',
+      body: fd
+    });
+    const j = await r.json();
+    if (j.ok) onDone(j.path, j.thumb);
+    else alert('Upload-Fehler');
+  } catch {
+    alert('Upload fehlgeschlagen');
+  }
 }
 
 // Direkter Upload von File-Objekten (z.B. aus WYSIWYG-Editoren)
-export function uploadFile(file, onDone){
+export async function uploadFile(file, onDone){
   if(!file) return;
   const fd = new FormData();
   fd.append('file', file);
 
-  const xhr = new XMLHttpRequest();
-  xhr.open('POST','/admin/api/upload.php');
-  xhr.onload = () => {
-    try{
-      const j = JSON.parse(xhr.responseText||'{}');
-      if (j.ok) onDone(j.path, j.thumb);
-      else alert('Upload-Fehler');
-    }catch{
-      alert('Upload fehlgeschlagen');
-    }
-  };
-  xhr.onerror = () => alert('Netzwerkfehler beim Upload');
-  xhr.send(fd);
+  try {
+    const r = await fetch('/admin/api/upload.php', {
+      method: 'POST',
+      body: fd
+    });
+    const j = await r.json();
+    if (j.ok) onDone(j.path, j.thumb);
+    else alert('Upload-Fehler');
+  } catch {
+    alert('Upload fehlgeschlagen');
+  }
 }


### PR DESCRIPTION
## Summary
- refactor uploader to use `fetch` and async/await
- preserve `onDone(path, thumb)` callback API

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c70ad2eca08320be3a9857e5fd509f