### PR TITLE
Compute device offline status on server

### DIFF
--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -9,6 +9,7 @@ header('Cache-Control: no-store');
 
 $db = devices_load();
 $now = time();
+if (!defined('OFFLINE_AFTER_MIN')) define('OFFLINE_AFTER_MIN', 10);
 
 $pairings = [];
 foreach (($db['pairings'] ?? []) as $code => $row) {
@@ -25,10 +26,13 @@ usort($pairings, fn($a,$b)=>($b['createdAt']??0)-($a['createdAt']??0));
 $devices = [];
 foreach (($db['devices'] ?? []) as $id => $d) {
 
+  $lastSeen = (int)($d['lastSeen'] ?? 0);
+  $offline = !$lastSeen || ($now - $lastSeen) > OFFLINE_AFTER_MIN * 60;
   $devices[] = [
     'id' => $id,
     'name' => $d['name'] ?? $id,
-    'lastSeenAt' => (int)($d['lastSeen'] ?? 0) ?: null,
+    'lastSeenAt' => $lastSeen ?: null,
+    'offline' => $offline,
     'useOverrides' => !empty($d['useOverrides']),
     'overrides' => [
       'settings' => $d['overrides']['settings'] ?? (object)[],

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -18,7 +18,6 @@ import { initGridDayLoader } from './ui/grid_day_loader.js';
 import { uploadGeneric } from './core/upload.js';
 
 const SLIDESHOW_ORIGIN = window.SLIDESHOW_ORIGIN || location.origin;
-const OFFLINE_AFTER_MIN = 10;
 const THUMB_FALLBACK = '/assets/img/thumb_fallback.svg';
 
 // Lokaler Speicher mit Fallback bei DOMException (z.B. QuotaExceeded)
@@ -790,7 +789,6 @@ async function createDevicesPane(){
     const L = document.getElementById('devPairedList');
     L.innerHTML = '';
     const paired = (j.devices || []);
-    const now = Date.now() / 1000;
     if (!paired.length) {
       L.innerHTML = '<div class="mut">Noch keine Geräte gekoppelt.</div>';
     } else {
@@ -804,7 +802,7 @@ async function createDevicesPane(){
       };
       paired.forEach(d=>{
         const seen = d.lastSeenAt ? new Date(d.lastSeenAt*1000).toLocaleString('de-DE') : '—';
-        const offline = !d.lastSeenAt || ((now - d.lastSeenAt) / 60) > OFFLINE_AFTER_MIN;
+        const offline = d.offline;
         const useInd = d.useOverrides;
         const modeLbl = useInd ? 'Individuell' : 'Global';
         const tr = document.createElement('tr');

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -999,6 +999,8 @@ function showPairing(){
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ device: jj.deviceId })
+            }).then(r => {
+              if (!r.ok) throw new Error('heartbeat http ' + r.status);
             }).catch(e => console.error('[heartbeat] post-pair failed', e));
             location.replace('/?device=' + encodeURIComponent(jj.deviceId));
           }


### PR DESCRIPTION
## Summary
- Determine device offline state server-side in `devices_list.php` and expose via API
- Admin UI now relies on `d.offline` instead of client-side timestamp comparison
- Improve slideshow heartbeat logging after pairing failures

## Testing
- `php -l webroot/admin/api/devices_list.php`
- `node --check webroot/admin/js/app.js`
- `node --check webroot/assets/slideshow.js`


------
https://chatgpt.com/codex/tasks/task_e_68c70fdcdbec8320b62cc641657460ed