### PR TITLE
Add hero timeline slide variant

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -46,10 +46,31 @@
   --flameSizePxOv:18; /* kleine Flames in Übersicht-Chips */
   --ovTitleScale:1; /* nur H1 der Übersicht */
   --flamesColW: calc(var(--flameSizePx)*1px*var(--scale)*3 + 24px);
+  --tileEnterDuration:600ms;
+  --tileEnterDelay:80ms;
+  --heroTimelineItemMs:500ms;
+  --heroTimelineItemDelay:140ms;
+  --heroTimelineFillMs:8000ms;
+  --heroTimelineDelayMs:400ms;
 }
 *{box-sizing:border-box}
 html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:var(--font)}
 .slideshow{overflow:hidden}
+
+@keyframes tileFadeUp{
+  from{opacity:0;transform:translateY(24px) scale(.96)}
+  to{opacity:1;transform:translateY(0) scale(1)}
+}
+
+@keyframes heroItemFade{
+  from{opacity:0;transform:translateY(18px) scale(.97)}
+  to{opacity:1;transform:translateY(0) scale(1)}
+}
+
+@keyframes heroBarFill{
+  from{transform:scaleX(0)}
+  to{transform:scaleX(1)}
+}
 
 /* Full-viewport – no transform */
 .fitbox{position:fixed; inset:0;}
@@ -93,6 +114,82 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 .overview .h1{line-height:1.1;font-size:calc(56px*var(--scale)*var(--ovTitleScale)*var(--ovAuto))}
 .overview .h2{font-size:calc(36px*var(--scale)*var(--h2Scale)*var(--ovAuto))}
 .caption{opacity:.85;font-size:calc(20px*var(--scale))}
+
+.container.hero{align-items:stretch}
+.hero-headings{width:100%;margin:0 0 calc(18px*var(--vwScale))}
+.hero-body{width:100%;display:flex;flex-direction:column;gap:calc(18px*var(--vwScale))}
+.hero-timeline-list{display:flex;flex-direction:column;gap:calc(16px*var(--vwScale));width:100%}
+.hero-timeline .timeline-item{
+  position:relative;
+  padding:calc(24px*var(--vwScale));
+  border-radius:var(--tileRadiusPx, calc(22px*var(--vwScale)));
+  border:calc(var(--tileBorderW)*var(--vwScale)) solid var(--tileBorder);
+  background:var(--cell);
+  color:var(--boxfg);
+  box-shadow:0 20px 44px rgba(0,0,0,.22);
+  overflow:hidden;
+  isolation:isolate;
+  --hero-index:0;
+  opacity:0;
+  transform:translateY(18px) scale(.97);
+  animation:heroItemFade var(--heroTimelineItemMs,500ms) cubic-bezier(.22,.61,.36,1) forwards;
+  animation-delay:calc(var(--heroTimelineItemDelay,140ms)*var(--hero-index,0));
+}
+.hero-timeline .timeline-item::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(135deg, rgba(255,255,255,.1) 0%, rgba(0,0,0,.38) 100%);
+  opacity:.85;
+  pointer-events:none;
+}
+.hero-timeline .timeline-item>*{position:relative;z-index:1}
+.hero-timeline .timeline-item.is-active{box-shadow:0 26px 60px rgba(0,0,0,.28)}
+.hero-timeline .timeline-time{
+  font-weight:700;
+  font-size:calc(32px*var(--scale));
+  margin:0 0 calc(8px*var(--vwScale));
+}
+.hero-timeline .timeline-details{display:flex;flex-direction:column;gap:calc(8px*var(--vwScale))}
+.hero-timeline .timeline-entry{display:flex;flex-wrap:wrap;gap:calc(8px*var(--vwScale));align-items:baseline;font-size:calc(22px*var(--scale))}
+.hero-timeline .timeline-entry .timeline-sauna{font-weight:700;letter-spacing:.01em}
+.hero-timeline .timeline-entry .timeline-title{font-weight:600}
+.hero-timeline .timeline-entry .timeline-detail{opacity:.82;font-size:calc(18px*var(--scale))}
+.hero-timeline .timeline-entry.highlight{color:var(--hlColor)}
+.hero-timeline .timeline-bar{
+  position:relative;
+  height:6px;
+  margin:calc(14px*var(--vwScale)) 0 0;
+  border-radius:999px;
+  background:rgba(255,255,255,.22);
+  overflow:hidden;
+}
+.hero-timeline .timeline-progress{
+  position:absolute;
+  inset:0;
+  background:var(--hlColor);
+  transform-origin:left;
+  transform:scaleX(0);
+  animation:heroBarFill calc(var(--heroTimelineFillMs,8000ms)*var(--hero-duration-ratio,1)) cubic-bezier(.22,.61,.36,1) forwards;
+  animation-delay:calc(var(--heroTimelineDelayMs,400ms)+var(--heroTimelineItemDelay,140ms)*var(--hero-index,0));
+}
+.hero-timeline .timeline-item.is-active .timeline-progress{background:var(--accent)}
+.hero-timeline .timeline-item.is-active .timeline-entry{color:var(--accent)}
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight{color:var(--hlColor)}
+
+@media (prefers-reduced-motion:reduce){
+  .tile,
+  .hero-timeline .timeline-item{
+    animation-duration:.01ms!important;
+    animation-delay:0ms!important;
+    transform:none!important;
+    opacity:1!important;
+  }
+  .hero-timeline .timeline-progress{
+    animation:none!important;
+    transform:scaleX(1)!important;
+  }
+}
 
 /* content area under headings is vertically centered */
 .body{flex:1; display:flex}
