### PR TITLE
Handle list-based device storage in touch endpoint

### DIFF
--- a/webroot/admin/api/devices_touch.php
+++ b/webroot/admin/api/devices_touch.php
@@ -22,14 +22,27 @@ if (!preg_match('/^dev_[a-f0-9]{12}$/i', $id)) {
 }
 
 $db = devices_load();
-if (!isset($db['devices'][$id])){
+$dev = null;
+if (isset($db['devices'][$id])) {
+  $dev =& $db['devices'][$id];
+} elseif (is_array($db['devices'] ?? null)) {
+  foreach ($db['devices'] as &$row) {
+    if (is_array($row) && ($row['id'] ?? null) === $id) {
+      $dev =& $row;
+      break;
+    }
+  }
+  unset($row);
+}
+
+if (!isset($dev)){
   echo json_encode(['ok'=>false,'error'=>'unknown-device']);
   exit;
 }
 
 $timestamp = time();
-$db['devices'][$id]['lastSeen'] = $timestamp;
-$db['devices'][$id]['lastSeenAt'] = $timestamp;
+$dev['lastSeen'] = $timestamp;
+$dev['lastSeenAt'] = $timestamp;
 
 devices_save($db);
 echo json_encode(['ok'=>true]);


### PR DESCRIPTION
## Summary
- support device lookups in devices_touch.php for both associative and list-based storage
- update last seen timestamps via references so list entries persist changes

## Testing
- php -S 0.0.0.0:8000 -t webroot & curl -s -X POST -H 'Content-Type: application/json' -d '{"device":"dev_123456789abc"}' http://127.0.0.1:8000/admin/api/devices_touch.php

------
https://chatgpt.com/codex/tasks/task_e_68cdba4ca5048320a93bf1b7569de58c