### PR TITLE
Add card icon toggle persistence

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -2212,6 +2212,15 @@ export function renderSlidesMaster(){
   maybeMigrateCardIcons(settings);
   const showIcons = settings.slides?.showIcons !== false;
 
+  const iconToggle = $('#toggleCardIcons');
+  if (iconToggle instanceof HTMLInputElement){
+    iconToggle.checked = showIcons;
+    iconToggle.onchange = () => {
+      (settings.slides ||= {}).showIcons = !!iconToggle.checked;
+      if (typeof window.dockPushDebounced === 'function') window.dockPushDebounced();
+    };
+  }
+
   // Transition
   const transEl = $('#transMs2');
   if (transEl){


### PR DESCRIPTION
## Summary
- wire the card icon toggle in the slides master view to the slides.showIcons flag
- persist the toggle through the existing debounced dock push when the checkbox changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec2d8ed548320a8b90f642aeca8d2