### PR TITLE
Adjust admin system section layout

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -211,6 +211,9 @@ details[open] .chev{ transform: rotate(90deg); }
 .btn.icon{ width:28px; height:28px; padding:0; display:grid; place-items:center; }
 .btn.has-meta{ position:relative; padding-right:38px; }
 .btn.sm.has-meta{ padding-right:34px; }
+.btn.icon-label{ gap:8px; }
+.btn.icon-label .icon{ display:inline-flex; align-items:center; justify-content:center; }
+.btn.icon-label .icon svg{ width:16px; height:16px; }
 .btn.has-meta .meta{
   position:absolute;
   top:50%;
@@ -242,6 +245,40 @@ details[open] .chev{ transform: rotate(90deg); }
 /* Ghost (grau) */
 .btn.ghost{
   background:var(--ghost-bg); color:var(--ghost-fg); border:1px solid var(--ghost-border);
+}
+
+/* ---------- System-Section ---------- */
+.sys-grid{
+  display:grid;
+  grid-template-columns:minmax(0, max-content) minmax(0, 1fr);
+  gap:10px 16px;
+  align-items:start;
+}
+.sys-action{ display:flex; align-items:center; justify-content:flex-start; }
+.sys-options{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  align-items:center;
+}
+.sys-toggle{ gap:6px; font-weight:600; }
+.sys-toggle input{
+  flex:0 0 auto;
+  margin:0;
+}
+.sys-file-btn{ position:relative; overflow:hidden; }
+.sys-file-btn input{
+  position:absolute;
+  inset:0;
+  opacity:0;
+  cursor:pointer;
+}
+.sys-cleanup{ margin-top:12px; }
+
+@media (max-width: 520px){
+  .sys-grid{ gap:8px 12px; }
+  .sys-options{ gap:6px; }
+  .btn.icon-label{ gap:6px; }
 }
 
 /* ---------- Hilfe-Overlay & Tooltips ---------- */

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -308,33 +308,60 @@
           <div class="ttl">▶<span class="chev">⮞</span> System</div>
         </summary>
         <div class="content">
-          <div class="row" style="gap:8px;flex-wrap:wrap">
-            <button class="btn" id="btnExport">Export</button>
-
-            <label class="btn sm ghost" style="gap:6px;display:flex;align-items:center">
-              <input type="checkbox" id="expWithSettings" checked>Einstellungen einschließen
-            </label>
-            <label class="btn sm ghost" style="gap:6px;display:flex;align-items:center">
-              <input type="checkbox" id="expWithSchedule" checked>Aufgusszeiten einschließen
-            </label>
-            <label class="btn sm ghost" style="gap:6px;display:flex;align-items:center">
-              <input type="checkbox" id="expWithImg">Bilder einschließen
-            </label>
-
-            <label class="btn" style="position:relative;overflow:hidden">
-              Import<input id="importFile" type="file" accept="application/json" style="position:absolute;inset:0;opacity:0">
-            </label>
-            <label class="btn sm ghost" style="gap:6px;display:flex;align-items:center">
-              <input type="checkbox" id="impWriteSettings" checked>Einstellungen anwenden
-            </label>
-            <label class="btn sm ghost" style="gap:6px;display:flex;align-items:center">
-              <input type="checkbox" id="impWriteSchedule" checked>Aufgusszeiten anwenden
-            </label>
-            <label class="btn sm ghost" style="gap:6px;display:flex;align-items:center">
-              <input type="checkbox" id="impWriteImg" checked>Bilder einspielen
-            </label>
-         <button class="btn sm ghost" id="btnCleanupSys">Assets aufräumen</button>
- </div>
+          <div class="sys-grid">
+            <div class="sys-action">
+              <button class="btn icon-label" id="btnExport">
+                <span class="icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" role="img" focusable="false">
+                    <path d="M12 3a1 1 0 0 1 .82.42l4 5.5A1 1 0 0 1 16 10h-3v6a1 1 0 1 1-2 0v-6H8a1 1 0 0 1-.82-1.58l4-5.5A1 1 0 0 1 12 3zm8 16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2h16z" fill="currentColor"/>
+                  </svg>
+                </span>
+                <span>Export</span>
+              </button>
+            </div>
+            <div class="sys-options">
+              <label class="btn sm ghost sys-toggle">
+                <input type="checkbox" id="expWithSettings" checked>
+                <span>Einst.</span>
+              </label>
+              <label class="btn sm ghost sys-toggle">
+                <input type="checkbox" id="expWithSchedule" checked>
+                <span>Zeiten</span>
+              </label>
+              <label class="btn sm ghost sys-toggle">
+                <input type="checkbox" id="expWithImg">
+                <span>Bilder</span>
+              </label>
+            </div>
+            <div class="sys-action">
+              <label class="btn icon-label sys-file-btn">
+                <span class="icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" role="img" focusable="false">
+                    <path d="M12 21a1 1 0 0 1-.82-.42l-4-5.5A1 1 0 0 1 8 14h3V8a1 1 0 0 1 2 0v6h3a1 1 0 0 1 .82 1.58l-4 5.5A1 1 0 0 1 12 21zM4 5a1 1 0 0 1 0-2h16a1 1 0 0 1 0 2H4z" fill="currentColor"/>
+                  </svg>
+                </span>
+                <span>Import</span>
+                <input id="importFile" type="file" accept="application/json">
+              </label>
+            </div>
+            <div class="sys-options">
+              <label class="btn sm ghost sys-toggle">
+                <input type="checkbox" id="impWriteSettings" checked>
+                <span>Einst.</span>
+              </label>
+              <label class="btn sm ghost sys-toggle">
+                <input type="checkbox" id="impWriteSchedule" checked>
+                <span>Zeiten</span>
+              </label>
+              <label class="btn sm ghost sys-toggle">
+                <input type="checkbox" id="impWriteImg" checked>
+                <span>Bilder</span>
+              </label>
+            </div>
+          </div>
+          <div class="sys-cleanup">
+            <button class="btn sm ghost" id="btnCleanupSys">Assets aufräumen</button>
+          </div>
           <small class="help">Export/Import von Einstellungen & Plan. „Bilder einschließen“ packt Flamme & Saunen-Bilder mit ein.</small>
         </div>
       </details>


### PR DESCRIPTION
## Summary
- restructure the System export/import controls so the buttons stack and the toggles sit inline beside them
- add arrow icons and shorter labels for the export/import controls
- add grid-based styling to stabilise the new layout across desktop and mobile widths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce588ba89c8320a5190a5172b83f26