### PR TITLE
Handle JSON body in devices_touch

### DIFF
--- a/webroot/admin/api/devices_touch.php
+++ b/webroot/admin/api/devices_touch.php
@@ -2,11 +2,34 @@
 header('Content-Type: application/json; charset=UTF-8');
 require_once __DIR__.'/devices_store.php';
 
-$id = isset($_GET['device']) ? $_GET['device'] : '';
-if ($id===''){ echo json_encode(['ok'=>false,'error'=>'no-device']); exit; }
+$raw = file_get_contents('php://input');
+$payload = json_decode($raw, true);
+if (!is_array($payload)) {
+  $payload = [];
+}
+
+$id = $payload['device'] ?? ($_POST['device'] ?? ($_GET['device'] ?? ''));
+$id = is_string($id) ? trim($id) : '';
+
+if ($id === '') {
+  echo json_encode(['ok'=>false,'error'=>'no-device']);
+  exit;
+}
+
+if (!preg_match('/^dev_[a-f0-9]{12}$/i', $id)) {
+  echo json_encode(['ok'=>false,'error'=>'invalid-device']);
+  exit;
+}
 
 $db = devices_load();
-if (!isset($db['devices'][$id])){ echo json_encode(['ok'=>false,'error'=>'unknown-device']); exit; }
-$db['devices'][$id]['lastSeen'] = time();
+if (!isset($db['devices'][$id])){
+  echo json_encode(['ok'=>false,'error'=>'unknown-device']);
+  exit;
+}
+
+$timestamp = time();
+$db['devices'][$id]['lastSeen'] = $timestamp;
+$db['devices'][$id]['lastSeenAt'] = $timestamp;
+
 devices_save($db);
 echo json_encode(['ok'=>true]);


### PR DESCRIPTION
## Summary
- parse the request body of /admin/api/devices_touch.php as JSON before falling back to POST/GET to obtain the device id
- validate the device id format like the heartbeat endpoint and persist both lastSeen and lastSeenAt timestamps when touching a device

## Testing
- curl -s -X POST -H 'Content-Type: application/json' -d '{"device":"dev_123456789abc"}' http://127.0.0.1:8000/pair/touch
- curl -s -X POST -d 'device=dev_123456789abc' http://127.0.0.1:8000/pair/touch

------
https://chatgpt.com/codex/tasks/task_e_68cdaf36ccb88320beb71e28b85e4255