### PR TITLE
Adjust color undo button styling

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -405,7 +405,7 @@ function colorField(key,label,init){
       <div class="swatch" id="sw_${key}"></div>
       <input class="input" id="cl_${key}" type="text" value="${valUp}" placeholder="#RRGGBB">
       <input type="color" id="cp_${key}" value="${valLow}">
-      <button class="btn sm undo" type="button">Undo</button>
+      <button class="btn sm ghost icon undo" type="button" title="Letzten Wert zurücksetzen" aria-label="Letzten Wert zurücksetzen">⟳</button>
     </div>`;
   return row;
 }


### PR DESCRIPTION
## Summary
- update the color-field undo button to reuse the ghost icon button styling used in the sauna defaults
- add accessible title and aria-label text so the refresh icon button remains discoverable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd8cfa7908832083843b82db91e7ce