### PR TITLE
Enhance hero timeline with imagery and badges

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -135,6 +135,7 @@ body[data-layout='split'] .stage-area .rightPanel{display:none;}
 .hero-headings{width:100%;margin:0 0 calc(18px*var(--vwScale))}
 .hero-body{width:100%;display:flex;flex-direction:column;gap:calc(18px*var(--vwScale))}
 .hero-timeline-list{display:flex;flex-direction:column;gap:calc(16px*var(--vwScale));width:100%}
+.hero-timeline{--heroTimelineThumb:calc(120px*var(--vwScale));--heroTimelineRadius:calc(18px*var(--vwScale));--heroTimelineGap:calc(16px*var(--vwScale));}
 .hero-timeline .timeline-item{
   position:relative;
   padding:calc(24px*var(--vwScale));
@@ -166,12 +167,107 @@ body[data-layout='split'] .stage-area .rightPanel{display:none;}
   font-size:calc(32px*var(--scale));
   margin:0 0 calc(8px*var(--vwScale));
 }
-.hero-timeline .timeline-details{display:flex;flex-direction:column;gap:calc(8px*var(--vwScale))}
-.hero-timeline .timeline-entry{display:flex;flex-wrap:wrap;gap:calc(8px*var(--vwScale));align-items:baseline;font-size:calc(22px*var(--scale))}
-.hero-timeline .timeline-entry .timeline-sauna{font-weight:700;letter-spacing:.01em}
-.hero-timeline .timeline-entry .timeline-title{font-weight:600}
-.hero-timeline .timeline-entry .timeline-detail{opacity:.82;font-size:calc(18px*var(--scale))}
-.hero-timeline .timeline-entry.highlight{color:var(--hlColor)}
+.hero-timeline .timeline-details{display:flex;flex-direction:column;gap:calc(12px*var(--vwScale))}
+.hero-timeline .timeline-entry{
+  position:relative;
+  display:grid;
+  grid-template-columns:minmax(0, var(--heroTimelineThumb)) 1fr;
+  align-items:center;
+  gap:var(--heroTimelineGap);
+  padding:calc(16px*var(--vwScale));
+  border-radius:var(--heroTimelineRadius);
+  background:color-mix(in srgb, rgba(255,255,255,.16) 68%, transparent);
+  border:1px solid rgba(255,255,255,.08);
+  font-size:calc(22px*var(--scale));
+  box-shadow:0 14px 32px rgba(0,0,0,.22);
+  transition:transform .4s cubic-bezier(.22,.61,.36,1), box-shadow .4s cubic-bezier(.22,.61,.36,1);
+}
+.hero-timeline .timeline-entry.highlight{
+  background:color-mix(in srgb, var(--hlColor) 42%, transparent);
+  border-color:color-mix(in srgb, var(--hlColor) 70%, transparent);
+  color:var(--fg);
+  box-shadow:0 18px 40px rgba(0,0,0,.28);
+}
+.hero-timeline .timeline-entry-thumb{
+  position:relative;
+  width:100%;
+  aspect-ratio:1/1;
+  border-radius:calc(var(--heroTimelineRadius)*0.82);
+  background:rgba(0,0,0,.28);
+  overflow:hidden;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.06);
+}
+.hero-timeline .timeline-entry-thumb.is-empty{background:rgba(0,0,0,.18);}
+.hero-timeline .timeline-entry.highlight .timeline-entry-thumb{box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--hlColor) 70%, transparent);}
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight .timeline-entry-thumb{box-shadow:inset 0 0 0 2px color-mix(in srgb, var(--accent) 70%, transparent);}
+.hero-timeline .timeline-entry-thumb-image{
+  position:absolute;
+  inset:0;
+  background-size:cover;
+  background-position:center;
+  transform:scale(1.02);
+  transition:transform .6s cubic-bezier(.22,.61,.36,1);
+}
+.hero-timeline .timeline-entry:hover .timeline-entry-thumb-image{transform:scale(1.08);}
+.hero-timeline .timeline-entry-thumb-fallback{
+  font-size:calc(42px*var(--scale));
+  font-weight:700;
+  letter-spacing:.06em;
+  color:color-mix(in srgb, var(--boxfg) 88%, rgba(0,0,0,.2));
+}
+.hero-timeline .timeline-entry-content{
+  display:flex;
+  flex-direction:column;
+  gap:calc(8px*var(--vwScale));
+  min-width:0;
+}
+.hero-timeline .timeline-entry-header{
+  display:flex;
+  flex-wrap:wrap;
+  gap:calc(8px*var(--vwScale));
+  align-items:baseline;
+  min-width:0;
+}
+.hero-timeline .timeline-entry-header>*{min-width:0;}
+.hero-timeline .timeline-entry .timeline-sauna{
+  font-weight:700;
+  letter-spacing:.02em;
+  color:var(--boxfg);
+}
+.hero-timeline .timeline-entry .timeline-title{
+  font-weight:600;
+  color:var(--boxfg);
+}
+.hero-timeline .timeline-entry .timeline-detail{
+  opacity:.86;
+  font-size:calc(18px*var(--scale));
+  line-height:1.35;
+}
+.hero-timeline .timeline-entry.highlight .timeline-sauna,
+.hero-timeline .timeline-entry.highlight .timeline-title{color:var(--accent);}
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight .timeline-sauna,
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight .timeline-title{color:var(--hlColor);}
+.hero-timeline .timeline-entry.highlight .timeline-detail{color:color-mix(in srgb, var(--accent) 75%, var(--boxfg) 25%);}
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight .timeline-detail{color:color-mix(in srgb, var(--hlColor) 80%, var(--boxfg) 20%);}
+.hero-timeline .timeline-entry-badges{--tileChipGapPx:calc(8px*var(--vwScale));margin-top:calc(4px*var(--vwScale));}
+.hero-timeline .timeline-entry-badges .badge{
+  display:inline-flex;
+  align-items:center;
+  gap:.45em;
+  padding:.35em 1em;
+  border-radius:999px;
+  background:rgba(0,0,0,.35);
+  color:var(--boxfg);
+  font-size:calc(18px*var(--scale));
+  font-weight:600;
+  letter-spacing:.06em;
+  box-shadow:none;
+}
+.hero-timeline .timeline-entry.highlight .timeline-entry-badges .badge{background:color-mix(in srgb, var(--accent) 50%, rgba(0,0,0,.15));color:var(--boxfg);}
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight .timeline-entry-badges .badge{background:color-mix(in srgb, var(--hlColor) 60%, transparent);color:var(--fg);}
 .hero-timeline .timeline-bar{
   position:relative;
   height:6px;
@@ -190,8 +286,15 @@ body[data-layout='split'] .stage-area .rightPanel{display:none;}
   animation-delay:calc(var(--heroTimelineDelayMs,400ms)+var(--heroTimelineItemDelay,140ms)*var(--hero-index,0));
 }
 .hero-timeline .timeline-item.is-active .timeline-progress{background:var(--accent)}
-.hero-timeline .timeline-item.is-active .timeline-entry{color:var(--accent)}
-.hero-timeline .timeline-item.is-active .timeline-entry.highlight{color:var(--hlColor)}
+.hero-timeline .timeline-item.is-active .timeline-entry{
+  border-color:color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow:0 20px 44px rgba(0,0,0,.32);
+}
+.hero-timeline .timeline-item.is-active .timeline-entry.highlight{
+  background:color-mix(in srgb, var(--accent) 58%, var(--hlColor) 42%);
+  color:var(--boxfg);
+  border-color:color-mix(in srgb, var(--accent) 68%, transparent);
+}
 
 @media (prefers-reduced-motion:reduce){
   .tile,


### PR DESCRIPTION
## Summary
- expose hero timeline entries to badge collections and matching sauna imagery.
- render hero timeline cards with thumbnails, rich layout and badge rows.
- refresh timeline styling for image/text grid, highlights and badge appearance.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ced77343348320b45a58493301f57b