### PR TITLE
Adjust context badge layout and styling

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -205,22 +205,20 @@ body.device-mode header{
 body.device-mode #ctxBadge{
   background:color-mix(in oklab,var(--btn-primary-fg) 85%,var(--btn-primary));
   color:var(--btn-primary);
-  font-size:20px;
-  padding:14px 22px;
 }
-body.device-mode .ctx-close{
-  border-color:color-mix(in oklab, var(--btn-primary) 70%, transparent);
+body.device-mode .ctx-badge-close{
+  border-color:color-mix(in oklab, var(--btn-primary) 60%, transparent);
   background:color-mix(in oklab, var(--btn-primary-fg) 92%, transparent);
   color:var(--btn-primary);
-  box-shadow:0 8px 20px rgba(0,0,0,.22);
+  box-shadow:0 5px 14px rgba(0,0,0,.2);
 }
-body.device-mode .ctx-close:hover,
-body.device-mode .ctx-close:focus-visible{
+body.device-mode .ctx-badge-close:hover,
+body.device-mode .ctx-badge-close:focus-visible{
   background:var(--btn-primary-fg);
-  border-color:color-mix(in oklab, var(--btn-primary) 85%, transparent);
+  border-color:color-mix(in oklab, var(--btn-primary) 80%, transparent);
 }
-body.device-mode .ctx-close:focus-visible{
-  outline:3px solid color-mix(in oklab, var(--btn-primary) 70%, transparent);
+body.device-mode .ctx-badge-close:focus-visible{
+  outline:2px solid color-mix(in oklab, var(--btn-primary) 70%, transparent);
 }
 
 /* ---------- Layout: Main + Rightbar ---------- */
@@ -610,52 +608,57 @@ body.device-mode .toggle.ind-active input:checked ~ .moon{ color:var(--btn-prima
 
 /* Badge für Geräte-Kontext */
 .ctx-wrap{
-    display:flex;
-    flex-basis:100%;
-    justify-content:center;
-    align-items:center;
-    gap:8px;
-    margin-top:4px;
+  display:flex;
+  flex:1 1 240px;
+  min-width:160px;
+  justify-content:center;
+  align-items:center;
+  gap:8px;
+  margin-top:0;
 }
 .ctx-badge{
-    display:inline-flex;
-    align-items:center;
-    gap:12px;
-    padding:12px 18px;
-    border-radius:14px;
-    background:var(--btn-accent);
-    color:var(--btn-accent-fg);
-    font-size:18px;
-    font-weight:700;
-}
-.ctx-close{
-  margin-left:8px;
-  inline-size:42px;
-  block-size:42px;
   display:inline-flex;
   align-items:center;
-  justify-content:center;
+  gap:10px;
+  padding:6px 12px;
   border-radius:999px;
-  border:2px solid color-mix(in oklab, var(--btn-accent) 70%, transparent);
+  background:var(--btn-accent);
+  color:var(--btn-accent-fg);
+  font-size:13px;
+  font-weight:600;
+  line-height:1.2;
+  white-space:nowrap;
+}
+.ctx-badge-label{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.ctx-badge-close{
+  appearance:none;
+  margin:0;
+  padding:4px 12px;
+  border-radius:999px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 55%, transparent);
   background:color-mix(in oklab, var(--btn-accent-fg) 92%, transparent);
   color:var(--btn-accent);
   cursor:pointer;
-  font-weight:800;
-  font-size:26px;
-  line-height:1;
-  box-shadow:0 8px 18px rgba(0,0,0,.22);
-  transition:transform .18s ease, box-shadow .18s ease, background-color .18s ease, color .18s ease, border-color .18s ease;
+  font-weight:700;
+  font-size:12px;
+  line-height:1.1;
+  box-shadow:0 4px 12px rgba(0,0,0,.18);
+  transition:transform .16s ease, box-shadow .16s ease, background-color .16s ease, color .16s ease, border-color .16s ease;
 }
-.ctx-close:hover,
-.ctx-close:focus-visible{
+.ctx-badge-close:hover,
+.ctx-badge-close:focus-visible{
   transform:translateY(-1px);
   background:var(--btn-accent-fg);
   color:var(--btn-accent);
-  border-color:color-mix(in oklab, var(--btn-accent) 85%, transparent);
-  box-shadow:0 10px 24px rgba(0,0,0,.28);
+  border-color:color-mix(in oklab, var(--btn-accent) 75%, transparent);
+  box-shadow:0 6px 16px rgba(0,0,0,.22);
 }
-.ctx-close:focus-visible{
-  outline:3px solid color-mix(in oklab, var(--btn-accent) 70%, transparent);
+.ctx-badge-close:focus-visible{
+  outline:2px solid color-mix(in oklab, var(--btn-accent) 70%, transparent);
   outline-offset:2px;
 }
 

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -297,9 +297,8 @@ if (document.readyState === 'loading'){
 // --- Kontext-Badge (Header) im Modul-Scope ---
 function renderContextBadge(){
   const header = document.querySelector('header');
-  const h1 = header?.querySelector('h1');
   const actions = header?.querySelector('.header-actions');
-  if (!header || !h1) return;
+  if (!header) return;
   let wrap = header.querySelector('.ctx-wrap');
   let el = document.getElementById('ctxBadge');
   if (!currentDeviceCtx){
@@ -309,29 +308,38 @@ function renderContextBadge(){
   if (!wrap){
     wrap = document.createElement('div');
     wrap.className = 'ctx-wrap';
-    if (actions){
-      header.insertBefore(wrap, actions);
-    } else {
-      header.appendChild(wrap);
-    }
-  } else if (actions && wrap.nextElementSibling !== actions){
+  }
+  if (actions){
     header.insertBefore(wrap, actions);
+  } else if (!wrap.isConnected){
+    header.appendChild(wrap);
   }
   if (!el){
     el = document.createElement('span');
     el.id = 'ctxBadge';
     el.className = 'ctx-badge';
-    el.title = 'Klick ×, um zur globalen Ansicht zurückzukehren';
+    el.title = 'Geräte-Kontext aktiv';
+
+    const label = document.createElement('span');
+    label.className = 'ctx-badge-label';
+    el.appendChild(label);
+
+    const resetBtn = document.createElement('button');
+    resetBtn.type = 'button';
+    resetBtn.id = 'ctxReset';
+    resetBtn.className = 'ctx-badge-close';
+    resetBtn.title = 'Geräte-Kontext verlassen';
+    resetBtn.textContent = 'Kontext schließen';
+    resetBtn.addEventListener('click', () => exitDeviceContext());
+    el.appendChild(resetBtn);
+
     wrap.appendChild(el);
   }
-  el.textContent = `Kontext: ${currentDeviceName || currentDeviceCtx} `;
-  const resetBtn = document.createElement('button');
-  resetBtn.id = 'ctxReset';
-  resetBtn.classList.add('ctx-close');
-  resetBtn.title = 'Zurück zu Global';
-  resetBtn.textContent = '×';
-  resetBtn.onclick = () => exitDeviceContext();
-  el.appendChild(resetBtn);
+
+  const labelEl = el.querySelector('.ctx-badge-label');
+  if (labelEl){
+    labelEl.textContent = `Kontext: ${currentDeviceName || currentDeviceCtx}`;
+  }
 }
 
 // --- e) Kontext-Wechsel-Funktionen (Modul-Scope) ---


### PR DESCRIPTION
## Summary
- ensure the context badge wrapper is inserted immediately before the header actions and expose a labelled close button
- refresh the badge styling to keep it compact within the header while highlighting the close control across themes

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ce6de8b2a48320851977208b1bbe79