### PR TITLE
Refactor badge management and dialog

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -877,6 +877,52 @@ body.mode-uniform #ovSec{ display:none !important; }
 .color-item input[type="color"]::-webkit-color-swatch{ border:0; border-radius:6px; }
 .swatch{ width:24px; height:24px; border-radius:6px; border:1px solid var(--inbr); }
 
+/* ---------- Badge-Auswahl & Bibliothek ---------- */
+.badge-picker{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  padding:4px 0;
+}
+.badge-choice{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:4px 10px;
+  border-radius:999px;
+  border:1px solid var(--ghost-border);
+  background:var(--panel);
+  cursor:pointer;
+  font-size:13px;
+  transition:border-color .15s, background .15s;
+}
+.badge-choice:focus-within{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+.badge-choice input{
+  margin:0;
+}
+.badge-choice-icon{ font-size:16px; }
+.badge-choice-label{ font-weight:600; }
+.badge-choice.is-checked{
+  border-color:var(--btn-primary);
+  background:color-mix(in oklab, var(--btn-primary) 14%, var(--panel));
+  color:var(--btn-primary);
+}
+.badge-choice.has-icon .badge-choice-label{ font-weight:500; }
+.badge-choice-missing{ margin-top:4px; font-size:12px; }
+
+.badge-library-list .badge-lib-row + .badge-lib-row{ margin-top:8px; }
+.badge-lib-fields{
+  display:flex;
+  gap:8px;
+  align-items:center;
+  flex-wrap:wrap;
+}
+.badge-lib-icon{ width:7ch; }
+.badge-lib-label{ flex:1; min-width:0; }
+
 /* ---------- Footer ---------- */
 footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1px solid var(--border); color:var(--muted); }
 

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -210,7 +210,19 @@
   </div>
 </details>
 
-    <!-- Unterbox 3: Story-Slides -->
+<!-- Unterbox 3: Badges -->
+<details class="ac sub" id="boxBadges">
+  <summary>
+    <div class="ttl">▶<span class="chev">⮞</span> Badges</div>
+    <div class="actions"><button class="btn sm" id="badgeAdd">Hinzufügen</button></div>
+  </summary>
+  <div class="content">
+    <div id="badgeLibraryList" class="badge-library-list"></div>
+    <div class="help">Verwalte Icon und Label der auswählbaren Badges für Aufgüsse.</div>
+  </div>
+</details>
+
+    <!-- Unterbox 4: Story-Slides -->
     <details class="ac sub" id="boxStories">
       <summary>
         <div class="ttl">▶<span class="chev">⮞</span> Saunen & Aufgüsse erklärt</div>
@@ -319,19 +331,8 @@
           <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
           <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
           <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
-          <div class="kv"><label>Aromen im Schrägschnitt</label><input id="aromaItalic" type="checkbox"></div>
-          <div class="kv"><label>Aufguss-Badge</label>
-            <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
-              <select id="badgeIcon" class="input">
-                <option value="">Ohne Icon</option>
-                <option value="🌿">🌿 Blatt</option>
-                <option value="💧">💧 Tropfen</option>
-                <option value="🔥">🔥 Flamme</option>
-                <option value="⭐">⭐ Stern</option>
-                <option value="ℹ️">ℹ️ Info</option>
-              </select>
-              <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
-            </div>
+          <div class="kv"><label>Badge-Farbe</label>
+            <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
           </div>
           <div class="kv">
             <label>Komponenten auf Slides</label>
@@ -528,12 +529,8 @@
         </div>
         <label>Beschreibung</label>
         <textarea id="m_description" class="input" rows="3" placeholder="Kurze Beschreibung oder Ritual"></textarea>
-        <label>Aromen</label>
-        <textarea id="m_aromas" class="input" rows="2" placeholder="Eine Zeile pro Aroma"></textarea>
-        <label>Fakten / Chips</label>
-        <textarea id="m_facts" class="input" rows="2" placeholder="Eine Zeile pro Fakt"></textarea>
-        <label>Aufgussart-Badge</label>
-        <input id="m_type" class="input" type="text" placeholder="z.B. Klassisch">
+        <label>Badges</label>
+        <div id="m_badgeList" class="badge-picker"></div>
       </div>
       <div class="row" style="justify-content:flex-end;margin-top:14px">
         <button class="btn" id="m_cancel">Abbrechen</button>

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -31,6 +31,12 @@ const DEFAULT_ENABLED_COMPONENTS = {
   badges:true
 };
 
