### PR TITLE
Add aroma styling toggle and badge customization

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -276,6 +276,20 @@
           <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
           <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
           <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
+          <div class="kv"><label>Aromen im Schrägschnitt</label><input id="aromaItalic" type="checkbox"></div>
+          <div class="kv"><label>Aufguss-Badge</label>
+            <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+              <select id="badgeIcon" class="input">
+                <option value="">Ohne Icon</option>
+                <option value="🌿">🌿 Blatt</option>
+                <option value="💧">💧 Tropfen</option>
+                <option value="🔥">🔥 Flamme</option>
+                <option value="⭐">⭐ Stern</option>
+                <option value="ℹ️">ℹ️ Info</option>
+              </select>
+              <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
+            </div>
+          </div>
 
           <div class="subh">Bildspalte / Schrägschnitt</div>
           <div class="kv"><label>Breite rechts (%)</label><input id="rightW" class="input" type="number" min="0" max="70" value="38"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -533,6 +533,10 @@ function renderSlidesBox(){
   setV('#tilePct',       settings.slides?.tileWidthPercent ?? 45);
   setV('#tileMin',       settings.slides?.tileMinScale ?? 0.25);
   setV('#tileMax',       settings.slides?.tileMaxScale ?? 0.57);
+  setC('#aromaItalic',   !!settings.slides?.aromaItalic);
+  const badgeColor = settings.slides?.infobadgeColor || settings.theme?.accent || DEFAULTS.slides.infobadgeColor;
+  setV('#badgeColor', badgeColor);
+  setV('#badgeIcon', settings.slides?.infobadgeIcon ?? DEFAULTS.slides.infobadgeIcon ?? '');
 
   // Bildspalte / Schrägschnitt
   setV('#rightW',   settings.display?.rightWidthPercent ?? 38);
@@ -565,6 +569,9 @@ function renderSlidesBox(){
     setV('#tilePct',       DEFAULTS.slides.tileWidthPercent);
     setV('#tileMin',       DEFAULTS.slides.tileMinScale);
     setV('#tileMax',       DEFAULTS.slides.tileMaxScale);
+    setC('#aromaItalic',   DEFAULTS.slides.aromaItalic);
+    setV('#badgeIcon',     DEFAULTS.slides.infobadgeIcon);
+    setV('#badgeColor',    DEFAULTS.slides.infobadgeColor);
 
     setV('#rightW',   DEFAULTS.display.rightWidthPercent);
     setV('#cutTop',   DEFAULTS.display.cutTopPercent);
@@ -820,11 +827,20 @@ function collectSettings(){
         tileWidthPercent:+($('#tilePct')?.value || 45),
         tileMinScale:+($('#tileMin')?.value || 0.25),
         tileMaxScale:+($('#tileMax')?.value || 0.57),
+        aromaItalic: !!document.getElementById('aromaItalic')?.checked,
+        infobadgeIcon: document.getElementById('badgeIcon')?.value || '',
+        infobadgeColor:(() => {
+          const el = document.getElementById('badgeColor');
+          const fallback = settings.slides?.infobadgeColor || settings.theme?.accent || DEFAULTS.slides.infobadgeColor || '#5C3101';
+          const current = (typeof fallback === 'string' ? fallback.toUpperCase() : '#5C3101');
+          const raw = el?.value || '';
+          return /^#([0-9A-F]{6})$/i.test(raw) ? raw.toUpperCase() : current;
+        })(),
         showOverview: !!document.getElementById('ovShow')?.checked,
         overviewDurationSec: (() => {
-  	const el = document.getElementById('ovSec') || document.getElementById('ovSecGlobal');
-  	const fallback = settings?.slides?.overviewDurationSec ?? (DEFAULTS?.slides?.overviewDurationSec ?? 10);
-  	const v = el?.value;
+        const el = document.getElementById('ovSec') || document.getElementById('ovSecGlobal');
+        const fallback = settings?.slides?.overviewDurationSec ?? (DEFAULTS?.slides?.overviewDurationSec ?? 10);
+        const v = el?.value;
   	const n = Number(v);
   	return Number.isFinite(n) ? Math.max(1, Math.min(120, n)) : fallback;
 	})(),

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -2,7 +2,17 @@
 // DEFAULTS + Wochentags-Helfer als Single Source of Truth
 
 export const DEFAULTS = {
-  slides:{ overviewDurationSec:10, saunaDurationSec:6, transitionMs:500, tileWidthPercent:45, tileMinScale:0.25, tileMaxScale:0.57 },
+  slides:{
+    overviewDurationSec:10,
+    saunaDurationSec:6,
+    transitionMs:500,
+    tileWidthPercent:45,
+    tileMinScale:0.25,
+    tileMaxScale:0.57,
+    aromaItalic:false,
+    infobadgeColor:'#5C3101',
+    infobadgeIcon:'ℹ️'
+  },
   display:{ fit:'auto', baseW:1920, baseH:1080, rightWidthPercent:38, cutTopPercent:28, cutBottomPercent:12 },
   theme:{
     bg:'#E8DEBD', fg:'#5C3101', accent:'#5C3101',

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -1065,6 +1065,40 @@ export function renderSlidesMaster(){
     waitEl.onchange = () => { (settings.slides ||= {}).waitForVideo = !!waitEl.checked; };
   }
 
+  const aromaItalicEl = $('#aromaItalic');
+  if (aromaItalicEl){
+    aromaItalicEl.checked = !!settings.slides?.aromaItalic;
+    aromaItalicEl.onchange = () => { (settings.slides ||= {}).aromaItalic = !!aromaItalicEl.checked; };
+  }
+
+  const badgeIconEl = $('#badgeIcon');
+  if (badgeIconEl){
+    const iconVal = settings.slides?.infobadgeIcon ?? DEFAULTS.slides.infobadgeIcon ?? '';
+    const options = Array.from(badgeIconEl.options || []);
+    if (iconVal && !options.some(opt => opt.value === iconVal)){
+      const opt = document.createElement('option');
+      opt.value = iconVal;
+      opt.textContent = iconVal;
+      badgeIconEl.appendChild(opt);
+    }
+    badgeIconEl.value = iconVal;
+    badgeIconEl.onchange = () => { (settings.slides ||= {}).infobadgeIcon = badgeIconEl.value; };
+  }
+
+  const badgeColorEl = $('#badgeColor');
+  if (badgeColorEl){
+    const rawInit = settings.slides?.infobadgeColor || settings.theme?.accent || DEFAULTS.slides.infobadgeColor || '#5C3101';
+    const initial = (typeof rawInit === 'string' ? rawInit.toUpperCase() : '#5C3101');
+    badgeColorEl.value = initial;
+    badgeColorEl.onchange = () => {
+      const raw = badgeColorEl.value || '';
+      const prev = settings.slides?.infobadgeColor || initial;
+      const next = /^#([0-9A-F]{6})$/i.test(raw) ? raw.toUpperCase() : prev;
+      (settings.slides ||= {}).infobadgeColor = next;
+      badgeColorEl.value = next;
+    };
+  }
+
 // === Dauer-Modus (Uniform vs. Individuell) ===
 const perMode = (settings.slides?.durationMode === 'per');
 

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -41,6 +41,8 @@
   --tileRadiusPx:calc(22px*var(--vwScale));
   --tileBadgeOffsetPx:calc(12px*var(--vwScale));
   --tileMetaScale:1;
+  --badgeBg:var(--accent);
+  --badgeFg:var(--boxfg);
   --flameSizePxOv:18; /* kleine Flames in Übersicht-Chips */
   --ovTitleScale:1; /* nur H1 der Übersicht */
   --flamesColW: calc(var(--flameSizePx)*1px*var(--scale)*3 + 24px);
@@ -242,11 +244,31 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 .tile .title .label{display:flex;align-items:baseline;gap:.35em;flex-wrap:wrap;min-width:0;}
 .tile .title .label .notewrap{flex:0 0 auto;}
 .tile .aroma{
+  display:block;
   font-size:calc(22px*var(--scale)*var(--tileMetaScale,1));
   font-weight:500;
   letter-spacing:.02em;
-  opacity:.95;
+  opacity:.9;
+  color:rgba(255,255,255,.8);
+  font-style:normal;
 }
+.tile .aroma.is-italic{font-style:italic;}
+.tile .badge{
+  display:inline-flex;
+  align-items:center;
+  gap:.45em;
+  padding:.25em .9em;
+  border-radius:999px;
+  background:var(--badgeBg, var(--accent));
+  color:var(--badgeFg, var(--boxfg));
+  font-size:calc(20px*var(--scale)*var(--tileMetaScale,1));
+  font-weight:600;
+  letter-spacing:.08em;
+  line-height:1.1;
+  box-shadow:0 12px 24px rgba(0,0,0,.28);
+}
+.tile .badge .badge-icon{line-height:1;font-size:1.1em;}
+.tile .badge .badge-label{white-space:nowrap;}
 .facts{
   display:flex;
   flex-wrap:wrap;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -229,7 +229,9 @@ async function loadDeviceResolved(id){
       '--ovCellScale': settings?.fonts?.overviewCellScale || 0.8,
       '--tileTextScale': settings?.fonts?.tileTextScale || 0.8,
       '--tileWeight': settings?.fonts?.tileWeight || 600,
-      '--chipHScale': (settings?.fonts?.chipHeight || 1)
+      '--chipHScale': (settings?.fonts?.chipHeight || 1),
+      '--badgeBg': settings?.slides?.infobadgeColor || t.accent || '#5C3101',
+      '--badgeFg': t.boxFg || '#FFFFFF'
     });
     if (settings?.fonts?.family) document.documentElement.style.setProperty('--font', settings.fonts.family);
 // Chip-Optionen (Übersicht): Größen & Overflow-Modus aus den Settings
@@ -920,6 +922,7 @@ function renderUrl(src) {
           flames: cell.flames || '',
           noteId: cell.noteId,
           aroma: aromaText,
+          type: firstText(cell.type),
           facts: factsList,
           hidden: isHidden,
           icon: cell.icon || null
@@ -952,7 +955,17 @@ function renderUrl(src) {
       titleNode.appendChild(labelNode);
 
       const contentChildren = [titleNode];
-      if (it.aroma) contentChildren.push(h('span', { class: 'aroma' }, it.aroma));
+      if (it.type) {
+        const badgeBits = [];
+        const iconChar = settings?.slides?.infobadgeIcon || '';
+        if (iconChar) badgeBits.push(h('span', { class: 'badge-icon', 'aria-hidden': 'true' }, iconChar));
+        badgeBits.push(h('span', { class: 'badge-label' }, it.type));
+        contentChildren.push(h('span', { class: 'badge' }, badgeBits));
+      }
+      if (it.aroma) {
+        const aromaCls = 'aroma' + (settings?.slides?.aromaItalic ? ' is-italic' : '');
+        contentChildren.push(h('span', { class: aromaCls }, it.aroma));
+      }
       if (it.facts && it.facts.length) {
         const factItems = it.facts.map(fact => h('li', { class: 'card-chip' }, fact));
         contentChildren.push(h('ul', { class: 'facts' }, factItems));

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -30,6 +30,9 @@
     "tileWidthPercent": 45,
     "tileMinScale": 0.25,
     "tileMaxScale": 0.57,
+    "aromaItalic": false,
+    "infobadgeColor": "#5C3101",
+    "infobadgeIcon": "ℹ️",
     "loop": true,
     "waitForVideo": false,
     "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"]


### PR DESCRIPTION
## Summary
- add admin controls to toggle italic aromas and configure a colored badge for sauna slides
- persist new aroma and badge settings and expose defaults for slideshow rendering
- update sauna tile rendering and design styles to show optional aroma text and configurable badges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce78bde9708320ac9053607d6e5331