### PR TITLE
Add slide style palettes and component toggles

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -302,6 +302,31 @@
               <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
             </div>
           </div>
+          <div class="kv">
+            <label>Komponenten auf Slides</label>
+            <div id="componentToggleWrap" class="component-toggle-wrap">
+              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="title"> Titel &amp; Uhrzeit</label>
+              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="description"> Beschreibung</label>
+              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="aromas"> Aromenliste</label>
+              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="facts"> Fakten/Chips</label>
+              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="badges"> Badge-Leiste</label>
+            </div>
+            <div class="help">Gilt auch für die Verfügbarkeitsliste in Story-Slides.</div>
+          </div>
+          <div class="kv">
+            <label>Stil-Paletten</label>
+            <div class="style-set-controls">
+              <select id="styleSetSelect" class="input"></select>
+              <div class="row" style="gap:6px;flex-wrap:wrap">
+                <button class="btn sm" id="styleSetApply" type="button">Aktivieren</button>
+                <button class="btn sm ghost" id="styleSetSave" type="button">Aktualisieren</button>
+                <button class="btn sm ghost" id="styleSetCreate" type="button">Neu</button>
+                <button class="btn sm ghost" id="styleSetDelete" type="button">Löschen</button>
+              </div>
+            </div>
+          </div>
+          <div class="kv"><label>Palettenname</label><input id="styleSetLabel" class="input" type="text" placeholder="Palette"></div>
+          <div class="help">Paletten speichern Farben, Typografie und Badge-Optionen. „Aktivieren“ übernimmt die Auswahl in die aktuellen Einstellungen.</div>
 
           <div class="subh">Bildspalte / Schrägschnitt</div>
           <div class="kv"><label>Breite rechts (%)</label><input id="rightW" class="input" type="number" min="0" max="70" value="38"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -384,7 +384,9 @@ async function enterDeviceContext(id, name){
     getSchedule:()=>schedule,
     getSettings:()=>settings,
     setSchedule:(s)=>{schedule=s;},
-    setSettings:(cs)=>{settings=cs;}
+    setSettings:(cs)=>{settings=cs;},
+    refreshSlidesBox: renderSlidesBox,
+    refreshColors: renderColors
   });
   renderContextBadge();
   window.__refreshDevicesPane?.();
@@ -412,7 +414,9 @@ function exitDeviceContext(){
     getSchedule:()=>schedule,
     getSettings:()=>settings,
     setSchedule:(s)=>{schedule=s;},
-    setSettings:(cs)=>{settings=cs;}
+    setSettings:(cs)=>{settings=cs;},
+    refreshSlidesBox: renderSlidesBox,
+    refreshColors: renderColors
   });
   renderContextBadge();
   window.__refreshDevicesPane?.();