+const DEFAULT_BADGE_LIBRARY = [
+  { id:'bdg_classic', icon:'🌿', label:'Klassisch' },
+  { id:'bdg_event', icon:'⭐', label:'Event' },
+  { id:'bdg_ritual', icon:'🔥', label:'Ritual' }
+];
+
 const DEFAULT_STYLE_SETS = {
   classic:{
     label:'Klassisch',
@@ -45,9 +51,8 @@ const DEFAULT_STYLE_SETS = {
       flameGapScale:DEFAULT_FONTS.flameGapScale
     },
     slides:{
-      aromaItalic:false,
       infobadgeColor:'#5C3101',
-      infobadgeIcon:'ℹ️'
+      badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY))
     }
   },
   fresh:{
@@ -76,9 +81,8 @@ const DEFAULT_STYLE_SETS = {
       flameGapScale:0.16
     },
     slides:{
-      aromaItalic:true,
       infobadgeColor:'#4EA8DE',
-      infobadgeIcon:'🌿'
+      badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY))
     }
   }
 };
@@ -91,9 +95,8 @@ export const DEFAULTS = {
     tileWidthPercent:45,
     tileMinScale:0.25,
     tileMaxScale:0.57,
-    aromaItalic:false,
     infobadgeColor:'#5C3101',
-    infobadgeIcon:'ℹ️',
+    badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
     showIcons:true,
     cardIcons:{},
     cardIconsMigrated:true,

--- a/webroot/admin/js/core/utils.js
+++ b/webroot/admin/js/core/utils.js
@@ -20,7 +20,7 @@ export const parseTime = (s) => {
 };
 
 // kurze IDs für Fußnoten etc.
-export const genId = () => 'fn_' + Math.random().toString(36).slice(2, 9);
+export const genId = (prefix = 'fn_') => String(prefix ?? 'fn_') + Math.random().toString(36).slice(2, 9);
 
 // HTML escapen für Option-Labels etc.
 export function escapeHtml(str) {

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -43,9 +43,12 @@
     "tileWidthPercent": 45,
     "tileMinScale": 0.25,
     "tileMaxScale": 0.57,
-    "aromaItalic": false,
     "infobadgeColor": "#5C3101",
-    "infobadgeIcon": "ℹ️",
+    "badgeLibrary": [
+      { "id": "bdg_classic", "icon": "🌿", "label": "Klassisch" },
+      { "id": "bdg_event", "icon": "⭐", "label": "Event" },
+      { "id": "bdg_ritual", "icon": "🔥", "label": "Ritual" }
+    ],
     "loop": true,
     "waitForVideo": false,
     "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"],
@@ -93,9 +96,12 @@
           "flameGapScale": 0.14
         },
         "slides": {
-          "aromaItalic": false,
           "infobadgeColor": "#5C3101",
-          "infobadgeIcon": "ℹ️"
+          "badgeLibrary": [
+            { "id": "bdg_classic", "icon": "🌿", "label": "Klassisch" },
+            { "id": "bdg_event", "icon": "⭐", "label": "Event" },
+            { "id": "bdg_ritual", "icon": "🔥", "label": "Ritual" }
+          ]
         }
       },
       "fresh": {
@@ -135,9 +141,12 @@
           "flameGapScale": 0.16
         },
         "slides": {
-          "aromaItalic": true,
           "infobadgeColor": "#4EA8DE",
-          "infobadgeIcon": "🌿"
+          "badgeLibrary": [
+            { "id": "bdg_classic", "icon": "🌿", "label": "Klassisch" },
+            { "id": "bdg_event", "icon": "⭐", "label": "Event" },
+            { "id": "bdg_ritual", "icon": "🔥", "label": "Ritual" }
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary
- replace the aroma/facts fields in the schedule dialog with a badge picker and style it along with a new badge library section in the admin UI
- wire grid handling, settings sanitization, and defaults to manage a reusable `badgeLibrary`, and expose badge editing controls in the Slides master view
- update the slideshow renderer to resolve badge selections via the library so multiple badges and icons render correctly

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cebd8277648320849bd5305becd9ff