### PR TITLE
Refine badge library editor and remove sauna card icons

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -650,6 +650,33 @@ body.device-mode .toggle.ind-active input:checked ~ .moon{ color:var(--btn-prima
   align-items:center;
   gap:6px;
 }
+.ctx-badge-media{
+  display:none;
+  align-items:center;
+  justify-content:center;
+  width:26px;
+  height:26px;
+  border-radius:50%;
+  background:color-mix(in oklab, var(--btn-accent-fg) 12%, transparent);
+  color:var(--btn-accent-fg);
+  overflow:hidden;
+  box-shadow:0 4px 8px rgba(0,0,0,.12);
+}
+.ctx-badge.has-media .ctx-badge-media{ display:inline-flex; }
+.ctx-badge-media-image{
+  width:26px;
+  height:26px;
+  object-fit:cover;
+  border-radius:inherit;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 50%, transparent);
+  background:var(--btn-accent-fg);
+}
+.ctx-badge-media-image[hidden]{ display:none; }
+.ctx-badge-media-icon{
+  font-size:16px;
+  line-height:1;
+}
+.ctx-badge-media-icon[hidden]{ display:none; }
 .ctx-badge-close{
   appearance:none;
   margin:0;
@@ -816,39 +843,6 @@ body.mode-uniform #ovSec{ display:none !important; }
 .saunarow .namewrap{ display:flex; flex-direction:column; gap:6px; }
 .saunarow .tag{ display:inline-block; margin-left:6px; padding:2px 6px; border:1px solid var(--inbr); border-radius:8px; font-size:11px; opacity:.8; }
 
-.icon-config-list{ display:flex; flex-direction:column; gap:8px; }
-.iconrow{
-  display:grid;
-  grid-template-columns:minmax(0,1fr) max-content max-content;
-  gap:12px;
-  align-items:center;
-  padding:4px 0;
-}
-.iconrow + .iconrow{
-  border-top:1px solid var(--ghost-border);
-  margin-top:8px;
-  padding-top:8px;
-}
-.iconrow-name{ font-weight:600; }
-.iconrow-preview{
-  width:56px;
-  height:56px;
-  display:grid;
-  place-items:center;
-  border:1px solid var(--inbr);
-  border-radius:12px;
-  background:var(--panel);
-  overflow:hidden;
-}
-.iconrow-preview img{ width:100%; height:100%; object-fit:contain; }
-.iconrow-placeholder{
-  font-weight:700;
-  letter-spacing:.08em;
-  opacity:.65;
-}
-.iconrow-actions{ display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end; }
-.iconrow.has-suggestion:not(.has-icon) .iconrow-preview{ border-style:dashed; opacity:.8; }
-.iconrow-note{ grid-column:1 / -1; font-size:12px; opacity:.7; }
 
 /* DnD Feedback */
 .sauna-bucket{ border:1px dashed var(--inbr); border-radius:12px; padding:8px; margin-top:6px; }
@@ -946,7 +940,7 @@ body.mode-uniform #ovSec{ display:none !important; }
 .badge-library-list{
   display:flex;
   flex-direction:column;
-  gap:10px;
+  gap:8px;
 }
 .badge-lib-section:not(.has-items) .badge-library-list{ gap:6px; }
 .badge-lib-row{
@@ -956,7 +950,7 @@ body.mode-uniform #ovSec{ display:none !important; }
   padding:10px 12px;
   border-radius:12px;
   border:1px solid var(--inbr);
-  background:color-mix(in oklab, var(--panel) 90%, var(--btn-accent) 10%);
+  background:color-mix(in oklab, var(--panel) 92%, var(--btn-accent) 8%);
   transition:border-color .18s ease, background .18s ease, box-shadow .18s ease;
 }
 .badge-lib-row:hover{
@@ -973,7 +967,7 @@ body.mode-uniform #ovSec{ display:none !important; }
 .badge-lib-chip{
   display:inline-flex;
   align-items:center;
-  gap:6px;
+  gap:8px;
   padding:4px 10px;
   border-radius:999px;
   background:var(--panel);
@@ -983,6 +977,28 @@ body.mode-uniform #ovSec{ display:none !important; }
   transition:background .18s ease, color .18s ease;
 }
 .badge-lib-row.has-icon .badge-lib-chip{ font-weight:500; }
+.badge-lib-row.has-image .badge-lib-chip{ gap:6px; }
+.badge-lib-chip-media{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:28px;
+  height:28px;
+  border-radius:999px;
+  background:color-mix(in oklab, var(--btn-accent) 16%, var(--panel) 84%);
+  color:var(--btn-accent);
+  overflow:hidden;
+}
+.badge-lib-row.has-image .badge-lib-chip-media{ background:none; padding:0; }
+.badge-lib-chip-image{
+  width:28px;
+  height:28px;
+  border-radius:999px;
+  object-fit:cover;
+  border:1px solid var(--ghost-border);
+  background:var(--panel);
+}
+.badge-lib-chip-image[hidden]{ display:none; }
 .badge-lib-chip-icon{ font-size:17px; }
 .badge-lib-chip-icon[hidden]{ display:none; }
 .badge-lib-chip-label{
@@ -998,13 +1014,74 @@ body.mode-uniform #ovSec{ display:none !important; }
 }
 .badge-lib-edit{
   display:flex;
-  align-items:center;
+  flex-direction:column;
+  gap:10px;
+}
+.badge-lib-fields{
+  display:grid;
   gap:8px;
+}
+.badge-lib-fields-main{
+  grid-template-columns: minmax(160px, 1.4fr) minmax(90px, .8fr) minmax(140px, 1fr);
+}
+.badge-lib-fields-secondary{
+  grid-template-columns: minmax(220px, 1fr);
+}
+.badge-lib-field{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.badge-lib-field-label{
+  font-size:11px;
+  font-weight:600;
+  letter-spacing:.04em;
+  text-transform:uppercase;
+  color:var(--muted);
+}
+.badge-lib-input,
+.badge-lib-select{
+  font-size:13px;
+  padding:6px 8px;
+  border-radius:8px;
+}
+.badge-lib-select{
+  border:1px solid var(--ghost-border);
+  background:var(--panel);
+  color:var(--fg);
+}
+.badge-lib-upload{
+  display:flex;
+  align-items:center;
+  gap:10px;
   flex-wrap:wrap;
 }
-.badge-lib-icon{ width:7ch; }
-.badge-lib-label{ flex:1; min-width:0; }
-.badge-lib-remove{ padding-inline:8px; }
+.badge-lib-upload-preview{
+  width:48px;
+  height:48px;
+  border-radius:12px;
+  object-fit:cover;
+  border:1px solid var(--ghost-border);
+  background:var(--panel);
+}
+.badge-lib-upload-preview[hidden]{ display:none; }
+.badge-lib-upload-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+}
+.badge-lib-action{
+  font-size:12px;
+  padding:4px 10px;
+}
+.badge-lib-actions{
+  display:flex;
+  justify-content:flex-end;
+}
+.badge-lib-remove{
+  font-size:12px;
+  padding:4px 12px;
+}
 
 .badge-picker{
   position:relative;
@@ -1062,7 +1139,7 @@ body.mode-uniform #ovSec{ display:none !important; }
 .badge-picker-chip{
   display:inline-flex;
   align-items:center;
-  gap:4px;
+  gap:6px;
   padding:4px 8px;
   border-radius:999px;
   background:color-mix(in oklab, var(--btn-primary) 14%, var(--panel));
@@ -1070,7 +1147,28 @@ body.mode-uniform #ovSec{ display:none !important; }
   font-size:12px;
   font-weight:600;
 }
+.badge-picker-chip-media{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:24px;
+  height:24px;
+  border-radius:50%;
+  background:color-mix(in oklab, var(--btn-primary) 16%, var(--panel) 84%);
+  color:var(--btn-primary);
+  overflow:hidden;
+}
+.badge-picker-chip-image{
+  width:24px;
+  height:24px;
+  object-fit:cover;
+  border-radius:inherit;
+  border:1px solid color-mix(in oklab, var(--btn-primary) 50%, transparent);
+  background:var(--panel);
+}
+.badge-picker-chip-image[hidden]{ display:none; }
 .badge-picker-chip-icon{ font-size:15px; }
+.badge-picker-chip-icon[hidden]{ display:none; }
 .badge-picker-placeholder{ font-size:12px; color:var(--muted); }
 .badge-picker-popup{
   position:absolute;
@@ -1116,7 +1214,27 @@ body.mode-uniform #ovSec{ display:none !important; }
   background:color-mix(in oklab, var(--btn-accent) 12%, transparent);
 }
 .badge-picker-option input{ margin:0; }
+.badge-picker-option-media{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:28px;
+  height:28px;
+  border-radius:50%;
+  background:color-mix(in oklab, var(--btn-primary) 10%, var(--panel));
+  overflow:hidden;
+}
+.badge-picker-option-image{
+  width:28px;
+  height:28px;
+  object-fit:cover;
+  border-radius:inherit;
+  border:1px solid color-mix(in oklab, var(--btn-primary) 40%, transparent);
+  background:var(--panel);
+}
+.badge-picker-option-image[hidden]{ display:none; }
 .badge-picker-option-icon{ font-size:16px; }
+.badge-picker-option-icon[hidden]{ display:none; }
 .badge-picker-option-label{ flex:1; font-size:13px; }
 .badge-picker-option.is-checked{
   background:color-mix(in oklab, var(--btn-primary) 18%, var(--panel));

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -176,21 +176,6 @@
 	<div class="subh" id="extraTitle" style="display:none">Heute kein Aufguss</div>
         <div id="extraSaunaList"></div>
 
-        <details class="ac sub" id="boxSaunaIcons" open>
-          <summary>
-            <div class="ttl">▶<span class="chev">⮞</span> Karten-Icons</div>
-            <div class="actions"></div>
-          </summary>
-          <div class="content">
-            <div class="kv">
-              <label>Icons anzeigen</label>
-              <input id="toggleCardIcons" type="checkbox">
-            </div>
-            <div class="help">Optionales Icon pro Sauna für die Kartenansicht. Ohne Icon wird automatisch eine Initiale angezeigt.</div>
-            <div id="saunaIconList" class="icon-config-list"></div>
-          </div>
-        </details>
-
         <div class="help" style="margin-top:6px">* Dauer nur sichtbar, wenn „Individuell“ gewählt ist.</div>
       </div>
     </details>

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -32,9 +32,9 @@ const DEFAULT_ENABLED_COMPONENTS = {
 };
 
 const DEFAULT_BADGE_LIBRARY = [
-  { id:'bdg_classic', icon:'🌿', label:'Klassisch' },
-  { id:'bdg_event', icon:'⭐', label:'Event' },
-  { id:'bdg_ritual', icon:'🔥', label:'Ritual' }
+  { id:'bdg_classic', icon:'🌿', label:'Klassisch', imageUrl:'', iconUrl:'', presetKey:'classic' },
+  { id:'bdg_event', icon:'⭐', label:'Event', imageUrl:'', iconUrl:'', presetKey:'event' },
+  { id:'bdg_ritual', icon:'🔥', label:'Ritual', imageUrl:'', iconUrl:'', presetKey:'ritual' }
 ];
 
 const DEFAULT_STYLE_SETS = {
@@ -97,9 +97,6 @@ export const DEFAULTS = {
     tileMaxScale:0.57,
     infobadgeColor:'#5C3101',
     badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
-    showIcons:true,
-    cardIcons:{},
-    cardIconsMigrated:true,
     heroEnabled:false,
     heroTimelineFillMs:8000,
     heroTimelineBaseMinutes:15,

--- a/webroot/admin/js/ui/grid.js
+++ b/webroot/admin/js/ui/grid.js
@@ -49,7 +49,13 @@ function getBadgeLibrary(){
     if (!id || seen.has(id)) return;
     const icon = typeof entry.icon === 'string' ? entry.icon : '';
     const label = typeof entry.label === 'string' ? entry.label : '';
-    out.push({ id, icon, label });
+    const imageUrlRaw = typeof entry.imageUrl === 'string' ? entry.imageUrl
+      : (typeof entry.iconUrl === 'string' ? entry.iconUrl : '');
+    const imageUrl = String(imageUrlRaw || '').trim();
+    const presetRaw = typeof entry.presetKey === 'string' ? entry.presetKey
+      : (typeof entry.preset === 'string' ? entry.preset : '');
+    const presetKey = String(presetRaw || '').trim();
+    out.push({ id, icon, label, imageUrl, iconUrl: imageUrl, presetKey: presetKey || null });
     seen.add(id);
   });
   return out;
@@ -128,11 +134,27 @@ function renderBadgePicker(selectedIds = []){
       selectedBadges.forEach(entry => {
         const chip = document.createElement('span');
         chip.className = 'badge-picker-chip';
-        if (entry.icon){
-          const icon = document.createElement('span');
-          icon.className = 'badge-picker-chip-icon';
-          icon.textContent = entry.icon;
-          chip.appendChild(icon);
+        const imageUrl = (entry.imageUrl || entry.iconUrl || '').trim();
+        const iconText = (entry.icon || '').trim();
+        if (imageUrl || iconText){
+          const media = document.createElement('span');
+          media.className = 'badge-picker-chip-media';
+          if (imageUrl){
+            const img = document.createElement('img');
+            img.className = 'badge-picker-chip-image';
+            img.src = imageUrl;
+            img.alt = '';
+            img.loading = 'lazy';
+            media.appendChild(img);
+            chip.classList.add('has-image');
+          } else if (iconText){
+            const iconEl = document.createElement('span');
+            iconEl.className = 'badge-picker-chip-icon';
+            iconEl.textContent = iconText;
+            media.appendChild(iconEl);
+            chip.classList.add('has-icon');
+          }
+          chip.appendChild(media);
         }
         const label = document.createElement('span');
         label.textContent = entry.label || entry.id;
@@ -169,20 +191,33 @@ function renderBadgePicker(selectedIds = []){
       updateSummary();
     });
 
-    const icon = document.createElement('span');
-    icon.className = 'badge-picker-option-icon';
-    if (badge.icon){
-      icon.textContent = badge.icon;
-    } else {
-      icon.hidden = true;
-    }
-
     const label = document.createElement('span');
     label.className = 'badge-picker-option-label';
     label.textContent = badge.label || badge.id;
 
     option.appendChild(input);
-    if (badge.icon) option.appendChild(icon);
+    const imageUrl = (badge.imageUrl || badge.iconUrl || '').trim();
+    const iconText = (badge.icon || '').trim();
+    if (imageUrl || iconText){
+      const media = document.createElement('span');
+      media.className = 'badge-picker-option-media';
+      if (imageUrl){
+        const img = document.createElement('img');
+        img.className = 'badge-picker-option-image';
+        img.src = imageUrl;
+        img.alt = '';
+        img.loading = 'lazy';
+        media.appendChild(img);
+        option.classList.add('has-image');
+      } else if (iconText){
+        const iconEl = document.createElement('span');
+        iconEl.className = 'badge-picker-option-icon';
+        iconEl.textContent = iconText;
+        media.appendChild(iconEl);
+        option.classList.add('has-icon');
+      }
+      option.appendChild(media);
+    }
     option.appendChild(label);
     option.classList.toggle('is-checked', input.checked);
 


### PR DESCRIPTION
## Summary
- remove the sauna card icon management UI and related defaults/migrations
- expand badge library objects to include optional image URLs and preset keys, updating sanitization and defaults
- redesign the badge library editor with preset dropdown, upload/preview controls and refreshed CSS, and enhance badge picker/context badge rendering to show emojis or images

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced0c6a6b4832085c5753f857c81e4