### PR TITLE
Convert sauna icon settings into collapsible panel

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -250,6 +250,7 @@ body.devices-pinned #devicesPane{ position:sticky; top:0; z-index:40; }
   background:var(--panel); border:1px solid var(--border);
   border-radius:16px; box-shadow:0 8px 20px rgba(0,0,0,.06);
 }
+.content > details.ac.sub{ margin-top:12px; }
 .card .content, .content{ padding:12px 14px; }
 summary{
   list-style:none; cursor:pointer; display:flex; align-items:center;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -176,15 +176,20 @@
 	<div class="subh" id="extraTitle" style="display:none">Heute kein Aufguss</div>
         <div id="extraSaunaList"></div>
 
-        <div class="fieldset" id="saunaIconFieldset">
-          <div class="legend">Karten-Icons</div>
-          <div class="kv">
-            <label>Icons anzeigen</label>
-            <input id="toggleCardIcons" type="checkbox">
+        <details class="ac sub" id="boxSaunaIcons" open>
+          <summary>
+            <div class="ttl">▶<span class="chev">⮞</span> Karten-Icons</div>
+            <div class="actions"></div>
+          </summary>
+          <div class="content">
+            <div class="kv">
+              <label>Icons anzeigen</label>
+              <input id="toggleCardIcons" type="checkbox">
+            </div>
+            <div class="help">Optionales Icon pro Sauna für die Kartenansicht. Ohne Icon wird automatisch eine Initiale angezeigt.</div>
+            <div id="saunaIconList" class="icon-config-list"></div>
           </div>
-          <div class="help">Optionales Icon pro Sauna für die Kartenansicht. Ohne Icon wird automatisch eine Initiale angezeigt.</div>
-          <div id="saunaIconList" class="icon-config-list"></div>
-        </div>
+        </details>
 
         <div class="help" style="margin-top:6px">* Dauer nur sichtbar, wenn „Individuell“ gewählt ist.</div>
       </div>

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -2209,14 +2209,26 @@ export function renderSlidesMaster(){
   ensureStorySlides(settings);
   const styleSets = ensureStyleSets(settings);
   const componentFlags = ensureEnabledComponents(settings);
-  maybeMigrateCardIcons(settings);
+  const cardIconMap = maybeMigrateCardIcons(settings) || {};
   const showIcons = settings.slides?.showIcons !== false;
+
+  const iconSection = $('#boxSaunaIcons');
+  if (iconSection instanceof HTMLDetailsElement){
+    if (!iconSection.dataset.initOpen){
+      const shouldOpen = showIcons || Object.keys(cardIconMap).length > 0;
+      iconSection.open = shouldOpen;
+      iconSection.dataset.initOpen = '1';
+    }
+  }
 
   const iconToggle = $('#toggleCardIcons');
   if (iconToggle instanceof HTMLInputElement){
     iconToggle.checked = showIcons;
     iconToggle.onchange = () => {
       (settings.slides ||= {}).showIcons = !!iconToggle.checked;
+      if (iconSection instanceof HTMLDetailsElement && iconToggle.checked){
+        iconSection.open = true;
+      }
       if (typeof window.dockPushDebounced === 'function') window.dockPushDebounced();
     };
   }


### PR DESCRIPTION
## Summary
- wrap the sauna icon configuration in an accordion-style details element with summary/actions content
- update renderSlidesMaster to locate handlers in the new markup and manage the initial open state
- tweak admin CSS to space nested accordion sections consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec83a3120832085264ed06854b4ae