### PR TITLE
Handle lastSeenAt timestamps in devices list

### DIFF
--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -24,14 +24,20 @@ foreach (($db['pairings'] ?? []) as $code => $row) {
 usort($pairings, fn($a,$b)=>($b['createdAt']??0)-($a['createdAt']??0));
 
 $devices = [];
-foreach (($db['devices'] ?? []) as $id => $d) {
+foreach (($db['devices'] ?? []) as $key => $d) {
 
-  $lastSeen = (int)($d['lastSeen'] ?? 0);
-  $offline = !$lastSeen || ($now - $lastSeen) > OFFLINE_AFTER_MIN * 60;
+  $id = $key;
+  if (is_int($key) || (is_string($key) && ctype_digit($key))) {
+    $id = $d['id'] ?? (string)$key;
+  }
+
+  $last = isset($d['lastSeenAt']) ? (int)$d['lastSeenAt'] : (int)($d['lastSeen'] ?? 0);
+  $offline = !$last || ($now - $last) > OFFLINE_AFTER_MIN * 60;
+
   $devices[] = [
     'id' => $id,
     'name' => $d['name'] ?? $id,
-    'lastSeenAt' => $lastSeen ?: null,
+    'lastSeenAt' => $last ?: null,
     'offline' => $offline,
     'useOverrides' => !empty($d['useOverrides']),
     'overrides' => [


### PR DESCRIPTION
## Summary
- ensure numeric-keyed device entries adopt their stored id before returning the list
- unify lastSeenAt/lastSeen handling so offline state and lastSeenAt always derive from the latest timestamp

## Testing
- DEVICES_PATH=/tmp/devices.json php webroot/admin/api/devices_list.php

------
https://chatgpt.com/codex/tasks/task_e_68cdaf418c88832098bdbdcda5f37faf