### PR TITLE
Add story sections and gallery support

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -945,6 +945,69 @@ function ensureStorySlides(settings){
     story.intro = typeof story.intro === 'string' ? story.intro : '';
     story.ritual = typeof story.ritual === 'string' ? story.ritual : '';
     story.tips = typeof story.tips === 'string' ? story.tips : '';
+    const normalizeSection = (section = {}, secIdx = 0) => {
+      const src = section && typeof section === 'object' ? section : { text: typeof section === 'string' ? section : '' };
+      const out = { ...src };
+      const legacyImg = (out.image && typeof out.image === 'object') ? out.image : null;
+      if (!out.id) out.id = 'story_sec_' + Math.random().toString(36).slice(2, 9);
+      out.title = typeof out.title === 'string' ? out.title : '';
+      out.text = typeof out.text === 'string'
+        ? out.text
+        : (typeof out.body === 'string' ? out.body : '');
+      out.imageUrl = typeof out.imageUrl === 'string'
+        ? out.imageUrl
+        : (typeof out.mediaUrl === 'string' ? out.mediaUrl
+          : (legacyImg && typeof legacyImg.url === 'string' ? legacyImg.url : (typeof out.image === 'string' ? out.image : '')));
+      out.imageAlt = typeof out.imageAlt === 'string'
+        ? out.imageAlt
+        : (legacyImg && typeof legacyImg.alt === 'string' ? legacyImg.alt : '');
+      out.imageCaption = typeof out.imageCaption === 'string'
+        ? out.imageCaption
+        : (legacyImg && typeof legacyImg.caption === 'string' ? legacyImg.caption : '');
+      const layout = typeof out.layout === 'string' ? out.layout : '';
+      out.layout = ['media-left', 'media-right', 'full'].includes(layout) ? layout : '';
+      delete out.image;
+      delete out.mediaUrl;
+      delete out.body;
+      return out;
+    };
+    const normalizeGalleryItem = (entry = {}, gIdx = 0) => {
+      if (entry && typeof entry === 'string') {
+        return {
+          id: 'story_gal_' + Math.random().toString(36).slice(2, 9),
+          url: entry,
+          alt: '',
+          caption: ''
+        };
+      }
+      const src = entry && typeof entry === 'object' ? entry : {};
+      const out = { ...src };
+      const legacyImg = (out.image && typeof out.image === 'object') ? out.image : null;
+      if (!out.id) out.id = 'story_gal_' + Math.random().toString(36).slice(2, 9);
+      out.url = typeof out.url === 'string'
+        ? out.url
+        : (typeof out.imageUrl === 'string' ? out.imageUrl
+          : (legacyImg && typeof legacyImg.url === 'string' ? legacyImg.url : ''));
+      out.alt = typeof out.alt === 'string'
+        ? out.alt
+        : (typeof out.imageAlt === 'string' ? out.imageAlt
+          : (legacyImg && typeof legacyImg.alt === 'string' ? legacyImg.alt : ''));
+      out.caption = typeof out.caption === 'string'
+        ? out.caption
+        : (typeof out.title === 'string' ? out.title
+          : (legacyImg && typeof legacyImg.caption === 'string' ? legacyImg.caption : ''));
+      delete out.imageUrl;
+      delete out.imageAlt;
+      delete out.title;
+      delete out.image;
+      return out;
+    };
+    story.sections = Array.isArray(story.sections)
+      ? story.sections.map(normalizeSection)
+      : [];
+    story.gallery = Array.isArray(story.gallery)
+      ? story.gallery.map(normalizeGalleryItem)
+      : [];
   });
   settings.slides.storySlides = list;
   return settings.slides.storySlides;
@@ -960,6 +1023,8 @@ function storyDefaults(){
     intro: '',
     ritual: '',
     tips: '',
+    sections: [],
+    gallery: [],
     faq: [],
     enabled: true
   };
