### PR TITLE
Adjust offline threshold to two minutes

### DIFF
--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -9,7 +9,8 @@ header('Cache-Control: no-store');
 
 $db = devices_load();
 $now = time();
-if (!defined('OFFLINE_AFTER_MIN')) define('OFFLINE_AFTER_MIN', 10);
+// Geräte gelten nach dieser Anzahl von Minuten ohne Heartbeat als offline.
+if (!defined('OFFLINE_AFTER_MIN')) define('OFFLINE_AFTER_MIN', 2);
 
 $pairings = [];
 foreach (($db['pairings'] ?? []) as $code => $row) {

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -761,8 +761,9 @@ async function createDevicesPane(){
     return normalizeSeconds(value);
   };
 
+  const OFFLINE_AFTER_MIN = 2;
+
   async function fetchDevicesStatus(){
-    const OFFLINE_AFTER_MIN = 10;
     try {
       const r = await fetch('/admin/api/devices_list.php', {cache:'no-store'});
       if (r.ok) {
@@ -856,7 +857,7 @@ async function createDevicesPane(){
         const seen = lastSeenAt ? new Date(lastSeenAt*1000).toLocaleString('de-DE') : '—';
         const offline = typeof d.offline === 'boolean'
           ? d.offline
-          : (!lastSeenAt || (now - lastSeenAt) > 10*60);
+          : (!lastSeenAt || (now - lastSeenAt) > OFFLINE_AFTER_MIN * 60);
         const useInd = d.useOverrides;
         const modeLbl = useInd ? 'Individuell' : 'Global';
         const tr = document.createElement('tr');


### PR DESCRIPTION
## Summary
- lower the default offline threshold in the devices list API to two minutes and document it
- reuse the same two-minute constant in the admin UI for API and fallback paths and in the table rendering

## Testing
- php -l webroot/admin/api/devices_list.php

------
https://chatgpt.com/codex/tasks/task_e_68ce5880b2608320b079a19f4c937f65