### PR TITLE
Add unsaved badge reset functionality

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -134,8 +134,8 @@ header .header-title{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:6px;
-  padding:4px 10px;
+  gap:8px;
+  padding:4px 12px;
   border-radius:999px;
   font-size:11px;
   font-weight:600;
@@ -151,6 +151,39 @@ header .header-title{
   content:'●';
   font-size:0.65em;
   filter:drop-shadow(0 0 4px currentColor);
+  margin-right:2px;
+}
+#unsavedBadge .unsaved-badge-text{
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+  white-space:nowrap;
+}
+#unsavedBadge .unsaved-badge-btn{
+  appearance:none;
+  border:1px solid color-mix(in oklab, var(--unsaved-bg) 65%, transparent);
+  background:color-mix(in oklab, var(--unsaved-bg) 85%, var(--unsaved-fg) 15%);
+  color:var(--unsaved-fg);
+  border-radius:999px;
+  padding:3px 8px;
+  font-size:13px;
+  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  transition:background-color .18s ease, box-shadow .18s ease, transform .18s ease;
+}
+#unsavedBadge .unsaved-badge-btn:hover,
+#unsavedBadge .unsaved-badge-btn:focus-visible{
+  background:color-mix(in oklab, var(--unsaved-bg) 70%, var(--unsaved-fg) 30%);
+  box-shadow:0 0 0 1px color-mix(in oklab, var(--unsaved-bg) 75%, transparent), 0 0 0 4px color-mix(in oklab, var(--unsaved-glow) 65%, transparent);
+}
+#unsavedBadge .unsaved-badge-btn:focus-visible{
+  outline:none;
+}
+#unsavedBadge .unsaved-badge-btn:active{
+  transform:translateY(1px);
 }
 #unsavedBadge[hidden]{
   display:none;
@@ -857,6 +890,12 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
   #unsavedBadge,
   body.has-unsaved-changes #btnSave{
     animation:none !important;
+  }
+  #unsavedBadge .unsaved-badge-btn{
+    transition:none !important;
+  }
+  #unsavedBadge .unsaved-badge-btn:active{
+    transform:none !important;
   }
 }
 

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -45,7 +45,10 @@
       <button class="btn" id="btnHelp">Hilfe</button>
       <button class="btn" id="btnOpen">Slideshow öffnen</button>
       <button class="btn primary" id="btnSave">Speichern</button>
-      <span id="unsavedBadge" class="unsaved-badge" hidden role="status" aria-live="polite">Änderungen noch nicht gespeichert</span>
+      <span id="unsavedBadge" class="unsaved-badge" hidden role="status" aria-live="polite">
+        <span class="unsaved-badge-text">Änderungen nicht gespeichert</span>
+        <button type="button" class="unsaved-badge-btn" id="unsavedBadgeReset" aria-label="Änderungen verwerfen">⟳</button>
+      </span>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- update the admin header badge to show “Änderungen nicht gespeichert” with a reset button
- restyle the unsaved badge so text and reset icon align neatly with hover and reduced-motion handling
- track baseline schedule/settings for global and device contexts, wiring the reset button to restore, rerender, clear drafts and reset the unsaved state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce67ac2c6483208b25d9106c41e9dc