### PR TITLE
Add heartbeat PHP location to slideshow nginx config

### DIFF
--- a/config/nginx/signage-slideshow.conf
+++ b/config/nginx/signage-slideshow.conf
@@ -14,6 +14,11 @@ server {
     add_header Cache-Control "no-store, must-revalidate" always;
     try_files $uri =404;
   }
+  location = /api/heartbeat.php {
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME /var/www/signage/api/heartbeat.php;
+    fastcgi_pass unix:__PHP_SOCK__;
+  }
 # Pairing/Device-API – ohne Auth, gleicher Origin (Port 80)
 include /etc/nginx/snippets/signage-pairing.conf;
 }


### PR DESCRIPTION
## Summary
- add a dedicated fastcgi location for /api/heartbeat.php in the slideshow nginx vhost

## Testing
- sudo nginx -t *(fails: nginx not installed in container)*
- sudo systemctl reload nginx *(fails: systemd not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc7085abc8320b2cc7105d993e844