@@ -181,6 +278,11 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
   box-shadow:0 22px 46px rgba(0,0,0,.24);
   overflow:hidden;
   isolation:isolate;
+  --tile-index:0;
+  opacity:0;
+  transform:translateY(24px) scale(.96);
+  animation:tileFadeUp var(--tileEnterDuration,600ms) cubic-bezier(.22,.61,.36,1) forwards;
+  animation-delay:calc(var(--tileEnterDelay,80ms)*var(--tile-index,0));
 }
 .tile::before{
   content:"";

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -57,6 +57,7 @@
   let schedule = null;
   let settings = null;
   let nextQueue = [];
+  let heroTimeline = [];
   let lastKey = null; // verhindert direkte Wiederholung derselben Folie
   let idx = 0;
   let slideTimer = 0, transTimer = 0;
@@ -213,6 +214,10 @@ async function loadDeviceResolved(id){
 
   function applyTheme() {
     const t = settings?.theme || {};
+    const msVar = (value, fallback) => {
+      const num = Number.isFinite(+value) ? Math.max(0, +value) : fallback;
+      return (Number.isFinite(num) ? num : fallback) + 'ms';
+    };
     setVars({
       '--bg': t.bg, '--fg': t.fg, '--accent': t.accent,
       '--grid': t.gridBorder, '--cell': t.cellBg, '--boxfg': t.boxFg,
@@ -238,7 +243,13 @@ async function loadDeviceResolved(id){
       '--tileWeight': settings?.fonts?.tileWeight || 600,
       '--chipHScale': (settings?.fonts?.chipHeight || 1),
       '--badgeBg': settings?.slides?.infobadgeColor || t.accent || '#5C3101',
-      '--badgeFg': t.boxFg || '#FFFFFF'
+      '--badgeFg': t.boxFg || '#FFFFFF',
+      '--tileEnterDuration': msVar(settings?.slides?.tileEnterMs, 600),
+      '--tileEnterDelay': msVar(settings?.slides?.tileStaggerMs, 80),
+      '--heroTimelineItemMs': msVar(settings?.slides?.heroTimelineItemMs, 500),
+      '--heroTimelineItemDelay': msVar(settings?.slides?.heroTimelineItemDelayMs, 140),
+      '--heroTimelineFillMs': msVar(settings?.slides?.heroTimelineFillMs, 8000),
+      '--heroTimelineDelayMs': msVar(settings?.slides?.heroTimelineDelayMs, 400)
     });
     if (settings?.fonts?.family) document.documentElement.style.setProperty('--font', settings.fonts.family);
 // Chip-Optionen (Übersicht): Größen & Overflow-Modus aus den Settings
@@ -299,10 +310,116 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     return 'cover';
   }
 
-// ---------- Slide queue ----------
-function buildQueue() {
+  function textFromValue(value) {
+    if (value == null) return '';
+    if (Array.isArray(value)) {
+      return value
+        .map(part => textFromValue(part))
+        .filter(Boolean)
+        .join(' · ');
+    }
+    if (typeof value === 'object') {
+      const candidates = ['text', 'label', 'name', 'value', 'title'];
+      for (const key of candidates) {
+        const v = value[key];
+        if (typeof v === 'string' && v.trim()) return v.trim();
+      }
+      return '';
+    }
+    if (typeof value === 'boolean') return value ? 'Ja' : 'Nein';
+    const str = String(value).trim();
+    return str;
+  }
+
+  function firstTextValue(...values) {
+    for (const value of values) {
+      const txt = textFromValue(value);
+      if (txt) return txt;
+    }
+    return '';
+  }
+
+  function collectHeroTimelineData() {
+    heroTimeline = [];
+    if (!schedule || !Array.isArray(schedule.rows)) return heroTimeline;
+
+    const saunas = Array.isArray(schedule.saunas) ? schedule.saunas : [];
+    if (!saunas.length) return heroTimeline;
+
+    const hiddenSaunas = new Set(settings?.slides?.hiddenSaunas || []);
+    const highlight = getHighlightMap();
+    const baseMinutes = Math.max(1, Number.isFinite(+settings?.slides?.heroTimelineBaseMinutes)
+      ? +settings.slides.heroTimelineBaseMinutes
+      : 15);
+    const maxEntries = Number.isFinite(+settings?.slides?.heroTimelineMaxEntries)
+      ? Math.max(1, Math.floor(+settings.slides.heroTimelineMaxEntries))
+      : null;
+
+    (schedule.rows || []).forEach((row, ri) => {
+      if (!row) return;
+      const time = String(row.time || '').trim();
+      const minute = parseHM(time);
+      if (!time || minute === null) return;
+      const entries = [];
+      saunas.forEach((saunaName, colIdx) => {
+        if (hiddenSaunas.has(saunaName)) return;
+        const cell = (row.entries || [])[colIdx];
+        if (!cell || !cell.title) return;
+        if (cell.hidden === true || cell.visible === false || cell.enabled === false) return;
+        const label = String(cell.title).replace(/\*+$/, '').trim();
+        if (!label) return;
+        const detail = firstTextValue(
+          cell.subtitle,
+          cell.detail,
+          cell.aroma,
+          cell.aromas,
+          cell.extra
+        );
+        const key = 'r' + ri + 'c' + colIdx;
+        entries.push({
+          sauna: saunaName,
+          title: label,
+          detail,
+          highlight: !!highlight.byCell[key]
+        });
+      });
+      if (entries.length) heroTimeline.push({ time, minute, entries });
+    });
+
+    heroTimeline.sort((a, b) => {
+      if (a.minute !== b.minute) return a.minute - b.minute;
+      return a.time.localeCompare(b.time);
+    });
+
+    if (maxEntries && heroTimeline.length > maxEntries) {
+      heroTimeline = heroTimeline.slice(0, maxEntries);
+    }
+
+    for (let i = 0; i < heroTimeline.length; i++) {
+      const cur = heroTimeline[i];
+      const next = heroTimeline[i + 1] || null;
+      const diff = next ? Math.max(1, next.minute - cur.minute) : baseMinutes;
+      const ratio = diff / baseMinutes;
+      cur.durationRatio = Number.isFinite(ratio) ? Math.max(0.25, Math.min(4, ratio)) : 1;
+      cur.isActive = cur.entries.some(entry => entry.highlight);
+    }
+
+    return heroTimeline;
+  }
+
+  // ---------- Slide queue ----------
+  function buildQueue() {
   // Tages-Preset ggf. anwenden
   maybeApplyPreset();
+
+  const heroEnabled = !!(settings?.slides?.heroEnabled);
+  const timeline = heroEnabled ? collectHeroTimelineData() : (heroTimeline = []);
+  const hasHero = heroEnabled && timeline.length > 0;
+
+  const finalizeQueue = (queue) => {
+    const out = hasHero ? [{ type: 'hero-timeline' }, ...queue] : queue.slice();
+    nextQueue.splice(0, nextQueue.length, ...out);
+  };
 
   const showOverview = (settings?.slides?.showOverview !== false);
   const hidden = new Set(settings?.slides?.hiddenSaunas || []);
@@ -397,7 +514,7 @@ function buildQueue() {
     }
     settings.slides.sortOrder = clean;
     if (!queue.length && showOverview) queue.push({ type: 'overview' });
-    nextQueue.splice(0, nextQueue.length, ...queue);
+    finalizeQueue(queue);
     return;
   }
 
@@ -461,7 +578,7 @@ function buildQueue() {
   // Falls nichts bleibt, notfalls Übersicht zeigen
   if (!queue.length && showOverview) queue.push({ type: 'overview' });
 
-  nextQueue.splice(0, nextQueue.length, ...queue);
+  finalizeQueue(queue);
 }
 
   // ---------- DOM helpers ----------
@@ -721,6 +838,59 @@ setTimeout(recalc, 0);
 if (document.fonts?.ready) { document.fonts.ready.then(recalc).catch(()=>{}); }
 onResizeCurrent = recalc;
     return c;
+  }
+
+  function renderHeroTimeline() {
+    const data = (heroTimeline.length ? heroTimeline : collectHeroTimelineData()).slice();
+    const headingWrap = h('div', { class: 'headings hero-headings' }, [
+      h('h1', { class: 'h1' }, settings?.slides?.heroTitle || 'Tagesüberblick'),
+      h('h2', { class: 'h2' }, computeH2Text() || '')
+    ]);
+
+    const list = h('div', { class: 'hero-timeline-list' });
+
+    if (!data.length) {
+      list.appendChild(h('div', { class: 'caption' }, 'Keine Einträge.'));
+    } else {
+      data.forEach((row, idx) => {
+        const cls = 'timeline-item' + (row.isActive ? ' is-active' : '');
+        const item = h('div', { class: cls });
+        item.style.setProperty('--hero-index', String(idx));
+        if (Number.isFinite(+row.durationRatio)) {
+          item.style.setProperty('--hero-duration-ratio', String(row.durationRatio));
+        }
+
+        item.appendChild(h('div', { class: 'timeline-time' }, row.time + ' Uhr'));
+
+        const details = h('div', { class: 'timeline-details' });
+        row.entries.forEach(entry => {
+          const entryCls = 'timeline-entry' + (entry.highlight ? ' highlight' : '');
+          const entryNode = h('div', { class: entryCls });
+          entryNode.appendChild(h('span', { class: 'timeline-sauna' }, entry.sauna));
+          entryNode.appendChild(h('span', { class: 'timeline-title' }, entry.title));
+          if (entry.detail) entryNode.appendChild(h('span', { class: 'timeline-detail' }, entry.detail));
+          details.appendChild(entryNode);
+        });
+        item.appendChild(details);
+
+        const bar = h('div', { class: 'timeline-bar' }, [
+          h('div', { class: 'timeline-progress' })
+        ]);
+        item.appendChild(bar);
+
+        list.appendChild(item);
+      });
+    }
+
+    const body = h('div', { class: 'hero-body' }, [list]);
+    const container = h('div', { class: 'container hero hero-timeline fade show' }, [
+      headingWrap,
+      body,
+      h('div', { class: 'brand' }, 'Signage')
+    ]);
+
+    onResizeCurrent = null;
+    return container;
   }
 
 // ---------- Interstitial image slide ----------
@@ -1214,6 +1384,7 @@ function renderStorySlide(story = {}) {
         contentBlock,
         flamesWrap(it.flames)
       ]);
+      tile.style.setProperty('--tile-index', String(list.children.length));
 
       if (it.hidden || hiddenSaunas.has(name)) {
         tile.appendChild(h('div', { class: 'card-chip card-chip--status', 'data-role': 'hidden' }, 'Ausgeblendet'));
@@ -1314,6 +1485,11 @@ function dwellMsForItem(item) {
     return sec(v) * 1000;
   }
 
+  if (item.type === 'hero-timeline') {
+    const fallback = slides.heroDurationSec ?? slides.globalDwellSec ?? slides.saunaDurationSec ?? 10;
+    return sec(fallback) * 1000;
+  }
+
   return 6000; // Fallback
 }
 
@@ -1337,6 +1513,7 @@ if (key === lastKey && nextQueue.length > 1) {
     (item.type === 'video')    ? renderVideo(item.src, item) :
     (item.type === 'url')      ? renderUrl(item.url) :
     (item.type === 'story')    ? renderStorySlide(item.story) :
+    (item.type === 'hero-timeline') ? renderHeroTimeline() :
                                  renderImage(item.src || item.url);
 
   show(el);


### PR DESCRIPTION
## Summary
- add a hero timeline slide that assembles schedule rows into an animated overview
- expose animation timing variables and CSS keyframes for tile and timeline transitions
- inject the hero slide at the start of each loop when enabled while keeping preload behaviour unchanged

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce7e4ca3c083208e331f7d52505b67