### PR TITLE
Add story slide support with admin configuration

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -179,7 +179,19 @@
   </div>
 </details>
 
-    <!-- Unterbox 3: Medien-Slides -->
+    <!-- Unterbox 3: Story-Slides -->
+    <details class="ac sub" id="boxStories">
+      <summary>
+        <div class="ttl">▶<span class="chev">⮞</span> Saunen & Aufgüsse erklärt</div>
+        <div class="actions"><button class="btn sm" id="btnStoryAdd">Erklärung hinzufügen</button></div>
+      </summary>
+      <div class="content">
+        <div class="help">Beschreibungen mit Einführung, Ritual, Tipps, FAQ und automatischer „Heute verfügbar“-Liste.</div>
+        <div id="storyList"></div>
+      </div>
+    </details>
+
+    <!-- Unterbox 4: Medien-Slides -->
     <details class="ac sub" id="boxImages">
 <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -348,3 +348,39 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 /* Trenner-Punkt zwischen Items (nur optisch) */
 .footer-note .fnsep{ margin:0 calc(8px*var(--ovAuto)); opacity:.7 }
 .brand{position:absolute;right:20px;bottom:16px;opacity:.6;font-size:14px;color:var(--fg)}
+
+/* story slides */
+.story-slide{padding-right:32px;}
+.story-slide .story-columns{display:flex; gap:clamp(24px, 3vw, 48px); width:100%; flex:1; align-items:stretch; justify-content:stretch;}
+.story-slide .story-hero{flex:0 0 clamp(28%, 34%, 40%); display:flex; align-items:center; justify-content:center; background:rgba(255,255,255,.25); border-radius:28px; overflow:hidden; min-height:320px; box-shadow:inset 0 0 0 1px rgba(0,0,0,.06);}
+.story-slide .story-hero img{width:100%; height:100%; object-fit:cover; display:block;}
+.story-slide .story-hero--placeholder{background:linear-gradient(135deg, rgba(255,255,255,.28), rgba(0,0,0,.08)); color:rgba(0,0,0,.65); font-weight:600; letter-spacing:.03em; text-transform:uppercase;}
+.story-slide .story-hero-placeholder{padding:1.6em; text-align:center; font-size:calc(18px*var(--scale));}
+.story-slide .story-content{flex:1 1 auto; display:flex; flex-direction:column; gap:clamp(14px, 2.6vh, 24px);}
+.story-slide .story-title{font-size:calc(64px*var(--scale)); margin:0; line-height:1.05; font-weight:800; letter-spacing:.01em;}
+.story-slide .story-subtitle{margin:0; opacity:.85; font-size:calc(24px*var(--scale));}
+.story-slide .story-section{display:flex; flex-direction:column; gap:calc(10px*var(--scale));}
+.story-slide .story-section-title{margin:0; font-size:calc(30px*var(--scale)); font-weight:700; letter-spacing:.01em;}
+.story-slide .story-paragraph{margin:0; font-size:calc(22px*var(--scale)); line-height:1.45; opacity:.95;}
+.story-slide .story-tip-list{margin:0; padding-left:1.2em; font-size:calc(22px*var(--scale)); line-height:1.45; display:flex; flex-direction:column; gap:.4em;}
+.story-slide .story-tip-list li{position:relative;}
+.story-slide .story-tip-list li::marker{color:var(--accent); font-weight:700;}
+.story-slide .story-faq-list{margin:0; padding:0; display:grid; gap:8px; font-size:calc(21px*var(--scale));}
+.story-slide .story-faq-list dt{font-weight:700;}
+.story-slide .story-faq-list dd{margin:0; opacity:.9;}
+.story-slide .story-availability{margin-top:auto; padding:clamp(16px, 2vh, 24px); border-radius:22px; background:linear-gradient(135deg, rgba(255,255,255,.88), rgba(255,255,255,.45)); box-shadow:0 18px 40px rgba(0,0,0,.18); border-left:6px solid var(--accent);}
+.story-slide .story-availability-list{margin:0; padding:0; list-style:none; display:grid; gap:8px; font-size:calc(22px*var(--scale));}
+.story-slide .story-availability-item{display:grid; grid-template-columns:minmax(0,8ch) minmax(0,1fr); gap:14px; align-items:baseline; padding:6px 10px; border-radius:14px; background:rgba(0,0,0,.05);}
+.story-slide .story-availability-item.is-upcoming{background:rgba(255,221,102,.28);}
+.story-slide .story-availability-item.is-next{background:rgba(255,221,102,.48); box-shadow:0 0 0 2px rgba(92,49,1,.18);}
+.story-slide .story-availability-time{font-variant-numeric:tabular-nums; font-weight:700;}
+.story-slide .story-availability-sauna{font-weight:600;}
+.story-slide .story-availability-title{opacity:.9;}
+.story-slide .story-availability-empty{margin:0; font-style:italic; opacity:.75; font-size:calc(21px*var(--scale));}
+
+@media (max-width: 1366px), (max-aspect-ratio: 4/3){
+  .story-slide .story-columns{flex-direction:column;}
+  .story-slide{padding-right:24px;}
+  .story-slide .story-hero{width:100%; min-height:260px;}
+  .story-slide .story-title{font-size:calc(54px*var(--scale));}
+}


### PR DESCRIPTION
## Summary
- extend the slideshow queue with a story slide type that renders structured content and shows today's availability
- add an admin form for capturing story slide text, hero image and sauna mapping
- style story slides with responsive columns and highlighted availability section

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce7af9059c83208fdd2e51ec8b14b8