### PR TITLE
Add hero timeline configuration controls

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -120,6 +120,27 @@
 
 <div class="kv"><label>Weiter erst nach Video-Ende</label><input id="waitForVideo" type="checkbox"></div>
 
+<div class="fieldset" id="heroTimelineBox">
+  <div class="legend">Hero-Timeline</div>
+  <div class="kv">
+    <label class="row" style="gap:8px;align-items:center">
+      <input id="heroTimelineEnabled" type="checkbox">
+      <span>Hero-Timeline anzeigen</span>
+    </label>
+  </div>
+  <div class="kv" id="heroTimelineSettings" hidden>
+    <label>Einstellungen</label>
+    <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+      <span class="mut">Dauer (s)</span>
+      <input id="heroTimelineDuration" class="input num3" type="number" min="1" max="120" step="1">
+      <span class="mut">Basis-Minuten</span>
+      <input id="heroTimelineBase" class="input num3" type="number" min="1" max="120" step="1">
+      <span class="mut">Max. Einträge</span>
+      <input id="heroTimelineMax" class="input num3" type="number" min="1" max="50" step="1" placeholder="leer = alle">
+    </div>
+  </div>
+</div>
+
     <!-- Unterbox 1: Saunen & Übersicht -->
     <details class="ac sub" open id="boxSaunas">
       <summary><div class="ttl">▶<span class="chev">⮞</span> Saunen & Übersicht</div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -847,12 +847,36 @@ function collectSettings(){
         const el = document.getElementById('ovSec') || document.getElementById('ovSecGlobal');
         const fallback = settings?.slides?.overviewDurationSec ?? (DEFAULTS?.slides?.overviewDurationSec ?? 10);
         const v = el?.value;
-  	const n = Number(v);
-  	return Number.isFinite(n) ? Math.max(1, Math.min(120, n)) : fallback;
-	})(),
+        const n = Number(v);
+        return Number.isFinite(n) ? Math.max(1, Math.min(120, n)) : fallback;
+        })(),
         transitionMs: +(document.getElementById('transMs2')?.value || 500),
         durationMode: (document.querySelector('input[name=durMode]:checked')?.value || 'uniform'),
