### PR TITLE
Adjust modal box sizing for taller infusion dialog

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -1259,8 +1259,11 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
 /* ---------- Modal ---------- */
 .modal{ position:fixed; inset:0; background:rgba(0,0,0,.5); display:none; place-items:center; z-index:100; }
 .box{ background:var(--panel); color:var(--fg); border:1px solid var(--inbr); border-radius:16px;
-  min-width:min(340px,95vw); max-width:95vw; max-height:90svh; overflow:auto; padding:16px; }
-.grid2{ display:grid; grid-template-columns:130px minmax(0,1fr); gap:10px; align-items:center; width:min(560px,calc(95vw - 36px)); margin:0 auto 12px; }
+  --modal-pad:clamp(16px, 2.4svh, 24px);
+  min-width:min(340px,95vw); max-width:95vw; max-height:95svh; overflow-y:auto;
+  padding:var(--modal-pad); scrollbar-gutter:stable; }
+.grid2{ display:grid; grid-template-columns:130px minmax(0,1fr); gap:10px; align-items:center;
+  width:min(560px, calc(95vw - (var(--modal-pad,16px) * 2) - 4px)); margin:0 auto 12px; }
 .iframeWrap{ width:min(92vw,1600px); height:min(85svh,900px); border:1px solid var(--inbr); border-radius:14px; overflow:hidden; background:#000; }
 .iframeWrap iframe{ width:100%; height:100%; display:block; border:0; }
 


### PR DESCRIPTION
## Summary
- raise the shared modal box max-height to 95svh so the Aufguss dialog can use more vertical space before scrolling
- switch modal overflow handling to vertical-only, introduce a viewport-aware padding token, and reserve scrollbar gutter space
- update the Aufguss form grid width calculation to respect the modal padding adjustments

## Testing
- Manual viewport checks for Aufguss dialog in Chromium via Playwright (1440×900, 1280×720, 1024×768, 834×1112, 768×1024)


------
https://chatgpt.com/codex/tasks/task_e_68ced771fa608320b3982cf48d8ac234