@@ -1164,6 +1229,416 @@ function storyEditor(story, idx){
   wrap.appendChild(makeTextarea('Einführung', 'intro', 3, 'Hintergrund & Wirkung'));
   wrap.appendChild(makeTextarea('Ritual', 'ritual', 3, 'Ablauf oder Besonderheiten'));
   wrap.appendChild(makeTextarea('Tipps (je Zeile ein Tipp)', 'tips', 3, 'Tipps oder Hinweise'));
+
+  const sectionsHeader = document.createElement('div');
+  sectionsHeader.className = 'subh';
+  sectionsHeader.textContent = 'Abschnitte';
+  wrap.appendChild(sectionsHeader);
+
+  const sectionsList = document.createElement('div');
+  sectionsList.className = 'story-sections-editor';
+  sectionsList.style.display = 'grid';
+  sectionsList.style.gap = '12px';
+  wrap.appendChild(sectionsList);
+
+  const renderSections = () => {
+    sectionsList.innerHTML = '';
+    const sections = Array.isArray(story.sections) ? story.sections : (story.sections = []);
+    if (!sections.length) {
+      const empty = document.createElement('div');
+      empty.className = 'mut';
+      empty.textContent = 'Noch keine Abschnitte angelegt.';
+      sectionsList.appendChild(empty);
+      return;
+    }
+    sections.forEach((section, sectionIdx) => {
+      const card = document.createElement('div');
+      card.className = 'story-section-card';
+      card.style.display = 'flex';
+      card.style.flexDirection = 'column';
+      card.style.gap = '10px';
+      card.style.padding = '12px';
+      card.style.border = '1px solid rgba(0,0,0,.12)';
+      card.style.borderRadius = '10px';
+
+      const head = document.createElement('div');
+      head.className = 'row story-section-card-head';
+      head.style.alignItems = 'center';
+      head.style.gap = '8px';
+
+      const label = document.createElement('strong');
+      label.className = 'story-section-card-title';
+      label.textContent = section.title?.trim() ? section.title.trim() : `Abschnitt ${sectionIdx + 1}`;
+      head.appendChild(label);
+
+      const controls = document.createElement('div');
+      controls.className = 'row story-section-card-controls';
+      controls.style.gap = '4px';
+
+      const move = (delta) => {
+        const arr = Array.isArray(story.sections) ? story.sections : [];
+        const nextIdx = sectionIdx + delta;
+        if (nextIdx < 0 || nextIdx >= arr.length) return;
+        const [item] = arr.splice(sectionIdx, 1);
+        arr.splice(nextIdx, 0, item);
+        renderSlidesMaster();
+      };
+
+      const makeCtrlBtn = (labelTxt, title) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn sm ghost icon';
+        btn.textContent = labelTxt;
+        btn.title = title;
+        return btn;
+      };
+
+      const upBtn = makeCtrlBtn('↑', 'Nach oben verschieben');
+      upBtn.onclick = () => move(-1);
+      controls.appendChild(upBtn);
+
+      const downBtn = makeCtrlBtn('↓', 'Nach unten verschieben');
+      downBtn.onclick = () => move(1);
+      controls.appendChild(downBtn);
+
+      const delBtn = makeCtrlBtn('✕', 'Abschnitt entfernen');
+      delBtn.onclick = () => {
+        const arr = Array.isArray(story.sections) ? story.sections : [];
+        arr.splice(sectionIdx, 1);
+        renderSlidesMaster();
+      };
+      controls.appendChild(delBtn);
+
+      head.appendChild(controls);
+      card.appendChild(head);
+
+      const titleWrap = document.createElement('div');
+      titleWrap.className = 'kv';
+      const titleLabel = document.createElement('label');
+      titleLabel.textContent = 'Titel';
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'input';
+      titleInput.placeholder = 'Abschnittstitel';
+      titleInput.value = section.title || '';
+      titleInput.onchange = () => { section.title = titleInput.value.trim(); renderSlidesMaster(); };
+      titleWrap.appendChild(titleLabel);
+      titleWrap.appendChild(titleInput);
+      card.appendChild(titleWrap);
+
+      const textWrap = document.createElement('div');
+      textWrap.className = 'kv';
+      const textLabel = document.createElement('label');
+      textLabel.textContent = 'Text';
+      const textArea = document.createElement('textarea');
+      textArea.className = 'input';
+      textArea.rows = 3;
+      textArea.placeholder = 'Abschnittsbeschreibung';
+      textArea.value = section.text || '';
+      textArea.onchange = () => { section.text = textArea.value.trim(); renderSlidesMaster(); };
+      textWrap.appendChild(textLabel);
+      textWrap.appendChild(textArea);
+      card.appendChild(textWrap);
+
+      const mediaRow = document.createElement('div');
+      mediaRow.className = 'row story-section-card-media';
+      mediaRow.style.gap = '12px';
+      mediaRow.style.flexWrap = 'wrap';
+      mediaRow.style.alignItems = 'center';
+
+      const preview = document.createElement('img');
+      preview.className = 'story-section-card-preview';
+      preview.style.width = '140px';
+      preview.style.height = '100px';
+      preview.style.objectFit = 'cover';
+      preview.style.borderRadius = '8px';
+      preview.style.boxShadow = 'inset 0 0 0 1px rgba(0,0,0,.12)';
+
+      const updatePreview = () => {
+        if (section.imageUrl) {
+          preview.src = section.imageUrl;
+          preview.title = stripCacheSimple(section.imageUrl);
+        } else {
+          preview.src = FALLBACK_HERO;
+          preview.title = 'Kein Bild ausgewählt';
+        }
+      };
+      updatePreview();
+
+      const mediaBtns = document.createElement('div');
+      mediaBtns.className = 'row';
+      mediaBtns.style.gap = '6px';
+
+      const uploadBtn = document.createElement('button');
+      uploadBtn.type = 'button';
+      uploadBtn.className = 'btn sm ghost';
+      uploadBtn.textContent = 'Bild hochladen';
+      uploadBtn.onclick = () => {
+        const fi = document.createElement('input');
+        fi.type = 'file';
+        fi.accept = 'image/*';
+        fi.onchange = () => uploadGeneric(fi, (url) => {
+          const clean = stripCacheSimple(url || '');
+          section.imageUrl = clean
+            ? clean + (clean.includes('?') ? '&' : '?') + 'v=' + Date.now()
+            : '';
+          renderSlidesMaster();
+        });
+        fi.click();
+      };
+      mediaBtns.appendChild(uploadBtn);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'btn sm ghost';
+      removeBtn.textContent = 'Bild entfernen';
+      removeBtn.onclick = () => { section.imageUrl = ''; renderSlidesMaster(); };
+      mediaBtns.appendChild(removeBtn);
+
+      mediaRow.appendChild(preview);
+      mediaRow.appendChild(mediaBtns);
+      card.appendChild(mediaRow);
+
+      const altWrap = document.createElement('div');
+      altWrap.className = 'kv';
+      const altLabel = document.createElement('label');
+      altLabel.textContent = 'Bildbeschreibung (Alt-Text)';
+      const altInput = document.createElement('input');
+      altInput.type = 'text';
+      altInput.className = 'input';
+      altInput.placeholder = 'Optional für Screenreader';
+      altInput.value = section.imageAlt || '';
+      altInput.onchange = () => { section.imageAlt = altInput.value.trim(); renderSlidesMaster(); };
+      altWrap.appendChild(altLabel);
+      altWrap.appendChild(altInput);
+      card.appendChild(altWrap);
+
+      const captionWrap = document.createElement('div');
+      captionWrap.className = 'kv';
+      const captionLabel = document.createElement('label');
+      captionLabel.textContent = 'Bildunterschrift (optional)';
+      const captionInput = document.createElement('input');
+      captionInput.type = 'text';
+      captionInput.className = 'input';
+      captionInput.placeholder = 'Kurze Bildbeschreibung';
+      captionInput.value = section.imageCaption || '';
+      captionInput.onchange = () => { section.imageCaption = captionInput.value.trim(); renderSlidesMaster(); };
+      captionWrap.appendChild(captionLabel);
+      captionWrap.appendChild(captionInput);
+      card.appendChild(captionWrap);
+
+      sectionsList.appendChild(card);
+    });
+  };
+  renderSections();
+
+  const addSectionBtn = document.createElement('button');
+  addSectionBtn.type = 'button';
+  addSectionBtn.className = 'btn sm ghost';
+  addSectionBtn.textContent = 'Abschnitt hinzufügen';
+  addSectionBtn.onclick = () => {
+    (story.sections ||= []).push({
+      id: 'story_sec_' + Math.random().toString(36).slice(2, 9),
+      title: '',
+      text: '',
+      imageUrl: '',
+      imageAlt: '',
+      imageCaption: ''
+    });
+    renderSlidesMaster();
+  };
+  wrap.appendChild(addSectionBtn);
+
+  const galleryHeader = document.createElement('div');
+  galleryHeader.className = 'subh';
+  galleryHeader.textContent = 'Galerie';
+  wrap.appendChild(galleryHeader);
+
+  const galleryList = document.createElement('div');
+  galleryList.className = 'story-gallery-editor';
+  galleryList.style.display = 'grid';
+  galleryList.style.gap = '12px';
+  wrap.appendChild(galleryList);
+
+  const renderGallery = () => {
+    galleryList.innerHTML = '';
+    const gallery = Array.isArray(story.gallery) ? story.gallery : (story.gallery = []);
+    if (!gallery.length) {
+      const empty = document.createElement('div');
+      empty.className = 'mut';
+      empty.textContent = 'Noch keine Galerie-Bilder.';
+      galleryList.appendChild(empty);
+      return;
+    }
+    gallery.forEach((entry, gIdx) => {
+      const row = document.createElement('div');
+      row.className = 'story-gallery-card';
+      row.style.display = 'flex';
+      row.style.flexDirection = 'column';
+      row.style.gap = '10px';
+      row.style.padding = '12px';
+      row.style.border = '1px solid rgba(0,0,0,.12)';
+      row.style.borderRadius = '10px';
+
+      const head = document.createElement('div');
+      head.className = 'row story-gallery-card-head';
+      head.style.gap = '8px';
+      head.style.alignItems = 'center';
+
+      const label = document.createElement('strong');
+      label.textContent = entry.caption?.trim() || `Bild ${gIdx + 1}`;
+      head.appendChild(label);
+
+      const controls = document.createElement('div');
+      controls.className = 'row';
+      controls.style.gap = '4px';
+
+      const move = (delta) => {
+        const arr = Array.isArray(story.gallery) ? story.gallery : [];
+        const nextIdx = gIdx + delta;
+        if (nextIdx < 0 || nextIdx >= arr.length) return;
+        const [item] = arr.splice(gIdx, 1);
+        arr.splice(nextIdx, 0, item);
+        renderSlidesMaster();
+      };
+
+      const up = document.createElement('button');
+      up.type = 'button';
+      up.className = 'btn sm ghost icon';
+      up.textContent = '↑';
+      up.title = 'Nach oben verschieben';
+      up.onclick = () => move(-1);
+      controls.appendChild(up);
+
+      const down = document.createElement('button');
+      down.type = 'button';
+      down.className = 'btn sm ghost icon';
+      down.textContent = '↓';
+      down.title = 'Nach unten verschieben';
+      down.onclick = () => move(1);
+      controls.appendChild(down);
+
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'btn sm ghost icon';
+      remove.textContent = '✕';
+      remove.title = 'Bild entfernen';
+      remove.onclick = () => {
+        const arr = Array.isArray(story.gallery) ? story.gallery : [];
+        arr.splice(gIdx, 1);
+        renderSlidesMaster();
+      };
+      controls.appendChild(remove);
+
+      head.appendChild(controls);
+      row.appendChild(head);
+
+      const mediaRow = document.createElement('div');
+      mediaRow.className = 'row story-gallery-card-media';
+      mediaRow.style.gap = '12px';
+      mediaRow.style.flexWrap = 'wrap';
+      mediaRow.style.alignItems = 'center';
+
+      const preview = document.createElement('img');
+      preview.className = 'story-gallery-card-preview';
+      preview.style.width = '140px';
+      preview.style.height = '100px';
+      preview.style.objectFit = 'cover';
+      preview.style.borderRadius = '8px';
+      preview.style.boxShadow = 'inset 0 0 0 1px rgba(0,0,0,.12)';
+
+      const updatePreview = () => {
+        if (entry.url) {
+          preview.src = entry.url;
+          preview.title = stripCacheSimple(entry.url);
+        } else {
+          preview.src = FALLBACK_HERO;
+          preview.title = 'Kein Bild ausgewählt';
+        }
+      };
+      updatePreview();
+
+      const mediaBtns = document.createElement('div');
+      mediaBtns.className = 'row';
+      mediaBtns.style.gap = '6px';
+
+      const upload = document.createElement('button');
+      upload.type = 'button';
+      upload.className = 'btn sm ghost';
+      upload.textContent = 'Bild hochladen';
+      upload.onclick = () => {
+        const fi = document.createElement('input');
+        fi.type = 'file';
+        fi.accept = 'image/*';
+        fi.onchange = () => uploadGeneric(fi, (url) => {
+          const clean = stripCacheSimple(url || '');
+          entry.url = clean
+            ? clean + (clean.includes('?') ? '&' : '?') + 'v=' + Date.now()
+            : '';
+          renderSlidesMaster();
+        });
+        fi.click();
+      };
+      mediaBtns.appendChild(upload);
+
+      const clear = document.createElement('button');
+      clear.type = 'button';
+      clear.className = 'btn sm ghost';
+      clear.textContent = 'Bild entfernen';
+      clear.onclick = () => { entry.url = ''; renderSlidesMaster(); };
+      mediaBtns.appendChild(clear);
+
+      mediaRow.appendChild(preview);
+      mediaRow.appendChild(mediaBtns);
+      row.appendChild(mediaRow);
+
+      const altWrap = document.createElement('div');
+      altWrap.className = 'kv';
+      const altLabel = document.createElement('label');
+      altLabel.textContent = 'Bildbeschreibung (Alt-Text)';
+      const altInput = document.createElement('input');
+      altInput.type = 'text';
+      altInput.className = 'input';
+      altInput.placeholder = 'Optional für Screenreader';
+      altInput.value = entry.alt || '';
+      altInput.onchange = () => { entry.alt = altInput.value.trim(); renderSlidesMaster(); };
+      altWrap.appendChild(altLabel);
+      altWrap.appendChild(altInput);
+      row.appendChild(altWrap);
+
+      const captionWrap = document.createElement('div');
+      captionWrap.className = 'kv';
+      const captionLabel = document.createElement('label');
+      captionLabel.textContent = 'Bildunterschrift (optional)';
+      const captionInput = document.createElement('input');
+      captionInput.type = 'text';
+      captionInput.className = 'input';
+      captionInput.placeholder = 'Kurzbeschreibung';
+      captionInput.value = entry.caption || '';
+      captionInput.onchange = () => { entry.caption = captionInput.value.trim(); renderSlidesMaster(); };
+      captionWrap.appendChild(captionLabel);
+      captionWrap.appendChild(captionInput);
+      row.appendChild(captionWrap);
+
+      galleryList.appendChild(row);
+    });
+  };
+  renderGallery();
+
+  const addGalleryBtn = document.createElement('button');
+  addGalleryBtn.type = 'button';
+  addGalleryBtn.className = 'btn sm ghost';
+  addGalleryBtn.textContent = 'Galerie-Bild hinzufügen';
+  addGalleryBtn.onclick = () => {
+    (story.gallery ||= []).push({
+      id: 'story_gal_' + Math.random().toString(36).slice(2, 9),
+      url: '',
+      alt: '',
+      caption: ''
+    });
+    renderSlidesMaster();
+  };
+  wrap.appendChild(addGalleryBtn);
 
   const faqHeader = document.createElement('div');
   faqHeader.className = 'subh';

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -488,6 +488,24 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 .story-slide .story-subtitle{margin:0; opacity:.85; font-size:calc(24px*var(--scale));}
 .story-slide .story-section{display:flex; flex-direction:column; gap:calc(10px*var(--scale));}
 .story-slide .story-section-title{margin:0; font-size:calc(30px*var(--scale)); font-weight:700; letter-spacing:.01em;}
