### PR TITLE
feat: allow renaming devices

### DIFF
--- a/webroot/admin/api/devices_rename.php
+++ b/webroot/admin/api/devices_rename.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/devices_store.php';
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store');
+
+$body = json_decode(file_get_contents('php://input'), true) ?: [];
+$devIn = trim((string)($body['device'] ?? ''));
+$name  = trim((string)($body['name'] ?? ''));
+
+if ($devIn === '') {
+  echo json_encode(['ok'=>false, 'error'=>'missing-device']);
+  exit;
+}
+
+$db = devices_load();
+if (!$db) {
+  echo json_encode(['ok'=>false, 'error'=>'load-failed']);
+  exit;
+}
+
+// exakte Übereinstimmung (neues Format) …
+$foundKey = isset($db['devices'][$devIn]) ? $devIn : null;
+// … oder Legacy: numerische Schlüssel als String ("0","1",…)
+if ($foundKey === null) {
+  $legacyKey = (string)intval($devIn);
+  if (isset($db['devices'][$legacyKey])) {
+    $foundKey = $legacyKey;
+  }
+}
+
+if ($foundKey === null) {
+  echo json_encode(['ok'=>false, 'error'=>'unknown-device']);
+  exit;
+}
+
+$db['devices'][$foundKey]['name'] = $name;
+
+try {
+  devices_save($db);
+} catch (Exception $e) {
+  echo json_encode(['ok'=>false, 'error'=>'save-failed']);
+  exit;
+}
+
+echo json_encode(['ok'=>true, 'device'=>$foundKey, 'name'=>$name]);

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -838,6 +838,7 @@ async function createDevicesPane(){
             <span data-mode-label>${modeLbl}</span>
           </label></td>
           <td><button class="btn sm" data-edit>Im Editor bearbeiten</button></td>
+          <td><button class="btn sm" data-rename>Umbenennen</button></td>
           <td><button class="btn sm ghost" data-url>URL kopieren</button></td>
           <td><button class="btn sm danger" data-unpair>Trennen…</button></td>
           ${statusCell}
@@ -891,6 +892,19 @@ async function createDevicesPane(){
         tr.querySelector('[data-edit]').onclick = ()=>{
           selectRow(tr);
           enterDeviceContext(d.id, d.name || d.id);
+        };
+        tr.querySelector('[data-rename]').onclick = async ()=>{
+          const newName = prompt('Neuer Gerätename:', d.name || '');
+          if (newName === null) return;
+          const r = await fetch('/admin/api/devices_rename.php', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({ device: d.id, name: newName })
+          });
+          const jj = await r.json().catch(()=>({ok:false}));
+          if (!jj.ok) { alert('Fehler: '+(jj.error||'unbekannt')); return; }
+          alert('Name gespeichert.');
+          render();
         };
         tbody.appendChild(tr);
       });


### PR DESCRIPTION
## Summary
- add devices_rename.php API to update device names in devices.json
- add "Umbenennen" button and handler in devices pane

## Testing
- `php -l webroot/admin/api/devices_rename.php`
- `node --check webroot/admin/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68c716335e60832095bafc77a391e412