### PR TITLE
Add touch-friendly slide order controls

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -325,6 +325,42 @@ details[open] .chev{ transform: rotate(90deg); }
   margin-bottom:4px;
 }
 
+.slide-order-tile .reorder-controls{
+  display:flex;
+  gap:8px;
+  margin-top:8px;
+  width:100%;
+}
+
+.slide-order-tile .reorder-btn{
+  flex:1 1 0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:4px;
+  padding:6px;
+  border-radius:8px;
+  border:1px solid var(--ghost-border);
+  background:var(--ghost-bg);
+  color:var(--fg);
+  font-size:18px;
+  line-height:1;
+  cursor:pointer;
+  min-height:34px;
+}
+
+.slide-order-tile .reorder-btn span{ pointer-events:none; }
+
+.slide-order-tile .reorder-btn:focus-visible{
+  outline:0;
+  box-shadow:0 0 0 3px color-mix(in oklab, var(--input-focus) 30%, transparent);
+  border-color:var(--input-focus);
+}
+
+.slide-order-tile .reorder-btn:active{
+  background: color-mix(in oklab, var(--ghost-fg, var(--fg)) 6%, transparent);
+}
+
 /* Toggle */
 .toggle{
   display:flex;

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -867,6 +867,55 @@ export function renderSlideOrderView(){
       tile.appendChild(img);
     }
 
+    const controls = document.createElement('div');
+    controls.className = 'reorder-controls';
+
+    const stopDragPropagation = ev => {
+      ev.stopPropagation();
+    };
+
+    const preventDragStart = ev => {
+      ev.preventDefault();
+    };
+
+    const makeCtrlButton = (dir, label, iconText) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = `reorder-btn ${dir > 0 ? 'reorder-down' : 'reorder-up'}`;
+      btn.setAttribute('aria-label', label);
+      btn.innerHTML = `<span aria-hidden="true">${iconText}</span>`;
+      btn.draggable = false;
+      btn.addEventListener('pointerdown', stopDragPropagation);
+      btn.addEventListener('mousedown', stopDragPropagation);
+      btn.addEventListener('touchstart', stopDragPropagation);
+      btn.addEventListener('click', ev => {
+        ev.stopPropagation();
+        let moved = false;
+        if (dir < 0){
+          const prev = tile.previousElementSibling;
+          if (prev){
+            prev.before(tile);
+            moved = true;
+          }
+        } else {
+          const next = tile.nextElementSibling;
+          if (next){
+            next.after(tile);
+            moved = true;
+          }
+        }
+        if (!moved) return;
+        clearDropIndicators();
+        commitReorder();
+      });
+      btn.addEventListener('dragstart', preventDragStart);
+      return btn;
+    };
+
+    controls.appendChild(makeCtrlButton(-1, 'Nach oben verschieben', '↑'));
+    controls.appendChild(makeCtrlButton(1, 'Nach unten verschieben', '↓'));
+    tile.appendChild(controls);
+
     host.appendChild(tile);
   });
 


### PR DESCRIPTION
## Summary
- add dedicated reorder controls to each slide tile so touch users can adjust the order without drag-and-drop
- ensure drag gestures remain unchanged while the buttons trigger the same ordering logic
- style the new control buttons for visibility and comfortable tap targets on small viewports

## Testing
- Manual drag reorder in slide order dialog
- Manual touch-button reorder in slide order dialog


------
https://chatgpt.com/codex/tasks/task_e_68cd7ce9d7388320a18f3273b92229c0