### PR TITLE
Unify slide status indicators

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -350,21 +350,9 @@ details[open] .chev{ transform: rotate(90deg); }
   border-radius:999px;
   text-align:center;
   width:100%;
-  border:1px solid color-mix(in oklab, var(--border) 55%, transparent);
-  color:color-mix(in oklab, var(--fg) 75%, var(--muted));
-  background:color-mix(in oklab, var(--muted) 18%, transparent);
-}
-
-.slide-order-tile .slide-status[data-state="hidden"]{
   border-color:color-mix(in oklab, var(--btn-accent) 45%, var(--border));
   color:color-mix(in oklab, var(--btn-accent) 70%, var(--fg));
   background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
-}
-
-.slide-order-tile .slide-status[data-state="disabled"]{
-  border-color:color-mix(in oklab, #EF4444 45%, var(--border));
-  color:color-mix(in oklab, #B91C1C 72%, var(--fg));
-  background:color-mix(in oklab, #EF4444 16%, var(--panel));
 }
 
 .slide-order-tile .reorder-controls{

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -856,10 +856,8 @@ export function renderSlideOrderView(){
     if (isHiddenSauna || isDisabledMedia){
       statusEl = document.createElement('div');
       statusEl.className = 'slide-status';
-      statusEl.dataset.state = isHiddenSauna ? 'hidden' : 'disabled';
-      statusEl.textContent = isHiddenSauna
-        ? 'Momentan ausgeblendet'
-        : 'Momentan deaktiviert';
+      statusEl.dataset.state = 'hidden';
+      statusEl.textContent = 'Ausgeblendet';
     }
     if (entry.kind === 'sauna'){
       tile.dataset.name = entry.name;


### PR DESCRIPTION
## Summary
- use the same "Ausgeblendet" label and data-state for hidden saunas and disabled media tiles
- collapse slide status styling to a single accent variant for consistent appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd8687b330832098f88ecccc7cefac