### PR TITLE
Improve visual feedback for slide order drag and drop

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -268,6 +268,51 @@ details[open] .chev{ transform: rotate(90deg); }
   cursor:grab;
 }
 
+.slide-order-tile.dragging{
+  opacity:0.6;
+  cursor:grabbing;
+  box-shadow:0 12px 24px rgba(15, 23, 42, 0.25);
+}
+
+.slide-order-tile.drop-before,
+.slide-order-tile.drop-after{
+  position:relative;
+  box-shadow:0 0 0 2px rgba(124, 58, 237, 0.25);
+}
+
+.slide-order-tile.drop-before::after,
+.slide-order-tile.drop-after::after{
+  content:'';
+  position:absolute;
+  left:12px;
+  right:12px;
+  height:4px;
+  border-radius:999px;
+  background:var(--btn-accent);
+}
+
+.slide-order-tile.drop-before::after{ top:-6px; }
+.slide-order-tile.drop-after::after{ bottom:-6px; }
+
+.slide-order-tile.drop-before::before,
+.slide-order-tile.drop-after::before{
+  content:'';
+  position:absolute;
+  left:50%;
+  transform:translateX(-50%);
+  border:6px solid transparent;
+}
+
+.slide-order-tile.drop-before::before{
+  top:-13px;
+  border-bottom-color:var(--btn-accent);
+}
+
+.slide-order-tile.drop-after::before{
+  bottom:-13px;
+  border-top-color:var(--btn-accent);
+}
+
 .slide-order-tile img{
   width:100%;
   height:80px;


### PR DESCRIPTION
## Summary
- enhance slide order drag and drop logic to track before/after positions and clean up helper classes
- clear visual indicators on drop and finalize the new order when dragging stops
- style slide tiles during drag operations and highlight drop targets for better feedback

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd7bb2eb5083208ad167b7d142d171