+.story-slide .story-section-content{display:flex; flex-direction:column; gap:calc(10px*var(--scale));}
+.story-slide .story-section-rich{display:flex; flex-direction:column; gap:calc(12px*var(--scale));}
+.story-slide .story-section-rich.has-media{display:grid; align-items:start; gap:calc(14px*var(--scale));}
+.story-slide .story-section-rich.has-media.layout-media-left{grid-template-columns:clamp(180px, 32%, 320px) minmax(0,1fr);}
+.story-slide .story-section-rich.has-media.layout-media-right{grid-template-columns:minmax(0,1fr) clamp(180px, 32%, 320px);}
+.story-slide .story-section-rich.has-media.layout-full{grid-template-columns:minmax(0,1fr);}
+.story-slide .story-section-media{margin:0; border-radius:24px; overflow:hidden; background:rgba(0,0,0,.08); display:flex; flex-direction:column;}
+.story-slide .story-section-media img{width:100%; height:100%; object-fit:cover; display:block;}
+.story-slide .story-section-media figcaption{margin:0; padding:.6em .8em; font-size:calc(18px*var(--scale)); opacity:.8;}
+.story-slide .story-section-media-fallback{padding:1.2em; text-align:center; font-size:calc(18px*var(--scale)); opacity:.75;}
+.story-slide .story-section-media.is-error{justify-content:center; align-items:center;}
+.story-slide .story-gallery{display:flex; flex-direction:column; gap:calc(12px*var(--scale));}
+.story-slide .story-gallery-grid{display:grid; gap:calc(12px*var(--scale)); grid-template-columns:repeat(auto-fit, minmax(160px, 1fr));}
+.story-slide .story-gallery-item{margin:0; border-radius:22px; overflow:hidden; background:rgba(0,0,0,.08); display:flex; flex-direction:column;}
+.story-slide .story-gallery-item img{width:100%; height:100%; object-fit:cover; display:block;}
+.story-slide .story-gallery-item figcaption{margin:0; padding:.6em .8em; font-size:calc(18px*var(--scale)); opacity:.8;}
+.story-slide .story-gallery-item.is-error{justify-content:center; align-items:center; padding:1.2em; font-size:calc(18px*var(--scale)); text-align:center;}
+.story-slide .story-gallery-fallback{padding:1.2em; font-size:calc(18px*var(--scale)); opacity:.75; text-align:center;}
 .story-slide .story-paragraph{margin:0; font-size:calc(22px*var(--scale)); line-height:1.45; opacity:.95;}
 .story-slide .story-tip-list{margin:0; padding-left:1.2em; font-size:calc(22px*var(--scale)); line-height:1.45; display:flex; flex-direction:column; gap:.4em;}
 .story-slide .story-tip-list li{position:relative;}
@@ -520,4 +538,5 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
   .story-slide{padding-right:24px;}
   .story-slide .story-hero{width:100%; min-height:260px;}
   .story-slide .story-title{font-size:calc(54px*var(--scale));}
+  .story-slide .story-section-rich.has-media{grid-template-columns:minmax(0,1fr);}
 }


### PR DESCRIPTION
## Summary
- extend story normalization and defaults to include structured sections and gallery images
- add admin editor controls to manage story sections and gallery entries with upload, ordering, and removal
- render new sections and gallery content in the player and style them for the slideshow layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce8dcaf17c83208ff94832d32381d3