@@ -477,7 +481,9 @@ async function loadAll(){
     getSchedule : () => schedule,
     getSettings : () => settings,
     setSchedule : (s)  => { schedule = s; },
-    setSettings : (cs) => { settings = cs; }
+    setSettings : (cs) => { settings = cs; },
+    refreshSlidesBox: renderSlidesBox,
+    refreshColors: renderColors
   });
 
   initGridDayLoader({

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -1,6 +1,89 @@
 // /admin/js/core/defaults.js
 // DEFAULTS + Wochentags-Helfer als Single Source of Truth
 
+const DEFAULT_THEME = {
+  bg:'#E8DEBD', fg:'#5C3101', accent:'#5C3101',
+  gridBorder:'#5C3101',
+  gridTable:'#5C3101', gridTableW:2,
+  cellBg:'#5C3101', boxFg:'#FFFFFF',
+  headRowBg:'#E8DEBD', headRowFg:'#5C3101',
+  timeColBg:'#E8DEBD', timeZebra1:'#EAD9A0', timeZebra2:'#E2CE91',
+  zebra1:'#EDDFAF', zebra2:'#E6D6A1',
+  cornerBg:'#E8DEBD', cornerFg:'#5C3101',
+  tileBorder:'#5C3101',
+  chipBorder:'#5C3101', chipBorderW:2,
+  flame:'#FFD166',
+  saunaColor:'#5C3101'
+};
+
+const DEFAULT_FONTS = {
+  family:"system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+  scale:1, h1Scale:1, h2Scale:1,
+  overviewTitleScale:1, overviewHeadScale:0.9, overviewCellScale:0.8,
+  tileTextScale:0.8, tileWeight:600, chipHeight:1,
+  chipOverflowMode:'scale', flamePct:55, flameGapScale:0.14
+};
+
+const DEFAULT_ENABLED_COMPONENTS = {
+  title:true,
+  description:true,
+  aromas:true,
+  facts:true,
+  badges:true
+};
+
+const DEFAULT_STYLE_SETS = {
+  classic:{
+    label:'Klassisch',
+    theme:{ ...DEFAULT_THEME },
+    fonts:{
+      family:DEFAULT_FONTS.family,
+      tileTextScale:DEFAULT_FONTS.tileTextScale,
+      tileWeight:DEFAULT_FONTS.tileWeight,
+      chipHeight:DEFAULT_FONTS.chipHeight,
+      chipOverflowMode:DEFAULT_FONTS.chipOverflowMode,
+      flamePct:DEFAULT_FONTS.flamePct,
+      flameGapScale:DEFAULT_FONTS.flameGapScale
+    },
+    slides:{
+      aromaItalic:false,
+      infobadgeColor:'#5C3101',
+      infobadgeIcon:'ℹ️'
+    }
+  },
+  fresh:{
+    label:'Frisch & Modern',
+    theme:{
+      bg:'#0F172A', fg:'#F4F6FF', accent:'#4EA8DE',
+      gridBorder:'#1E2A4A',
+      gridTable:'#1E2A4A', gridTableW:2,
+      cellBg:'#1B2542', boxFg:'#F4F6FF',
+      headRowBg:'#131D36', headRowFg:'#F4F6FF',
+      timeColBg:'#131D36', timeZebra1:'#1C2747', timeZebra2:'#15203A',
+      zebra1:'#1F2B4D', zebra2:'#18233F',
+      cornerBg:'#131D36', cornerFg:'#F4F6FF',
+      tileBorder:'#4EA8DE', tileBorderW:3,
+      chipBorder:'#4EA8DE', chipBorderW:2,
+      flame:'#FFB703',
+      saunaColor:'#4EA8DE'
+    },
+    fonts:{
+      family:"'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif",
+      tileTextScale:0.86,
+      tileWeight:600,
+      chipHeight:1.05,
+      chipOverflowMode:'scale',
+      flamePct:60,
+      flameGapScale:0.16
+    },
+    slides:{
+      aromaItalic:true,
+      infobadgeColor:'#4EA8DE',
+      infobadgeIcon:'🌿'
+    }
+  }
+};
+
 export const DEFAULTS = {
   slides:{
     overviewDurationSec:10,
@@ -11,31 +94,15 @@ export const DEFAULTS = {
     tileMaxScale:0.57,
     aromaItalic:false,
     infobadgeColor:'#5C3101',
-    infobadgeIcon:'ℹ️'
+    infobadgeIcon:'ℹ️',
+    enabledComponents:{ ...DEFAULT_ENABLED_COMPONENTS },
+    styleSets:{ ...DEFAULT_STYLE_SETS },
+    activeStyleSet:'classic'
   },
   display:{ fit:'auto', baseW:1920, baseH:1080, rightWidthPercent:38, cutTopPercent:28, cutBottomPercent:12 },
-  theme:{
-    bg:'#E8DEBD', fg:'#5C3101', accent:'#5C3101',
-    gridBorder:'#5C3101',
-    gridTable:'#5C3101', gridTableW:2,
-    cellBg:'#5C3101', boxFg:'#FFFFFF',
-    headRowBg:'#E8DEBD', headRowFg:'#5C3101',
-    timeColBg:'#E8DEBD', timeZebra1:'#EAD9A0', timeZebra2:'#E2CE91',
-    zebra1:'#EDDFAF', zebra2:'#E6D6A1',
-    cornerBg:'#E8DEBD', cornerFg:'#5C3101',
-    tileBorder:'#5C3101',
-    chipBorder:'#5C3101', chipBorderW:2,
-    flame:'#FFD166',
-    saunaColor:'#5C3101'
-  },
+  theme:{ ...DEFAULT_THEME },
   highlightNext:{ enabled:false, color:'#FFDD66', minutesBeforeNext:15, minutesAfterStart:15 },
-  fonts:{
-    family:"system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-    scale:1, h1Scale:1, h2Scale:1,
-    overviewTitleScale:1, overviewHeadScale:0.9, overviewCellScale:0.8,
-    tileTextScale:0.8, tileWeight:600, chipHeight:1,
-    chipOverflowMode:'scale', flamePct:55, flameGapScale:0.14
-  },
+  fonts:{ ...DEFAULT_FONTS },
   h2:{ mode:'text', text:'Aufgusszeiten', showOnOverview:true },
   assets:{ flameImage:'/assets/img/flame_test.svg' },
   footnotes:[ { id:'star', label:'*', text:'Nur am Fr und Sa' } ]

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -22,6 +22,127 @@ import { DEFAULTS } from '../core/defaults.js';
 let ctx = null; // { getSchedule, getSettings, setSchedule, setSettings }
 let wiredStatic = false;
 
+const COMPONENT_KEYS = ['title','description','aromas','facts','badges'];
+
+const STYLE_THEME_KEYS = [
+  'bg','fg','accent','gridBorder','gridTable','gridTableW','cellBg','boxFg','headRowBg','headRowFg',
+  'timeColBg','timeZebra1','timeZebra2','zebra1','zebra2','cornerBg','cornerFg','tileBorder','tileBorderW',
+  'chipBorder','chipBorderW','flame','saunaColor'
+];
+
+const STYLE_FONT_KEYS = ['family','tileTextScale','tileWeight','chipHeight','chipOverflowMode','flamePct','flameGapScale'];
+const STYLE_SLIDE_KEYS = ['aromaItalic','infobadgeColor','infobadgeIcon'];
+
+const cloneValue = (value) => {
+  if (value == null) return value;
+  if (typeof value === 'object') return JSON.parse(JSON.stringify(value));
+  return value;
+};
+
+function cloneSubset(src = {}, keys = []){
+  const out = {};
+  keys.forEach(key => {
+    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = cloneValue(src[key]);
+  });
+  return out;
+}
+
+function ensureEnabledComponents(settings){
+  settings.slides ||= {};
+  const defaults = DEFAULTS.slides?.enabledComponents || {};
+  const merged = { ...defaults };
+  const current = settings.slides.enabledComponents;
+  if (current && typeof current === 'object'){
+    COMPONENT_KEYS.forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(current, key)) merged[key] = !!current[key];
+    });
+  }
+  settings.slides.enabledComponents = merged;
+  return merged;
+}
+
+function sanitizeStyleSetEntry(entry = {}){
+  const label = String(entry.label || '').trim();
+  const clean = {
+    label: label || null,
+    theme: cloneSubset(entry.theme, STYLE_THEME_KEYS),
+    fonts: cloneSubset(entry.fonts, STYLE_FONT_KEYS),
+    slides: cloneSubset(entry.slides, STYLE_SLIDE_KEYS)
+  };
+  if (!clean.label) clean.label = null;
+  return clean;
+}
+
+function ensureStyleSets(settings){
+  settings.slides ||= {};
+  let sets = settings.slides.styleSets;
+  if (!sets || typeof sets !== 'object'){
+    sets = JSON.parse(JSON.stringify(DEFAULTS.slides?.styleSets || {}));
+  }
+
+  const cleaned = {};
+  Object.entries(sets).forEach(([key, value]) => {
+    if (!value || typeof value !== 'object') return;
+    const slug = String(key || '').trim();
+    if (!slug) return;
+    const entry = sanitizeStyleSetEntry(value);
+    cleaned[slug] = {
+      label: entry.label || slug,
+      theme: entry.theme,
+      fonts: entry.fonts,
+      slides: entry.slides
+    };
+  });
+
+  if (!Object.keys(cleaned).length){
+    Object.assign(cleaned, JSON.parse(JSON.stringify(DEFAULTS.slides?.styleSets || {})));
+  }
+
+  settings.slides.styleSets = cleaned;
+  const ids = Object.keys(cleaned);
+  if (!settings.slides.activeStyleSet || !ids.includes(settings.slides.activeStyleSet)){
+    settings.slides.activeStyleSet = ids[0] || '';
+  }
+  return cleaned;
+}
+
+function snapshotStyleSet(settings){
+  return {
+    theme: cloneSubset(settings.theme, STYLE_THEME_KEYS),
+    fonts: cloneSubset(settings.fonts, STYLE_FONT_KEYS),
+    slides: cloneSubset(settings.slides, STYLE_SLIDE_KEYS)
+  };
+}
+
+function slugifyStyleSet(label, existingIds = []){
+  const base = (label || 'palette').toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'palette';
+  const set = new Set(existingIds);
+  let slug = base;
+  let i = 2;
+  while (set.has(slug)){
+    slug = `${base}-${i}`;
+    i++;
+  }
+  return slug;
+}
+
+function applyStyleSet(settings, id){
+  const sets = ensureStyleSets(settings);
+  const entry = sets[id];
+  if (!entry) return false;
+  if (entry.theme && typeof entry.theme === 'object'){
+    settings.theme = { ...(settings.theme || {}), ...cloneSubset(entry.theme, STYLE_THEME_KEYS) };
+  }
+  if (entry.fonts && typeof entry.fonts === 'object'){
+    settings.fonts = { ...(settings.fonts || {}), ...cloneSubset(entry.fonts, STYLE_FONT_KEYS) };
+  }
+  if (entry.slides && typeof entry.slides === 'object'){
+    settings.slides = { ...(settings.slides || {}), ...cloneSubset(entry.slides, STYLE_SLIDE_KEYS) };
+  }
+  settings.slides.activeStyleSet = id;
+  return true;
+}
+
 // ============================================================================
 // 1) Wochentage / Presets
 // ============================================================================
@@ -1401,6 +1522,8 @@ export function renderSlidesMaster(){
   const schedule = ctx.getSchedule();
 
   ensureStorySlides(settings);
+  const styleSets = ensureStyleSets(settings);
+  const componentFlags = ensureEnabledComponents(settings);
 
   // Transition
   const transEl = $('#transMs2');
@@ -1454,6 +1577,141 @@ export function renderSlidesMaster(){
       const next = /^#([0-9A-F]{6})$/i.test(raw) ? raw.toUpperCase() : prev;
       (settings.slides ||= {}).infobadgeColor = next;
       badgeColorEl.value = next;
+    };
+  }
+
+  const toggleWrap = $('#componentToggleWrap');
+  if (toggleWrap){
+    toggleWrap.querySelectorAll('input[data-component]').forEach(inp => {
+      if (!(inp instanceof HTMLInputElement)) return;
+      const key = inp.dataset.component;
+      if (!key) return;
+      inp.checked = componentFlags[key] !== false;
+      const label = inp.closest('label');
+      if (label) label.classList.toggle('active', inp.checked);
+      inp.onchange = () => {
+        componentFlags[key] = !!inp.checked;
+        if (label) label.classList.toggle('active', inp.checked);
+      };
+    });
+  }
+
+  const styleSelect = $('#styleSetSelect');
+  const labelField = $('#styleSetLabel');
+  const applyBtn = $('#styleSetApply');
+  const saveBtn = $('#styleSetSave');
+  const createBtn = $('#styleSetCreate');
+  const deleteBtn = $('#styleSetDelete');
+  const setIds = Object.keys(styleSets);
+  const activeSetId = settings.slides?.activeStyleSet && setIds.includes(settings.slides.activeStyleSet)
+    ? settings.slides.activeStyleSet
+    : (setIds[0] || '');
+
+  if (styleSelect){
+    styleSelect.innerHTML = '';
+    setIds.forEach(id => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = styleSets[id]?.label || id;
+      opt.selected = (id === activeSetId);
+      styleSelect.appendChild(opt);
+    });
+    styleSelect.disabled = setIds.length === 0;
+  }
+
+  const updateLabelField = () => {
+    if (!labelField) return;
+    const currentId = styleSelect?.value || activeSetId;
+    if (currentId && styleSets[currentId]){
+      labelField.disabled = false;
+      labelField.value = styleSets[currentId].label || currentId;
+    } else {
+      labelField.disabled = true;
+      labelField.value = '';
+    }
+  };
+  updateLabelField();
+
+  if (styleSelect){
+    styleSelect.onchange = () => {
+      updateLabelField();
+    };
+  }
+
+  if (labelField){
+    labelField.oninput = () => {
+      const currentId = styleSelect?.value || activeSetId;
+      if (!currentId || !styleSets[currentId]) return;
+      styleSets[currentId].label = labelField.value.trim() || currentId;
+      if (styleSelect){
+        Array.from(styleSelect.options).forEach(opt => {
+          if (opt.value === currentId){
+            opt.textContent = styleSets[currentId].label || currentId;
+          }
+        });
+      }
+    };
+  }
+
+  if (applyBtn){
+    applyBtn.onclick = () => {
+      const currentId = styleSelect?.value || activeSetId;
+      if (!currentId) return;
+      if (!applyStyleSet(settings, currentId)) return;
+      if (typeof ctx.refreshSlidesBox === 'function') ctx.refreshSlidesBox();
+      if (typeof ctx.refreshColors === 'function') ctx.refreshColors();
+      renderSlidesMaster();
+    };
+  }
+
+  if (saveBtn){
+    saveBtn.onclick = () => {
+      const currentId = styleSelect?.value || activeSetId;
+      if (!currentId || !styleSets[currentId]) return;
+      const snap = snapshotStyleSet(settings);
+      styleSets[currentId] = {
+        label: styleSets[currentId].label || currentId,
+        theme: snap.theme,
+        fonts: snap.fonts,
+        slides: snap.slides
+      };
+      renderSlidesMaster();
+    };
+  }
+
+  if (createBtn){
+    createBtn.onclick = () => {
+      const name = prompt('Name der neuen Palette:', 'Neue Palette');
+      if (name === null) return;
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const newId = slugifyStyleSet(trimmed, Object.keys(styleSets));
+      const snap = snapshotStyleSet(settings);
+      styleSets[newId] = {
+        label: trimmed,
+        theme: snap.theme,
+        fonts: snap.fonts,
+        slides: snap.slides
+      };
+      settings.slides.activeStyleSet = newId;
+      renderSlidesMaster();
+    };
+  }
+
+  if (deleteBtn){
+    deleteBtn.onclick = () => {
+      const currentId = styleSelect?.value || activeSetId;
+      if (!currentId || !styleSets[currentId]) return;
+      if (Object.keys(styleSets).length <= 1){
+        alert('Mindestens eine Palette muss vorhanden sein.');
+        return;
+      }
+      if (!confirm('Palette wirklich löschen?')) return;
+      delete styleSets[currentId];
+      if (settings.slides.activeStyleSet === currentId){
+        settings.slides.activeStyleSet = Object.keys(styleSets)[0] || '';
+      }
+      renderSlidesMaster();
     };
   }
 

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -243,16 +243,37 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 }
 .tile .title .label{display:flex;align-items:baseline;gap:.35em;flex-wrap:wrap;min-width:0;}
 .tile .title .label .notewrap{flex:0 0 auto;}
