### PR TITLE
Handle storage errors for device heartbeats

### DIFF
--- a/webroot/admin/api/devices_touch.php
+++ b/webroot/admin/api/devices_touch.php
@@ -44,5 +44,12 @@ $timestamp = time();
 $dev['lastSeen'] = $timestamp;
 $dev['lastSeenAt'] = $timestamp;
 
-devices_save($db);
+try {
+  devices_save($db);
+} catch (RuntimeException $e) {
+  http_response_code(500);
+  error_log('Failed to persist device touch: ' . $e->getMessage());
+  echo json_encode(['ok'=>false,'error'=>'storage-failed']);
+  exit;
+}
 echo json_encode(['ok'=>true]);

--- a/webroot/api/heartbeat.php
+++ b/webroot/api/heartbeat.php
@@ -36,6 +36,13 @@ $timestamp = time();
 $dev['lastSeen'] = $timestamp;
 $dev['lastSeenAt'] = $timestamp;
 
-devices_save($db);
+try {
+  devices_save($db);
+} catch (RuntimeException $e) {
+  http_response_code(500);
+  error_log('Failed to persist device heartbeat: ' . $e->getMessage());
+  echo json_encode(['ok'=>false, 'error'=>'storage-failed']);
+  exit;
+}
 
 echo json_encode(['ok'=>true]);


### PR DESCRIPTION
## Summary
- wrap device heartbeat persistence in a RuntimeException handler that returns a JSON error response on failure
- apply the same error handling to the admin device touch endpoint so storage failures return 500

## Testing
- php -l webroot/api/heartbeat.php
- php -l webroot/admin/api/devices_touch.php

------
https://chatgpt.com/codex/tasks/task_e_68cdc9363acc83209a1705b30cb1527f