### PR TITLE
Use server timestamp for device offline detection

### DIFF
--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -42,4 +42,9 @@ foreach (($db['devices'] ?? []) as $id => $d) {
 
 }
 
-echo json_encode(['ok'=>true, 'pairings'=>$pairings, 'devices'=>$devices], JSON_UNESCAPED_SLASHES);
+echo json_encode([
+  'ok' => true,
+  'now' => $now,
+  'pairings' => $pairings,
+  'devices' => $devices
+], JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
## Summary
- expose the server timestamp in the devices list API response
- base offline calculations in the admin UI on the server-provided time with a Date.now fallback

## Testing
- php -l webroot/admin/api/devices_list.php

------
https://chatgpt.com/codex/tasks/task_e_68cd868cdb7c8320b0728eef33f9fef8