-.tile .aroma{
+.card-content .description{
   display:block;
   font-size:calc(22px*var(--scale)*var(--tileMetaScale,1));
   font-weight:500;
   letter-spacing:.02em;
   opacity:.9;
-  color:rgba(255,255,255,.8);
-  font-style:normal;
+  color:rgba(255,255,255,.82);
+  margin:0;
 }
-.tile .aroma.is-italic{font-style:italic;}
+.aroma-list{
+  display:flex;
+  flex-wrap:wrap;
+  gap:var(--tileChipGapPx, calc(8px*var(--vwScale)));
+  padding:0;
+  margin:0;
+  list-style:none;
+  font-size:calc(18px*var(--scale)*var(--tileMetaScale,1));
+  font-weight:500;
+  letter-spacing:.02em;
+  color:rgba(255,255,255,.78);
+}
+.aroma-list li{
+  padding:.35em .9em;
+  border-radius:999px;
+  background:rgba(0,0,0,.22);
+}
+.aroma-list.is-italic li{font-style:italic;}
+.badge-row{
+  display:flex;
+  align-items:center;
+}
 .tile .badge{
   display:inline-flex;
   align-items:center;
@@ -294,6 +315,10 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
   max-width:100%;
   overflow:hidden;
   text-overflow:ellipsis;
+}
+.card-empty{
+  font-size:calc(18px*var(--scale)*var(--tileMetaScale,1));
+  opacity:.72;
 }
 .card-chip--status{
   position:absolute;
@@ -370,12 +395,22 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 .story-slide .story-faq-list dd{margin:0; opacity:.9;}
 .story-slide .story-availability{margin-top:auto; padding:clamp(16px, 2vh, 24px); border-radius:22px; background:linear-gradient(135deg, rgba(255,255,255,.88), rgba(255,255,255,.45)); box-shadow:0 18px 40px rgba(0,0,0,.18); border-left:6px solid var(--accent);}
 .story-slide .story-availability-list{margin:0; padding:0; list-style:none; display:grid; gap:8px; font-size:calc(22px*var(--scale));}
-.story-slide .story-availability-item{display:grid; grid-template-columns:minmax(0,8ch) minmax(0,1fr); gap:14px; align-items:baseline; padding:6px 10px; border-radius:14px; background:rgba(0,0,0,.05);}
+.story-slide .story-availability-item{display:flex; flex-direction:column; gap:8px; align-items:stretch; padding:10px 12px; border-radius:14px; background:rgba(0,0,0,.05);}
 .story-slide .story-availability-item.is-upcoming{background:rgba(255,221,102,.28);}
 .story-slide .story-availability-item.is-next{background:rgba(255,221,102,.48); box-shadow:0 0 0 2px rgba(92,49,1,.18);}
+.story-slide .story-availability-head{display:grid; grid-template-columns:minmax(0,8ch) minmax(0,1fr); gap:12px; align-items:baseline;}
 .story-slide .story-availability-time{font-variant-numeric:tabular-nums; font-weight:700;}
+.story-slide .story-availability-headline{display:flex; flex-direction:column; gap:2px; min-width:0;}
 .story-slide .story-availability-sauna{font-weight:600;}
 .story-slide .story-availability-title{opacity:.9;}
+.story-slide .story-availability-description{margin:0; font-size:calc(21px*var(--scale)); line-height:1.45; opacity:.92;}
+.story-slide .story-availability-aromas{margin:0; padding:0; list-style:none; display:flex; flex-wrap:wrap; gap:6px; font-size:calc(20px*var(--scale)); opacity:.85;}
+.story-slide .story-availability-aromas li{padding:.3em .8em; border-radius:999px; background:rgba(0,0,0,.08);}
+.story-slide .story-availability-facts{margin:0; padding:0; list-style:none; display:flex; flex-wrap:wrap; gap:6px;}
+.story-slide .story-card-chip{background:rgba(0,0,0,.12); border-color:rgba(0,0,0,.15); color:inherit;}
+.story-slide .story-availability-badges{display:flex; flex-wrap:wrap; gap:6px;}
+.story-slide .story-availability-badges .badge{box-shadow:none; font-size:calc(18px*var(--scale)); padding:.3em .8em;}
+.story-slide .story-availability-empty-detail{font-style:italic; opacity:.65; font-size:calc(18px*var(--scale));}
 .story-slide .story-availability-empty{margin:0; font-style:italic; opacity:.75; font-size:calc(21px*var(--scale));}
 
 @media (max-width: 1366px), (max-aspect-ratio: 4/3){

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -532,6 +532,134 @@ function buildQueue() {
     return h('sup', { class: 'note' }, String(fn.label || '*'));
   }
 
+  const SLIDE_COMPONENT_DEFAULTS = { title:true, description:true, aromas:true, facts:true, badges:true };
+
+  function getSlideComponentFlags(){
+    const src = settings?.slides?.enabledComponents;
+    const merged = { ...SLIDE_COMPONENT_DEFAULTS };
+    if (src && typeof src === 'object'){
+      Object.keys(merged).forEach(key => {
+        if (Object.prototype.hasOwnProperty.call(src, key)) merged[key] = !!src[key];
+      });
+    }
+    return merged;
+  }
+
+  function renderComponentNodes(flags, defs, fallbackFactory){
+    const enabled = flags || {};
+    const anyEnabled = Object.values(enabled).some(Boolean);
+    const nodes = [];
+    defs.forEach(def => {
+      if (!def) return;
+      const { key } = def;
+      if (!key) return;
+      if (enabled[key] === false) return;
+      const node = def.node ?? (typeof def.render === 'function' ? def.render() : null);
+      if (!node) return;
+      nodes.push(node);
+    });
+    if (!nodes.length && typeof fallbackFactory === 'function'){
+      const fallbackNode = fallbackFactory(anyEnabled);
+      if (fallbackNode) nodes.push(fallbackNode);
+    }
+    return nodes;
+  }
+
+  function gatherList(...values){
+    const seen = new Set();
+    const out = [];
+    const add = (txt) => {
+      const str = String(txt ?? '').trim();
+      if (!str) return;
+      const key = str.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push(str);
+    };
+    const walk = (value) => {
+      if (value == null) return;
+      if (Array.isArray(value)) { value.forEach(walk); return; }
+      if (typeof value === 'object') {
+        if (typeof value.text === 'string') { walk(value.text); return; }
+        if (typeof value.label === 'string') { walk(value.label); return; }
+        if (typeof value.value === 'string') { walk(value.value); return; }
+        if (typeof value.name === 'string') { walk(value.name); return; }
+        return;
+      }
+      if (typeof value === 'string') {
+        value.split(/[|•·;\n\r]+/).forEach(part => add(part));
+        return;
+      }
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        add(value);
+      }
+    };
+    values.forEach(walk);
+    return out;
+  }
+
+  function firstText(...values){
+    for (const value of values) {
+      if (value == null) continue;
+      if (Array.isArray(value)) {
+        const parts = value.map(v => firstText(v)).filter(Boolean);
+        if (parts.length) return parts.join(' · ');
+        continue;
+      }
+      if (typeof value === 'object') {
+        if (typeof value.text === 'string' && value.text.trim()) return value.text.trim();
+        if (typeof value.label === 'string' && value.label.trim()) return value.label.trim();
+        if (typeof value.value === 'string' && value.value.trim()) return value.value.trim();
+        if (typeof value.name === 'string' && value.name.trim()) return value.name.trim();
+        continue;
+      }
+      const str = String(value).trim();
+      if (str) return str;
+    }
+    return '';
+  }
+
+  function collectCellDetails(cell){
+    if (!cell) return { description:'', aromas:[], facts:[], badgeLabel:'' };
+    const description = firstText(cell.description, cell.detail, cell.subtitle, cell.text, cell.extra);
+    const aromas = gatherList(cell.aromaList, cell.aromas, cell.aroma, cell.scent, cell.scents);
+    const facts = gatherList(cell.facts, cell.details, cell.detailsList, cell.tags, cell.chips, cell.meta, cell.badges);
+    const badgeLabel = firstText(cell.type);
+    return { description, aromas, facts, badgeLabel };
+  }
+
+  function createDescriptionNode(text, className){
+    const str = String(text || '').trim();
+    if (!str) return null;
+    return h('p', { class: className || 'description' }, str);
+  }
+
+  function createAromaListNode(items, className){
+    const list = Array.isArray(items) ? items.filter(v => String(v || '').trim()) : [];
+    if (!list.length) return null;
+    const cls = className || 'aroma-list';
+    const nodes = list.map(item => h('li', String(item)));
+    return h('ul', { class: cls }, nodes);
+  }
+
+  function createFactsList(items, className = 'facts', chipClass = 'card-chip'){
+    const list = Array.isArray(items) ? items.filter(v => String(v || '').trim()) : [];
+    if (!list.length) return null;
+    const nodes = list.map(fact => h('li', { class: chipClass }, fact));
+    return h('ul', { class: className }, nodes);
+  }
+
+  function createBadgeRow(label, className){
+    const str = String(label || '').trim();
+    if (!str) return null;
+    const iconChar = settings?.slides?.infobadgeIcon || '';
+    const bits = [];
+    if (iconChar) bits.push(h('span', { class: 'badge-icon', 'aria-hidden': 'true' }, iconChar));
+    bits.push(h('span', { class: 'badge-label' }, str));
+    const badge = h('span', { class: 'badge' }, bits);
+    return h('div', { class: className || 'badge-row' }, [badge]);
+  }
+
   // ---------- Highlight logic ----------
   function getHighlightMap() {
     const HL = settings?.highlightNext || {};
@@ -830,6 +958,7 @@ function renderStorySlide(story = {}) {
   const data = story || {};
   const container = h('div', { class: 'container story-slide fade show' });
   const columns = h('div', { class: 'story-columns' });
+  const componentFlags = getSlideComponentFlags();
 
   const hero = h('div', { class: 'story-hero' });
   const heroUrl = data.heroUrl || data.hero?.url || '';
@@ -943,12 +1072,14 @@ function renderStorySlide(story = {}) {
       indices.forEach(({ name, idx }) => {
         const cell = Array.isArray(row.entries) ? row.entries[idx] : null;
         if (cell && cell.title) {
+          const details = collectCellDetails(cell);
           items.push({
             sauna: name,
             title: cell.title,
             time,
             minutes: m,
-            isUpcoming: (m != null) ? (m >= now) : false
+            isUpcoming: (m != null) ? (m >= now) : false,
+            ...details
           });
         }
       });
@@ -980,11 +1111,29 @@ function renderStorySlide(story = {}) {
       const cls = ['story-availability-item'];
       if (entry.isNext) cls.push('is-next');
       else if (entry.isUpcoming) cls.push('is-upcoming');
-      const li = h('li', { class: cls.join(' ') }, [
-        h('span', { class: 'story-availability-time' }, entry.time || '–'),
-        h('span', { class: 'story-availability-sauna' }, entry.sauna),
-        entry.title ? h('span', { class: 'story-availability-title' }, entry.title) : null
-      ]);
+      const li = h('li', { class: cls.join(' ') });
+      const components = [
+        {
+          key: 'title',
+          render: () => {
+            const head = h('div', { class: 'story-availability-head' });
+            head.appendChild(h('span', { class: 'story-availability-time' }, entry.time || '–'));
+            const headline = h('div', { class: 'story-availability-headline' }, [
+              h('span', { class: 'story-availability-sauna' }, entry.sauna),
+              entry.title ? h('span', { class: 'story-availability-title' }, entry.title) : null
+            ].filter(Boolean));
+            head.appendChild(headline);
+            return head;
+          }
+        },
+        { key: 'description', render: () => createDescriptionNode(entry.description, 'story-availability-description') },
+        { key: 'aromas', render: () => createAromaListNode(entry.aromas, 'aroma-list story-availability-aromas') },
+        { key: 'facts', render: () => createFactsList(entry.facts, 'story-availability-facts', 'card-chip story-card-chip') },
+        { key: 'badges', render: () => createBadgeRow(entry.badgeLabel, 'badge-row story-availability-badges') }
+      ];
+      renderComponentNodes(componentFlags, components, (anyEnabled) => h('div', {
+        class: 'story-availability-empty-detail'
+      }, anyEnabled ? 'Keine weiteren Details hinterlegt.' : 'Alle Komponenten deaktiviert.')).forEach(node => li.appendChild(node));
       list.appendChild(li);
     });
     section.appendChild(list);
@@ -1067,84 +1216,23 @@ function renderStorySlide(story = {}) {
     const colIdx = (schedule.saunas || []).indexOf(name);
     const iconFallback = settings?.slides?.cardIcons?.[name] || rightUrl || '';
     const hiddenSaunas = new Set(settings?.slides?.hiddenSaunas || []);
-
-    const gatherList = (...values) => {
-      const seen = new Set();
-      const out = [];
-      const add = (txt) => {
-        const str = String(txt ?? '').trim();
-        if (!str) return;
-        const key = str.toLowerCase();
-        if (seen.has(key)) return;
-        seen.add(key);
-        out.push(str);
-      };
-      const walk = (value) => {
-        if (value == null) return;
-        if (Array.isArray(value)) { value.forEach(walk); return; }
-        if (typeof value === 'object') {
-          if (typeof value.text === 'string') { walk(value.text); return; }
-          if (typeof value.label === 'string') { walk(value.label); return; }
-          if (typeof value.value === 'string') { walk(value.value); return; }
-          if (typeof value.name === 'string') { walk(value.name); return; }
-          return;
-        }
-        if (typeof value === 'string') {
-          value.split(/[|•·;\n\r]+/).forEach(part => add(part));
-          return;
-        }
-        if (typeof value === 'number' || typeof value === 'boolean') {
-          add(value);
-        }
-      };
-      values.forEach(walk);
-      return out;
-    };
-
-    const firstText = (...values) => {
-      for (const value of values) {
-        if (value == null) continue;
-        if (Array.isArray(value)) {
-          const parts = value.map(v => firstText(v)).filter(Boolean);
-          if (parts.length) return parts.join(' · ');
-          continue;
-        }
-        if (typeof value === 'object') {
-          if (typeof value.text === 'string' && value.text.trim()) return value.text.trim();
-          if (typeof value.label === 'string' && value.label.trim()) return value.label.trim();
-          if (typeof value.value === 'string' && value.value.trim()) return value.value.trim();
-          if (typeof value.name === 'string' && value.name.trim()) return value.name.trim();
-          continue;
-        }
-        const str = String(value).trim();
-        if (str) return str;
-      }
-      return '';
-    };
+    const componentFlags = getSlideComponentFlags();
 
     const items = [];
     for (const row of (schedule.rows || [])) {
       const cell = (row.entries || [])[colIdx];
       if (cell && cell.title) {
-        const aromaText = firstText(cell.aroma, cell.aromas, cell.scent, cell.subtitle, cell.detail, cell.extra);
-        const factsList = gatherList(
-          cell.facts,
-          cell.details,
-          cell.detailsList,
-          cell.tags,
-          cell.chips,
-          cell.meta,
-          cell.badges
-        );
+        const details = collectCellDetails(cell);
         const isHidden = cell.hidden === true || cell.visible === false || cell.enabled === false;
         items.push({
           time: row.time,
           title: cell.title,
           flames: cell.flames || '',
           noteId: cell.noteId,
-          aroma: aromaText,
-          type: firstText(cell.type),
-          facts: factsList,
+          description: details.description,
+          aromas: details.aromas,
+          facts: details.facts,
+          badgeLabel: details.badgeLabel,
           hidden: isHidden,
           icon: cell.icon || null
         });
@@ -1175,23 +1263,15 @@ function renderStorySlide(story = {}) {
       titleNode.appendChild(sepNode);
       titleNode.appendChild(labelNode);
 
-      const contentChildren = [titleNode];
-      if (it.type) {
-        const badgeBits = [];
-        const iconChar = settings?.slides?.infobadgeIcon || '';
-        if (iconChar) badgeBits.push(h('span', { class: 'badge-icon', 'aria-hidden': 'true' }, iconChar));
-        badgeBits.push(h('span', { class: 'badge-label' }, it.type));
-        contentChildren.push(h('span', { class: 'badge' }, badgeBits));
-      }
-      if (it.aroma) {
-        const aromaCls = 'aroma' + (settings?.slides?.aromaItalic ? ' is-italic' : '');
-        contentChildren.push(h('span', { class: aromaCls }, it.aroma));
-      }
-      if (it.facts && it.facts.length) {
-        const factItems = it.facts.map(fact => h('li', { class: 'card-chip' }, fact));
-        contentChildren.push(h('ul', { class: 'facts' }, factItems));
-      }
-      const contentBlock = h('div', { class: 'card-content' }, contentChildren);
+      const contentBlock = h('div', { class: 'card-content' });
+      renderComponentNodes(componentFlags, [
+        { key: 'title', node: titleNode },
+        { key: 'description', render: () => createDescriptionNode(it.description, 'description') },
+        { key: 'aromas', render: () => createAromaListNode(it.aromas, (settings?.slides?.aromaItalic ? 'aroma-list is-italic' : 'aroma-list')) },
+        { key: 'facts', render: () => createFactsList(it.facts, 'facts', 'card-chip') },
+        { key: 'badges', render: () => createBadgeRow(it.badgeLabel, 'badge-row') }
+      ], (anyEnabled) => h('div', { class: 'card-empty' }, anyEnabled ? 'Keine Details hinterlegt.' : 'Alle Komponenten deaktiviert.'))
+        .forEach(node => contentBlock.appendChild(node));
 
       const iconUrl = it.icon || iconFallback;
       const iconBox = h('div', { class: 'card-icon' + (iconUrl ? '' : ' is-empty') });

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -35,7 +35,100 @@
     "infobadgeIcon": "ℹ️",
     "loop": true,
     "waitForVideo": false,
-    "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"]
+    "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"],
+    "enabledComponents": {
+      "title": true,
+      "description": true,
+      "aromas": true,
+      "facts": true,
+      "badges": true
+    },
+    "styleSets": {
+      "classic": {
+        "label": "Klassisch",
+        "theme": {
+          "bg": "#E8DEBD",
+          "fg": "#5C3101",
+          "accent": "#5C3101",
+          "gridBorder": "#5C3101",
+          "gridTable": "#5C3101",
+          "gridTableW": 2,
+          "cellBg": "#5C3101",
+          "boxFg": "#FFFFFF",
+          "headRowBg": "#E8DEBD",
+          "headRowFg": "#5C3101",
+          "timeColBg": "#E8DEBD",
+          "timeZebra1": "#EAD9A0",
+          "timeZebra2": "#E2CE91",
+          "zebra1": "#EDDFAF",
+          "zebra2": "#E6D6A1",
+          "cornerBg": "#E8DEBD",
+          "cornerFg": "#5C3101",
+          "tileBorder": "#5C3101",
+          "chipBorder": "#5C3101",
+          "chipBorderW": 2,
+          "flame": "#FFD166",
+          "saunaColor": "#5C3101"
+        },
+        "fonts": {
+          "family": "system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+          "tileTextScale": 0.8,
+          "tileWeight": 600,
+          "chipHeight": 1,
+          "chipOverflowMode": "scale",
+          "flamePct": 55,
+          "flameGapScale": 0.14
+        },
+        "slides": {
+          "aromaItalic": false,
+          "infobadgeColor": "#5C3101",
+          "infobadgeIcon": "ℹ️"
+        }
+      },
+      "fresh": {
+        "label": "Frisch & Modern",
+        "theme": {
+          "bg": "#0F172A",
+          "fg": "#F4F6FF",
+          "accent": "#4EA8DE",
+          "gridBorder": "#1E2A4A",
+          "gridTable": "#1E2A4A",
+          "gridTableW": 2,
+          "cellBg": "#1B2542",
+          "boxFg": "#F4F6FF",
+          "headRowBg": "#131D36",
+          "headRowFg": "#F4F6FF",
+          "timeColBg": "#131D36",
+          "timeZebra1": "#1C2747",
+          "timeZebra2": "#15203A",
+          "zebra1": "#1F2B4D",
+          "zebra2": "#18233F",
+          "cornerBg": "#131D36",
+          "cornerFg": "#F4F6FF",
+          "tileBorder": "#4EA8DE",
+          "tileBorderW": 3,
+          "chipBorder": "#4EA8DE",
+          "chipBorderW": 2,
+          "flame": "#FFB703",
+          "saunaColor": "#4EA8DE"
+        },
+        "fonts": {
+          "family": "'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif",
+          "tileTextScale": 0.86,
+          "tileWeight": 600,
+          "chipHeight": 1.05,
+          "chipOverflowMode": "scale",
+          "flamePct": 60,
+          "flameGapScale": 0.16
+        },
+        "slides": {
+          "aromaItalic": true,
+          "infobadgeColor": "#4EA8DE",
+          "infobadgeIcon": "🌿"
+        }
+      }
+    },
+    "activeStyleSet": "classic"
   },
   "assets": {
     "rightImages": {


### PR DESCRIPTION
## Summary
- add default slide style palettes and expose management UI with activation, save, create and delete actions
- introduce per-component toggles for slide cards and persist enabled component choices
- update slideshow rendering to respect enabled components with graceful fallbacks and refresh tile/story styling

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce7e4963808320a8b3ff5ef61cc9ff