### PR TITLE
Improve visibility of disabled slide tiles in admin overlay

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -266,6 +266,22 @@ details[open] .chev{ transform: rotate(90deg); }
   padding:8px;
   background:var(--panel);
   cursor:grab;
+  gap:6px;
+}
+
+.slide-order-tile.is-disabled{
+  background:color-mix(in oklab, var(--panel) 70%, transparent);
+  border-color:color-mix(in oklab, var(--border) 55%, transparent);
+  box-shadow:inset 0 0 0 1px color-mix(in oklab, var(--border) 35%, transparent);
+}
+
+.slide-order-tile.is-disabled img{
+  filter:saturate(0) brightness(0.82);
+  opacity:0.55;
+}
+
+.slide-order-tile.is-disabled .title{
+  color:color-mix(in oklab, var(--muted) 82%, var(--fg));
 }
 
 .slide-order-tile.dragging{
@@ -322,7 +338,33 @@ details[open] .chev{ transform: rotate(90deg); }
 
 .slide-order-tile .title{
   font-weight:600;
-  margin-bottom:4px;
+  margin-bottom:2px;
+  text-align:center;
+}
+
+.slide-order-tile .slide-status{
+  font-size:12px;
+  font-weight:600;
+  line-height:1.3;
+  padding:4px 8px;
+  border-radius:999px;
+  text-align:center;
+  width:100%;
+  border:1px solid color-mix(in oklab, var(--border) 55%, transparent);
+  color:color-mix(in oklab, var(--fg) 75%, var(--muted));
+  background:color-mix(in oklab, var(--muted) 18%, transparent);
+}
+
+.slide-order-tile .slide-status[data-state="hidden"]{
+  border-color:color-mix(in oklab, var(--btn-accent) 45%, var(--border));
+  color:color-mix(in oklab, var(--btn-accent) 70%, var(--fg));
+  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
+}
+
+.slide-order-tile .slide-status[data-state="disabled"]{
+  border-color:color-mix(in oklab, #EF4444 45%, var(--border));
+  color:color-mix(in oklab, #B91C1C 72%, var(--fg));
+  background:color-mix(in oklab, #EF4444 16%, var(--panel));
 }
 
 .slide-order-tile .reorder-controls{


### PR DESCRIPTION
## Summary
- dim slide order tiles flagged as hidden or disabled and mute their preview imagery
- add pill-style status label with dedicated colors for hidden saunas versus disabled media entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd81b25ad88320bd877b19ae94e298