### PR TITLE
Ensure system action buttons span full width

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -344,7 +344,16 @@ details[open] .chev{ transform: rotate(90deg); }
   gap:10px 16px;
   align-items:start;
 }
-.sys-action{ display:flex; align-items:center; justify-content:flex-start; }
+.sys-action{
+  display:flex;
+  align-items:stretch;
+  justify-content:flex-start;
+}
+.sys-action .btn.icon-label{
+  flex:1 1 100%;
+  min-width:0;
+  width:100%;
+}
 .sys-options{
   display:flex;
   flex-wrap:wrap;


### PR DESCRIPTION
## Summary
- stretch the system action button container so export/import controls fill the available column width
- give the icon-label buttons a flexible full-width layout to keep sizing consistent for long labels

## Testing
- Manual verification via browser screenshot of the system section

------
https://chatgpt.com/codex/tasks/task_e_68ce6dfe31208320a60ac3cbc967fbc4