### PR TITLE
Handle legacy heartbeat device lookup

### DIFF
--- a/webroot/api/heartbeat.php
+++ b/webroot/api/heartbeat.php
@@ -14,11 +14,28 @@ if (!preg_match('/^dev_[a-f0-9]{12}$/i', $id)) {
 }
 
 $db = devices_load();
-if (!isset($db['devices'][$id])) {
+$dev = null;
+if (isset($db['devices'][$id])) {
+  $dev =& $db['devices'][$id];
+} elseif (is_array($db['devices'] ?? null)) {
+  foreach ($db['devices'] as &$row) {
+    if (is_array($row) && ($row['id'] ?? null) === $id) {
+      $dev =& $row;
+      break;
+    }
+  }
+  unset($row);
+}
+
+if (!isset($dev)) {
   echo json_encode(['ok'=>false, 'error'=>'unknown-device']);
   exit;
 }
-$db['devices'][$id]['lastSeen'] = time();
+
+$timestamp = time();
+$dev['lastSeen'] = $timestamp;
+$dev['lastSeenAt'] = $timestamp;
+
 devices_save($db);
 
 echo json_encode(['ok'=>true]);


### PR DESCRIPTION
## Summary
- resolve heartbeat device lookup using map-first then fallback iteration
- update heartbeat to record lastSeen and lastSeenAt timestamps before saving

## Testing
- php -l webroot/api/heartbeat.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc557ca0c8320adf678817f99f035