### PR TITLE
Embed devices refresh badge in button

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -209,6 +209,24 @@ details[open] .chev{ transform: rotate(90deg); }
 }
 .btn.sm{ padding:var(--btn-sm-pad); border-radius:10px; }
 .btn.icon{ width:28px; height:28px; padding:0; display:grid; place-items:center; }
+.btn.has-meta{ position:relative; padding-right:38px; }
+.btn.sm.has-meta{ padding-right:34px; }
+.btn.has-meta .meta{
+  position:absolute;
+  top:50%;
+  right:10px;
+  transform:translateY(-50%);
+  font-size:11px;
+  line-height:1;
+  font-weight:600;
+  padding:2px 6px;
+  border-radius:999px;
+  background:rgba(0,0,0,.25);
+  color:inherit;
+  opacity:.85;
+  pointer-events:none;
+  white-space:nowrap;
+}
 
 /* Default (flieder) */
 .btn:not(.ghost):not(.primary){ background:var(--btn-accent); color:var(--btn-accent-fg); }

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -726,8 +726,7 @@ async function createDevicesPane(){
         <div class="card-title">Geräte</div>
         <div class="device-toolbar">
           <button class="btn sm icon-label" id="devPairManual"><span class="icon">⌨️</span><span class="label">Code eingeben…</span></button>
-          <button class="btn sm icon-label" id="devRefresh"><span class="icon">⟳</span><span class="label">Aktualisieren</span></button>
-          <span class="mut" id="devLastUpdate"></span>
+          <button class="btn sm icon-label has-meta" id="devRefresh"><span class="icon">⟳</span><span class="label">Aktualisieren</span><span class="meta" id="devLastUpdate" aria-live="polite"></span></button>
           <button class="btn sm danger icon-label" id="devGc"><span class="icon">🧹</span><span class="label">Aufräumen</span></button>
         </div>
       </div>
@@ -948,7 +947,13 @@ async function createDevicesPane(){
       });
     }
     const ts = card.querySelector('#devLastUpdate');
-    if (ts) ts.textContent = 'Stand: ' + new Date().toLocaleString('de-DE');
+    if (ts) {
+      const fallbackNow = normalizeSeconds(Date.now());
+      const tsSeconds = now || fallbackNow;
+      const tsDate = new Date(tsSeconds * 1000);
+      ts.textContent = tsDate.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+      ts.title = 'Stand: ' + tsDate.toLocaleString('de-DE');
+    }
   }
 
   // oben rechts: „Code eingeben…“


### PR DESCRIPTION
## Summary
- embed the last-refresh indicator inside the Geräte refresh button markup
- style buttons with inline metadata badges so the new timestamp fits without stretching the control
- update the render routine to show a short, badge-friendly timestamp and keep the full value as a tooltip

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd8afbe8608320bff58fa782e397c6