### PR TITLE
Use devices_list API with offline fallback computation

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -743,22 +743,16 @@ async function createDevicesPane(){
   // --- API-Adapter: devices_list.php (wenn vorhanden) oder Fallback auf devices.json
   async function fetchDevicesStatus(){
     try {
-      const r = await fetch('/admin/api/devices_status.php', {cache:'no-store'});
+      const r = await fetch('/admin/api/devices_list.php', {cache:'no-store'});
       if (r.ok) {
         const j = await r.json();
-        const pairings = [];
-        if (j.openPairing) {
-          const created = j.openPairing.created ?? j.openPairing.createdAt;
-          pairings.push({
-            code: j.openPairing.code,
-            createdAt: created,
-            expiresAt: created ? created + 900 : null
-          });
-        }
+        const pairings = j.pairings || [];
         const devices = (j.devices || []).map(d => ({
           id: d.id,
           name: d.name || '',
-          lastSeenAt: d.lastSeen || d.lastSeenAt || 0
+          lastSeenAt: d.lastSeenAt || 0,
+          offline: !!d.offline,
+          useOverrides: !!d.useOverrides
         }));
         return { ok:true, pairings, devices };
       }
@@ -770,8 +764,19 @@ async function createDevicesPane(){
         const pairings = Object.values(j2.pairings || {})
           .filter(p => !p.deviceId)
           .map(p => ({ code: p.code, createdAt: p.created }));
-        const devices = Object.values(j2.devices || {})
-          .map(d => ({ id: d.id, name: d.name || '', lastSeenAt: d.lastSeen || 0 }));
+        const now = j2.now || 0;
+        const OFFLINE_AFTER_MIN = 10;
+        const devices = Object.values(j2.devices || {}).map(d => {
+          const lastSeenAt = d.lastSeen || 0;
+          const offline = !lastSeenAt || (now - lastSeenAt) > OFFLINE_AFTER_MIN * 60;
+          return {
+            id: d.id,
+            name: d.name || '',
+            lastSeenAt,
+            offline,
+            useOverrides: !!d.useOverrides
+          };
+        });
         return { ok:true, pairings, devices };
       }
     } catch(e){}


### PR DESCRIPTION
## Summary
- Query `/admin/api/devices_list.php` for device status and expose `offline` and `useOverrides` flags
- Fallback to `/data/devices.json` only when API fails, deriving offline state from `now`
- Keep heartbeat error logging for debugging of network or auth issues

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c716172ebc8320b47856d55b82aa76