### PR TITLE
Add sauna card icon management and compact layout option

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -809,6 +809,40 @@ body.mode-uniform #ovSec{ display:none !important; }
 .saunarow .namewrap{ display:flex; flex-direction:column; gap:6px; }
 .saunarow .tag{ display:inline-block; margin-left:6px; padding:2px 6px; border:1px solid var(--inbr); border-radius:8px; font-size:11px; opacity:.8; }
 
+.icon-config-list{ display:flex; flex-direction:column; gap:8px; }
+.iconrow{
+  display:grid;
+  grid-template-columns:minmax(0,1fr) max-content max-content;
+  gap:12px;
+  align-items:center;
+  padding:4px 0;
+}
+.iconrow + .iconrow{
+  border-top:1px solid var(--ghost-border);
+  margin-top:8px;
+  padding-top:8px;
+}
+.iconrow-name{ font-weight:600; }
+.iconrow-preview{
+  width:56px;
+  height:56px;
+  display:grid;
+  place-items:center;
+  border:1px solid var(--inbr);
+  border-radius:12px;
+  background:var(--panel);
+  overflow:hidden;
+}
+.iconrow-preview img{ width:100%; height:100%; object-fit:contain; }
+.iconrow-placeholder{
+  font-weight:700;
+  letter-spacing:.08em;
+  opacity:.65;
+}
+.iconrow-actions{ display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end; }
+.iconrow.has-suggestion:not(.has-icon) .iconrow-preview{ border-style:dashed; opacity:.8; }
+.iconrow-note{ grid-column:1 / -1; font-size:12px; opacity:.7; }
+
 /* DnD Feedback */
 .sauna-bucket{ border:1px dashed var(--inbr); border-radius:12px; padding:8px; margin-top:6px; }
 .sauna-bucket.drag-over{ outline:2px solid var(--btn-accent); }

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -153,7 +153,17 @@
 	<!-- kein Aufguss -->
 	<div id="saunaList"></div>
 	<div class="subh" id="extraTitle" style="display:none">Heute kein Aufguss</div>
