### PR TITLE
Add extended metadata inputs for sauna grid cells

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -445,6 +445,14 @@
             <select id="m_note" class="input"></select>
           </div>
         </div>
+        <label>Beschreibung</label>
+        <textarea id="m_description" class="input" rows="3" placeholder="Kurze Beschreibung oder Ritual"></textarea>
+        <label>Aromen</label>
+        <textarea id="m_aromas" class="input" rows="2" placeholder="Eine Zeile pro Aroma"></textarea>
+        <label>Fakten / Chips</label>
+        <textarea id="m_facts" class="input" rows="2" placeholder="Eine Zeile pro Fakt"></textarea>
+        <label>Aufgussart-Badge</label>
+        <input id="m_type" class="input" type="text" placeholder="z.B. Klassisch">
       </div>
       <div class="row" style="justify-content:flex-end;margin-top:14px">
         <button class="btn" id="m_cancel">Abbrechen</button>


### PR DESCRIPTION
## Summary
- add description, aroma, fact and badge inputs to the sauna cell dialog
- prefill the new fields from existing cell metadata and persist them back into the schedule
- ensure undo/redo history uses deep clones so extended cell data is preserved

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce8a9f24f08320ac63902c96a75ce8