### PR TITLE
Adjust unsaved changes badge styling

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -134,23 +134,23 @@ header .header-title{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:8px;
-  padding:6px 14px;
+  gap:6px;
+  padding:4px 10px;
   border-radius:999px;
-  font-size:12px;
-  font-weight:700;
-  letter-spacing:0.04em;
-  text-transform:uppercase;
+  font-size:11px;
+  font-weight:600;
+  letter-spacing:0.025em;
+  text-transform:none;
   color:var(--unsaved-fg);
   background:var(--unsaved-bg);
-  box-shadow:0 0 0 0 var(--unsaved-glow);
-  animation:unsavedPulse 2.4s ease-in-out infinite;
+  box-shadow:0 0 0 1px color-mix(in oklab, var(--unsaved-bg) 55%, transparent);
+  line-height:1.1;
   flex-shrink:0;
 }
 #unsavedBadge::before{
   content:'●';
-  font-size:0.7em;
-  filter:drop-shadow(0 0 6px currentColor);
+  font-size:0.65em;
+  filter:drop-shadow(0 0 4px currentColor);
 }
 #unsavedBadge[hidden]{
   display:none;
@@ -815,12 +815,6 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
 /* Falls die Dock-Box mal in einer .row (flex) sitzt: trotzdem volle Zeile belegen */
 .row > .dockWrap{
   flex: 1 1 100%;
-}
-
-@keyframes unsavedPulse{
-  0%{ box-shadow:0 0 0 0 var(--unsaved-glow); transform:translateY(0); }
-  55%{ box-shadow:0 0 0 12px color-mix(in oklab, var(--unsaved-bg) 26%, transparent); transform:translateY(-1px); }
-  100%{ box-shadow:0 0 0 0 transparent; transform:translateY(0); }
 }
 
 @keyframes unsavedBtnGlow{


### PR DESCRIPTION
## Summary
- shrink and soften the unsaved changes badge for a calmer static appearance next to the save button
- remove the unused pulse animation keyframes now that the badge no longer animates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce5fbeb7908320821b0b6eec180ac0