-	<div id="extraSaunaList"></div>
+        <div id="extraSaunaList"></div>
+
+        <div class="fieldset" id="saunaIconFieldset">
+          <div class="legend">Karten-Icons</div>
+          <div class="kv">
+            <label>Icons anzeigen</label>
+            <input id="toggleCardIcons" type="checkbox">
+          </div>
+          <div class="help">Optionales Icon pro Sauna für die Kartenansicht. Ohne Icon wird automatisch eine Initiale angezeigt.</div>
+          <div id="saunaIconList" class="icon-config-list"></div>
+        </div>
 
         <div class="help" style="margin-top:6px">* Dauer nur sichtbar, wenn „Individuell“ gewählt ist.</div>
       </div>

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -95,6 +95,9 @@ export const DEFAULTS = {
     aromaItalic:false,
     infobadgeColor:'#5C3101',
     infobadgeIcon:'ℹ️',
+    showIcons:true,
+    cardIcons:{},
+    cardIconsMigrated:true,
     enabledComponents:{ ...DEFAULT_ENABLED_COMPONENTS },
     styleSets:{ ...DEFAULT_STYLE_SETS },
     activeStyleSet:'classic'

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -143,6 +143,43 @@ function applyStyleSet(settings, id){
   return true;
 }
 
+function ensureCardIconMap(settings){
+  settings.slides ||= {};
+  const raw = settings.slides.cardIcons;
+  const clean = {};
+  if (raw && typeof raw === 'object'){
+    Object.entries(raw).forEach(([key, value]) => {
+      const safeKey = String(key ?? '');
+      if (!safeKey) return;
+      const url = (typeof value === 'string') ? value.trim() : '';
+      if (url) clean[safeKey] = url;
+    });
+  }
+  settings.slides.cardIcons = clean;
+  return clean;
+}
+
+function maybeMigrateCardIcons(settings){
+  settings.slides ||= {};
+  if (settings.slides.cardIconsMigrated === true){
+    return ensureCardIconMap(settings);
+  }
+  const map = ensureCardIconMap(settings);
+  if (!Object.keys(map).length){
+    const legacy = settings.assets?.rightImages;
+    if (legacy && typeof legacy === 'object'){
+      Object.entries(legacy).forEach(([key, value]) => {
+        const safeKey = String(key ?? '');
+        if (!safeKey) return;
+        const url = (typeof value === 'string') ? value.trim() : '';
+        if (url) map[safeKey] = url;
+      });
+    }
+  }
+  settings.slides.cardIconsMigrated = true;
+  return map;
+}
+
 // ============================================================================
 // 1) Wochentage / Presets
 // ============================================================================
@@ -266,6 +303,10 @@ function deleteSaunaEverywhere(name){
     delete settings.assets.rightImages[name];
   }
 
+  // 4b) Karten-Icons
+  const iconMap = ensureCardIconMap(settings);
+  delete iconMap[name];
+
   // 5) Per-Sauna-Dauern
   if (settings.slides?.saunaDurations && settings.slides.saunaDurations[name] != null){
     delete settings.slides.saunaDurations[name];
@@ -305,6 +346,12 @@ function renameSaunaEverywhere(oldName, newName){
     const val = settings.assets.rightImages[oldName];
     delete settings.assets.rightImages[oldName];
     settings.assets.rightImages[newName] = val;
+  }
+
+  const iconMap = ensureCardIconMap(settings);
+  if (Object.prototype.hasOwnProperty.call(iconMap, oldName)){
+    iconMap[newName] = iconMap[oldName];
+    delete iconMap[oldName];
   }
 
   // Per-Sauna-Dauern
@@ -641,6 +688,138 @@ if ($name && mode === 'normal') {
 
 const saunaExtraRow = (name, dayLabels) =>
   saunaRow({ name, mode:'extra', dayLabels: dayLabels || [] });
+
+function cardIconFallbackLabel(name){
+  const trimmed = (name || '').trim();
+  if (trimmed.length >= 2) return trimmed.slice(0, 2).toUpperCase();
+  if (trimmed.length === 1) return trimmed.toUpperCase();
+  return '–';
+}
+
+function cardIconRow(name){
+  const settings = ctx.getSettings();
+  const iconMap = ensureCardIconMap(settings);
+  const iconUrl = iconMap[name] || '';
+  const rightImage = settings.assets?.rightImages?.[name] || '';
+  const suggestion = (!iconUrl && rightImage) ? rightImage : '';
+  const isLegacyIcon = !!iconUrl && rightImage && iconUrl === rightImage;
+
+  const row = document.createElement('div');
+  row.className = 'iconrow';
+  if (iconUrl) row.classList.add('has-icon');
+  else if (suggestion) row.classList.add('has-suggestion');
+
+  const nameEl = document.createElement('div');
+  nameEl.className = 'iconrow-name';
+  nameEl.textContent = String(name || '');
+  row.appendChild(nameEl);
+
+  const preview = document.createElement('div');
+  preview.className = 'iconrow-preview';
+  row.appendChild(preview);
+
+  const actions = document.createElement('div');
+  actions.className = 'iconrow-actions';
+  row.appendChild(actions);
+
+  const updatePreview = (src) => {
+    preview.innerHTML = '';
+    preview.title = '';
+    if (src){
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = '';
+      preview.appendChild(img);
+      preloadImg(src).then(r => {
+        if (r.ok) preview.title = `${r.w}×${r.h}`;
+      });
+    } else {
+      const span = document.createElement('span');
+      span.className = 'iconrow-placeholder';
+      span.textContent = cardIconFallbackLabel(name);
+      preview.appendChild(span);
+    }
+  };
+
+  if (iconUrl) updatePreview(iconUrl);
+  else if (suggestion) updatePreview(suggestion);
+  else updatePreview('');
+
+  const rerender = () => {
+    renderSlidesMaster();
+    if (typeof ctx.refreshSlidesBox === 'function') ctx.refreshSlidesBox();
+  };
+
+  if (suggestion){
+    const adoptBtn = document.createElement('button');
+    adoptBtn.type = 'button';
+    adoptBtn.className = 'btn sm ghost';
+    adoptBtn.textContent = 'Übernehmen';
+    adoptBtn.onclick = () => {
+      iconMap[name] = suggestion;
+      rerender();
+    };
+    actions.appendChild(adoptBtn);
+  }
+
+  const uploadBtn = document.createElement('button');
+  uploadBtn.type = 'button';
+  uploadBtn.className = 'btn sm ghost';
+  uploadBtn.textContent = iconUrl ? 'Ersetzen' : 'Hochladen';
+  uploadBtn.onclick = () => {
+    const fi = document.createElement('input');
+    fi.type = 'file';
+    fi.accept = 'image/*';
+    fi.onchange = () => uploadGeneric(fi, (p) => {
+      if (!p) return;
+      iconMap[name] = p;
+      rerender();
+    });
+    fi.click();
+  };
+  actions.appendChild(uploadBtn);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'btn sm ghost';
+  removeBtn.textContent = 'Entfernen';
+  removeBtn.disabled = !iconUrl;
+  removeBtn.onclick = () => {
+    if (!iconMap[name]) return;
+    delete iconMap[name];
+    rerender();
+  };
+  actions.appendChild(removeBtn);
+
+  if (!iconUrl && suggestion){
+    const note = document.createElement('div');
+    note.className = 'iconrow-note';
+    note.textContent = 'Vorschlag aus „Bild rechts“.';
+    row.appendChild(note);
+  } else if (isLegacyIcon){
+    const note = document.createElement('div');
+    note.className = 'iconrow-note';
+    note.textContent = 'Aus „Bild rechts“ übernommen.';
+    row.appendChild(note);
+  }
+
+  return row;
+}
+
+function renderSaunaIconList(){
+  const host = $('#saunaIconList');
+  if (!host) return;
+  host.innerHTML = '';
+  const all = getAllSaunas();
+  if (!all.length){
+    const empty = document.createElement('div');
+    empty.className = 'mut';
+    empty.textContent = 'Keine Saunen im Inventar.';
+    host.appendChild(empty);
+    return;
+  }
+  all.forEach(name => host.appendChild(cardIconRow(name)));
+}
 
 // ============================================================================
 // 4) Drag & Drop
@@ -1524,6 +1703,8 @@ export function renderSlidesMaster(){
   ensureStorySlides(settings);
   const styleSets = ensureStyleSets(settings);
   const componentFlags = ensureEnabledComponents(settings);
+  maybeMigrateCardIcons(settings);
+  const showIcons = settings.slides?.showIcons !== false;
 
   // Transition
   const transEl = $('#transMs2');
@@ -1544,6 +1725,16 @@ export function renderSlidesMaster(){
   if (waitEl){
     waitEl.checked = !!settings.slides?.waitForVideo;
     waitEl.onchange = () => { (settings.slides ||= {}).waitForVideo = !!waitEl.checked; };
+  }
+
+  const showIconsEl = $('#toggleCardIcons');
+  if (showIconsEl){
+    showIconsEl.checked = showIcons;
+    showIconsEl.onchange = () => {
+      (settings.slides ||= {}).showIcons = !!showIconsEl.checked;
+      renderSlidesMaster();
+      if (typeof ctx.refreshSlidesBox === 'function') ctx.refreshSlidesBox();
+    };
   }
 
   const aromaItalicEl = $('#aromaItalic');
@@ -1746,6 +1937,7 @@ if (sHost){
 // --- „Kein Aufguss“ + Drag&Drop ---
 renderSaunaOffList();
 applyDnD();
+renderSaunaIconList();
 
 // --- Sichtbarkeit der Dauer-Inputs gezielt steuern ---
 // Per-Sauna-Dauer (nur im PER-Modus)
@@ -1840,6 +2032,9 @@ if (durPer) durPer.onchange = () => {
     settings.slides.waitForVideo = false;
     settings.slides.hiddenSaunas = [];
     settings.slides.saunaDurations = {};
+    settings.slides.showIcons = true;
+    settings.slides.cardIcons = {};
+    settings.slides.cardIconsMigrated = true;
     renderSlidesMaster();
   };
 

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -314,6 +314,13 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
   text-transform:uppercase;
   opacity:.8;
 }
+.container.no-card-icons{ --tileIconSizePx:0px; }
+.tile.tile--compact{
+  grid-template-columns:minmax(0,1fr) auto;
+  min-height:auto;
+}
+.tile.tile--compact .card-icon{ display:none; }
+.container.no-card-icons .list{ gap:var(--tileGapPx, calc(14px*var(--vwScale))); }
 .card-content{
   display:flex;
   flex-direction:column;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -1330,9 +1330,11 @@ function renderStorySlide(story = {}) {
     const padding = 32;
     return Math.max(0, cw - intrude - padding);
   }
-  function applyTileSizing(container) {
+  function applyTileSizing(container, opts = {}) {
+    const useIcons = opts.useIcons !== false;
     const avail = computeAvailContentWidth(container);
-    const pct = (settings?.slides?.tileWidthPercent ?? 45) / 100;
+    const defaultPct = useIcons ? 45 : 42;
+    const pct = ((settings?.slides?.tileWidthPercent ?? defaultPct) / 100);
     const target = Math.max(0, avail * pct);
     const minScale = Math.max(0, settings?.slides?.tileMinScale ?? 0.25);
     const maxScale = Math.max(minScale, settings?.slides?.tileMaxScale ?? 0.57);
@@ -1346,16 +1348,19 @@ function renderStorySlide(story = {}) {
     const clamp = (min, val, max) => Math.min(Math.max(val, min), max);
 
     const iconSize = clamp(60, t * 0.18, 200);
-    const padY = clamp(14, t * 0.045, 44);
-    const padX = Math.max(clamp(20, t * 0.07, 68), padY + 6);
-    const gap = clamp(16, t * 0.05, 38);
-    const contentGap = clamp(8, t * 0.03, 26);
-    const chipGap = clamp(6, t * 0.022, 22);
-    const badgeOffset = clamp(10, t * 0.02, 28);
-    const radius = clamp(18, t * 0.06, 48);
-    const metaScale = clamp(0.72, t / 720, 1.12);
+    const padY = useIcons ? clamp(14, t * 0.045, 44) : clamp(10, t * 0.035, 32);
+    const padX = useIcons
+      ? Math.max(clamp(20, t * 0.07, 68), padY + 6)
+      : Math.max(clamp(18, t * 0.06, 48), padY + 4);
+    const gap = useIcons ? clamp(16, t * 0.05, 38) : clamp(12, t * 0.04, 30);
+    const contentGap = useIcons ? clamp(8, t * 0.03, 26) : clamp(6, t * 0.022, 18);
+    const chipGap = useIcons ? clamp(6, t * 0.022, 22) : clamp(4, t * 0.018, 16);
+    const badgeOffset = useIcons ? clamp(10, t * 0.02, 28) : clamp(8, t * 0.018, 22);
+    const radius = useIcons ? clamp(18, t * 0.06, 48) : clamp(16, t * 0.05, 44);
+    const metaScale = useIcons ? clamp(0.72, t / 720, 1.12) : clamp(0.78, t / 820, 1.08);
+    const flameSize = useIcons ? clamp(22, t * 0.03, 42) : clamp(18, t * 0.026, 32);
 
-    container.style.setProperty('--tileIconSizePx', iconSize.toFixed(2) + 'px');
+    container.style.setProperty('--tileIconSizePx', useIcons ? (iconSize.toFixed(2) + 'px') : '0px');
     container.style.setProperty('--tilePadYPx', padY.toFixed(2) + 'px');
     container.style.setProperty('--tilePadXPx', padX.toFixed(2) + 'px');
     container.style.setProperty('--tileGapPx', gap.toFixed(2) + 'px');
@@ -1364,12 +1369,20 @@ function renderStorySlide(story = {}) {
     container.style.setProperty('--tileBadgeOffsetPx', badgeOffset.toFixed(2) + 'px');
     container.style.setProperty('--tileRadiusPx', radius.toFixed(2) + 'px');
     container.style.setProperty('--tileMetaScale', metaScale.toFixed(3));
+    container.style.setProperty('--flameSizePx', flameSize.toFixed(2));
   }
 
   // ---------- Sauna slide ----------
   function renderSauna(name) {
     const hlMap = getHighlightMap();
     const rightUrl = settings?.assets?.rightImages?.[name] || '';
+    const iconsEnabled = settings?.slides?.showIcons !== false;
+    const cardIconMap = (iconsEnabled && settings?.slides?.cardIcons && typeof settings.slides.cardIcons === 'object')
+      ? settings.slides.cardIcons
+      : null;
+    const migrationDone = settings?.slides?.cardIconsMigrated === true;
+    const defaultIconForSauna = (cardIconMap && typeof cardIconMap[name] === 'string') ? cardIconMap[name] : '';
+    const legacyIconFallback = (!migrationDone && iconsEnabled && rightUrl) ? rightUrl : '';
     const headingWrap = h('div', { class: 'headings' }, [
       h('h1', { class: 'h1', style: 'color:var(--saunaColor);' }, name),
       h('h2', { class: 'h2' }, computeH2Text() || '')
@@ -1378,13 +1391,13 @@ function renderStorySlide(story = {}) {
       h('div', { class: 'rightPanel', style: rightUrl ? ('background-image:url(' + JSON.stringify(rightUrl) + ')') : 'display:none;' }),
       headingWrap
     ]);
+    if (iconsEnabled) c.classList.add('has-card-icons'); else c.classList.add('no-card-icons');
 
     const body = h('div', { class: 'body' });
     const list = h('div', { class: 'list' });
 
     const notes = footnoteMap();
     const colIdx = (schedule.saunas || []).indexOf(name);
-    const iconFallback = settings?.slides?.cardIcons?.[name] || rightUrl || '';
     const hiddenSaunas = new Set(settings?.slides?.hiddenSaunas || []);
     const componentFlags = getSlideComponentFlags();
 
@@ -1414,9 +1427,10 @@ function renderStorySlide(story = {}) {
     for (const it of items) {
       const baseTitle = String(it.title).replace(/\*+$/, '');
       const hasStar = /\*$/.test(it.title || '');
-      const tileClass = 'tile'
-        + ((hlMap.bySauna[name] && hlMap.bySauna[name].has(it.time)) ? ' highlight' : '')
-        + ((it.hidden || hiddenSaunas.has(name)) ? ' is-hidden' : '');
+      const tileClasses = ['tile'];
+      if (hlMap.bySauna[name] && hlMap.bySauna[name].has(it.time)) tileClasses.push('highlight');
+      if (it.hidden || hiddenSaunas.has(name)) tileClasses.push('is-hidden');
+      if (!iconsEnabled) tileClasses.push('tile--compact');
 
       const titleNode = h('div', { class: 'title' });
       const timeNode = h('span', { class: 'time' }, it.time + ' Uhr');
@@ -1443,27 +1457,29 @@ function renderStorySlide(story = {}) {
       ], (anyEnabled) => h('div', { class: 'card-empty' }, anyEnabled ? 'Keine Details hinterlegt.' : 'Alle Komponenten deaktiviert.'))
         .forEach(node => contentBlock.appendChild(node));
 
-      const iconUrl = it.icon || iconFallback;
-      const iconBox = h('div', { class: 'card-icon' + (iconUrl ? '' : ' is-empty') });
-      if (iconUrl) {
-        iconBox.appendChild(h('img', { src: iconUrl, alt: '' }));
-      } else {
-        const fallbackLabel = (() => {
-          if (typeof name === 'string') {
-            const trimmed = name.trim();
-            if (trimmed.length >= 2) return trimmed.slice(0, 2);
-            if (trimmed.length === 1) return trimmed;
-          }
-          return '?';
-        })();
-        iconBox.appendChild(h('span', { class: 'card-icon__fallback' }, fallbackLabel));
+      const tileChildren = [];
+      if (iconsEnabled) {
+        const iconUrl = it.icon || defaultIconForSauna || legacyIconFallback || '';
+        const iconBox = h('div', { class: 'card-icon' + (iconUrl ? '' : ' is-empty') });
+        if (iconUrl) {
+          iconBox.appendChild(h('img', { src: iconUrl, alt: '' }));
+        } else {
+          const fallbackLabel = (() => {
+            if (typeof name === 'string') {
+              const trimmed = name.trim();
+              if (trimmed.length >= 2) return trimmed.slice(0, 2);
+              if (trimmed.length === 1) return trimmed;
+            }
+            return '?';
+          })();
+          iconBox.appendChild(h('span', { class: 'card-icon__fallback' }, fallbackLabel));
+        }
+        tileChildren.push(iconBox);
       }
+      tileChildren.push(contentBlock);
+      tileChildren.push(flamesWrap(it.flames));
 
-      const tile = h('div', { class: tileClass, 'data-time': it.time }, [
-        iconBox,
-        contentBlock,
-        flamesWrap(it.flames)
-      ]);
+      const tile = h('div', { class: tileClasses.join(' '), 'data-time': it.time }, tileChildren);
       tile.style.setProperty('--tile-index', String(list.children.length));
 
       if (it.hidden || hiddenSaunas.has(name)) {
@@ -1498,7 +1514,7 @@ function renderStorySlide(story = {}) {
 
     c.appendChild(h('div', { class: 'brand' }, 'Signage'));
 
-    const recalc = () => applyTileSizing(c);
+    const recalc = () => applyTileSizing(c, { useIcons: iconsEnabled });
     setTimeout(recalc, 0);
     onResizeCurrent = recalc;
 


### PR DESCRIPTION
## Summary
- add an admin section to upload or remove per-sauna card icons, control their visibility, and style the new management list
- migrate legacy right-side images into the new icon map by default and persist icon-related defaults in settings
- update slideshow rendering and styles to respect the global icon toggle, use dedicated icons, and fall back to a compact layout when icons are hidden

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce8abc1940832097c6b99c421af1c6