### PR TITLE
Handle invalid heartbeat payload

### DIFF
--- a/webroot/api/heartbeat.php
+++ b/webroot/api/heartbeat.php
@@ -5,6 +5,9 @@ require_once __DIR__ . '/../admin/api/devices_store.php';
 
 $raw = file_get_contents('php://input');
 $payload = json_decode($raw, true);
+if (!is_array($payload)) {
+  $payload = [];
+}
 $id = $payload['device'] ?? ($_POST['device'] ?? ($_GET['device'] ?? ''));
 $id = is_string($id) ? trim($id) : '';
 


### PR DESCRIPTION
## Summary
- default the heartbeat payload to an empty array when the JSON body is invalid before reading the device id

## Testing
- curl -X POST http://127.0.0.1:8000/api/heartbeat.php

------
https://chatgpt.com/codex/tasks/task_e_68cdcadd1e288320977b4841d9e0675e