### PR TITLE
Remove pipette color picker

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -402,7 +402,6 @@ function colorField(key,label,init){
       <div class="swatch" id="sw_${key}"></div>
       <input class="input" id="cl_${key}" type="text" value="${valUp}" placeholder="#RRGGBB">
       <input type="color" id="cp_${key}" value="${valLow}">
-      <button class="btn sm pipette" id="ey_${key}" type="button">Pipette</button>
     </div>`;
   return row;
 }
@@ -449,7 +448,6 @@ const host = $('#colorList');
   $$('#colorList .color-item').forEach(item=>{
     const txt = item.querySelector('input[type="text"]');
     const pick = item.querySelector('input[type="color"]');
-    const pip = item.querySelector('.pipette');
     const sw = item.querySelector('.swatch');
     const setVal = v=>{
       const hex = v.startsWith('#') ? v : '#'+v;
@@ -464,18 +462,6 @@ const host = $('#colorList');
       if(/^#([0-9A-F]{6})$/.test(txt.value)) setVal(txt.value);
     });
     pick.addEventListener('input',()=> setVal(pick.value));
-    pip?.addEventListener('click', async ()=>{
-      if(!window.EyeDropper){
-        alert('EyeDropper wird nicht unterstützt.');
-        return;
-      }
-      try{
-        const res = await new EyeDropper().open();
-        if(res?.sRGBHex) setVal(res.sRGBHex);
-      }catch(err){
-        console.warn('EyeDropper abgebrochen', err);
-      }
-    });
   });
 
   $('#resetColors').onclick = ()=>{


### PR DESCRIPTION
## Summary
- remove pipette button from color field markup
- drop EyeDropper pipette logic in color rendering

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c715fbc23883209ab648a1f9081130