-        globalDwellSec: +(document.getElementById('dwellAll')?.value || 6)
+        globalDwellSec: +(document.getElementById('dwellAll')?.value || 6),
+        heroEnabled: !!document.getElementById('heroTimelineEnabled')?.checked,
+        heroTimelineFillMs: (() => {
+          const el = document.getElementById('heroTimelineDuration');
+          const fallback = settings?.slides?.heroTimelineFillMs ?? (DEFAULTS?.slides?.heroTimelineFillMs ?? 8000);
+          const raw = Number(el?.value);
+          if (!Number.isFinite(raw) || raw <= 0) return Math.max(1000, Math.round(fallback));
+          return Math.max(1, Math.round(raw)) * 1000;
+        })(),
+        heroTimelineBaseMinutes: (() => {
+          const el = document.getElementById('heroTimelineBase');
+          const fallback = settings?.slides?.heroTimelineBaseMinutes ?? (DEFAULTS?.slides?.heroTimelineBaseMinutes ?? 15);
+          const raw = Number(el?.value);
+          if (!Number.isFinite(raw) || raw <= 0) return Math.max(1, Math.round(fallback));
+          return Math.max(1, Math.round(raw));
+        })(),
+        heroTimelineMaxEntries: (() => {
+          const el = document.getElementById('heroTimelineMax');
+          if (!el) return settings.slides?.heroTimelineMaxEntries ?? null;
+          const raw = el.value;
+          if (raw == null || String(raw).trim() === '') return null;
+          const num = Number(raw);
+          if (!Number.isFinite(num) || num <= 0) return null;
+          return Math.max(1, Math.floor(num));
+        })()
       },
       theme: collectColors(),
       highlightNext:{

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -95,6 +95,10 @@ export const DEFAULTS = {
     aromaItalic:false,
     infobadgeColor:'#5C3101',
     infobadgeIcon:'ℹ️',
+    heroEnabled:false,
+    heroTimelineFillMs:8000,
+    heroTimelineBaseMinutes:15,
+    heroTimelineMaxEntries:null,
     enabledComponents:{ ...DEFAULT_ENABLED_COMPONENTS },
     styleSets:{ ...DEFAULT_STYLE_SETS },
     activeStyleSet:'classic'

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -1546,6 +1546,88 @@ export function renderSlidesMaster(){
     waitEl.onchange = () => { (settings.slides ||= {}).waitForVideo = !!waitEl.checked; };
   }
 
+  const heroToggle = $('#heroTimelineEnabled');
+  const heroSettingsRow = $('#heroTimelineSettings');
+  if (heroToggle){
+    const enabled = !!settings.slides?.heroEnabled;
+    heroToggle.checked = enabled;
+    if (heroSettingsRow) heroSettingsRow.hidden = !enabled;
+    heroToggle.onchange = () => {
+      (settings.slides ||= {}).heroEnabled = !!heroToggle.checked;
+      if (heroSettingsRow) heroSettingsRow.hidden = !heroToggle.checked;
+      if (typeof window.dockPushDebounced === 'function') window.dockPushDebounced();
+    };
+  } else if (heroSettingsRow){
+    heroSettingsRow.hidden = true;
+  }
+
+  const heroDurationEl = $('#heroTimelineDuration');
+  if (heroDurationEl){
+    const fallback = Math.max(1000, Math.round(DEFAULTS.slides?.heroTimelineFillMs ?? 8000));
+    const raw = settings.slides?.heroTimelineFillMs;
+    const init = Number.isFinite(+raw) ? Math.max(1000, Math.round(+raw)) : fallback;
+    heroDurationEl.value = String(Math.round(init / 1000));
+    heroDurationEl.onchange = () => {
+      const num = Number(heroDurationEl.value);
+      if (!Number.isFinite(num) || num <= 0){
+        (settings.slides ||= {}).heroTimelineFillMs = fallback;
+        heroDurationEl.value = String(Math.round(fallback / 1000));
+        return;
+      }
+      const secs = Math.max(1, Math.round(num));
+      (settings.slides ||= {}).heroTimelineFillMs = secs * 1000;
+      heroDurationEl.value = String(secs);
+    };
+  }
+
+  const heroBaseEl = $('#heroTimelineBase');
+  if (heroBaseEl){
+    const fallback = Math.max(1, Math.round(DEFAULTS.slides?.heroTimelineBaseMinutes ?? 15));
+    const raw = settings.slides?.heroTimelineBaseMinutes;
+    const init = Number.isFinite(+raw) ? Math.max(1, Math.round(+raw)) : fallback;
+    heroBaseEl.value = String(init);
+    heroBaseEl.onchange = () => {
+      const num = Number(heroBaseEl.value);
+      if (!Number.isFinite(num) || num <= 0){
+        (settings.slides ||= {}).heroTimelineBaseMinutes = fallback;
+        heroBaseEl.value = String(fallback);
+        return;
+      }
+      const minutes = Math.max(1, Math.round(num));
+      (settings.slides ||= {}).heroTimelineBaseMinutes = minutes;
+      heroBaseEl.value = String(minutes);
+    };
+  }
+
+  const heroMaxEl = $('#heroTimelineMax');
+  if (heroMaxEl){
+    const raw = settings.slides?.heroTimelineMaxEntries;
+    if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0){
+      const normalized = Math.max(1, Math.floor(raw));
+      (settings.slides ||= {}).heroTimelineMaxEntries = normalized;
+      heroMaxEl.value = String(normalized);
+    } else {
+      heroMaxEl.value = '';
+    }
+    heroMaxEl.onchange = () => {
+      const value = heroMaxEl.value;
+      if (value == null || String(value).trim() === ''){
+        (settings.slides ||= {}).heroTimelineMaxEntries = null;
+        heroMaxEl.value = '';
+        return;
+      }
+      const num = Number(value);
+      if (!Number.isFinite(num) || num <= 0){
+        (settings.slides ||= {}).heroTimelineMaxEntries = null;
+        heroMaxEl.value = '';
+        return;
+      }
+      const normalized = Math.max(1, Math.floor(num));
+      (settings.slides ||= {}).heroTimelineMaxEntries = normalized;
+      heroMaxEl.value = String(normalized);
+    };
+  }
+
   const aromaItalicEl = $('#aromaItalic');
   if (aromaItalicEl){
     aromaItalicEl.checked = !!settings.slides?.aromaItalic;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -348,11 +348,15 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
 
     const hiddenSaunas = new Set(settings?.slides?.hiddenSaunas || []);
     const highlight = getHighlightMap();
-    const baseMinutes = Math.max(1, Number.isFinite(+settings?.slides?.heroTimelineBaseMinutes)
-      ? +settings.slides.heroTimelineBaseMinutes
-      : 15);
-    const maxEntries = Number.isFinite(+settings?.slides?.heroTimelineMaxEntries)
-      ? Math.max(1, Math.floor(+settings.slides.heroTimelineMaxEntries))
+    const rawBase = settings?.slides?.heroTimelineBaseMinutes;
+    const parsedBase = Number(rawBase);
+    const baseMinutes = Number.isFinite(parsedBase) && parsedBase > 0
+      ? Math.max(1, Math.round(parsedBase))
+      : 15;
+    const rawMax = settings?.slides?.heroTimelineMaxEntries;
+    const parsedMax = Number(rawMax);
+    const maxEntries = Number.isFinite(parsedMax) && parsedMax > 0
+      ? Math.max(1, Math.floor(parsedMax))
       : null;
 
     (schedule.rows || []).forEach((row, ri) => {


### PR DESCRIPTION
## Summary
- add hero timeline controls to the admin slides master so the hero timeline can be toggled and configured
- persist hero timeline defaults and export values for preview/slideshow consumption
- ensure the slideshow respects the optional max-entry limit for the hero timeline

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce8ae9227883209488c75d0144471a