### PR TITLE
Make slide reorder buttons compact icons

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -369,26 +369,34 @@ details[open] .chev{ transform: rotate(90deg); }
 
 .slide-order-tile .reorder-controls{
   display:flex;
+  justify-content:center;
   gap:8px;
   margin-top:8px;
   width:100%;
 }
 
 .slide-order-tile .reorder-btn{
-  flex:1 1 0;
-  display:flex;
+  --btn-size:28px;
+  flex:0 0 auto;
+  inline-size:var(--btn-size);
+  block-size:var(--btn-size);
+  display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:4px;
-  padding:6px;
-  border-radius:8px;
+  border-radius:999px;
   border:1px solid var(--ghost-border);
   background:var(--ghost-bg);
   color:var(--fg);
-  font-size:18px;
-  line-height:1;
   cursor:pointer;
-  min-height:34px;
+  padding:0;
+  transition:background-color .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.slide-order-tile .reorder-btn svg{
+  width:16px;
+  height:16px;
+  fill:currentColor;
+  pointer-events:none;
 }
 
 .slide-order-tile .reorder-btn span{ pointer-events:none; }

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -895,12 +895,16 @@ export function renderSlideOrderView(){
       ev.preventDefault();
     };
 
-    const makeCtrlButton = (dir, label, iconText) => {
+    const makeCtrlButton = (dir, label) => {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = `reorder-btn ${dir > 0 ? 'reorder-down' : 'reorder-up'}`;
       btn.setAttribute('aria-label', label);
-      btn.innerHTML = `<span aria-hidden="true">${iconText}</span>`;
+      btn.title = label;
+      const iconMarkup = dir < 0
+        ? '<svg aria-hidden="true" viewBox="0 0 16 16" focusable="false"><path d="M8 3.5 12.5 8l-.7.7L8 4.9 4.2 8.7l-.7-.7Z"/></svg>'
+        : '<svg aria-hidden="true" viewBox="0 0 16 16" focusable="false"><path d="m8 12.5-4.5-4.5.7-.7L8 11.1l3.8-3.8.7.7Z"/></svg>';
+      btn.innerHTML = iconMarkup;
       btn.draggable = false;
       btn.addEventListener('pointerdown', stopDragPropagation);
       btn.addEventListener('mousedown', stopDragPropagation);
@@ -929,8 +933,8 @@ export function renderSlideOrderView(){
       return btn;
     };
 
-    controls.appendChild(makeCtrlButton(-1, 'Nach oben verschieben', '↑'));
-    controls.appendChild(makeCtrlButton(1, 'Nach unten verschieben', '↓'));
+    controls.appendChild(makeCtrlButton(-1, 'Nach oben verschieben'));
+    controls.appendChild(makeCtrlButton(1, 'Nach unten verschieben'));
     tile.appendChild(controls);
 
     host.appendChild(tile);


### PR DESCRIPTION
## Summary
- shrink the slide reorder controls to round icon-sized buttons that align with the compact tile layout
- add SVG icons, accessible labels and browser tooltips so the reduced controls remain clear to all users

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd82a1ba388320960bccc999804a06