### PR TITLE
Simplify badge editing and data structure

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -1020,12 +1020,13 @@ body.mode-uniform #ovSec{ display:none !important; }
 .badge-lib-fields{
   display:grid;
   gap:8px;
+  grid-template-columns: minmax(140px, .6fr) minmax(220px, 1.4fr);
+  align-items:start;
 }
-.badge-lib-fields-main{
-  grid-template-columns: minmax(160px, 1.4fr) minmax(90px, .8fr) minmax(140px, 1fr);
-}
-.badge-lib-fields-secondary{
-  grid-template-columns: minmax(220px, 1fr);
+@media (max-width: 720px){
+  .badge-lib-fields{
+    grid-template-columns: 1fr;
+  }
 }
 .badge-lib-field{
   display:flex;
@@ -1039,16 +1040,10 @@ body.mode-uniform #ovSec{ display:none !important; }
   text-transform:uppercase;
   color:var(--muted);
 }
-.badge-lib-input,
-.badge-lib-select{
+.badge-lib-input{
   font-size:13px;
   padding:6px 8px;
   border-radius:8px;
-}
-.badge-lib-select{
-  border:1px solid var(--ghost-border);
-  background:var(--panel);
-  color:var(--fg);
 }
 .badge-lib-upload{
   display:flex;

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -44,16 +44,11 @@ function sanitizeBadgeLibrary(list, { assignMissingIds = false, fallback } = {})
     const imageUrlRaw = typeof entry.imageUrl === 'string' ? entry.imageUrl
       : (typeof entry.iconUrl === 'string' ? entry.iconUrl : '');
     const imageUrl = String(imageUrlRaw || '').trim();
-    const presetRaw = typeof entry.presetKey === 'string' ? entry.presetKey
-      : (typeof entry.preset === 'string' ? entry.preset : '');
-    const presetKey = String(presetRaw || '').trim();
     const record = {
       id,
       icon,
       label,
-      imageUrl,
-      iconUrl: imageUrl,
-      presetKey: presetKey || null
+      imageUrl
     };
     normalized.push(record);
     seen.add(id);
@@ -376,8 +371,8 @@ function normalizeContextBadge(source){
     const trimmed = source.trim();
     if (!trimmed) return null;
     const isUrl = /^(?:https?:)?\//i.test(trimmed) || /^data:/i.test(trimmed);
-    if (isUrl) return { icon:'', imageUrl: trimmed, iconUrl: trimmed, presetKey: null, label:'' };
-    return { icon: trimmed, imageUrl:'', iconUrl:'', presetKey: null, label:'' };
+    if (isUrl) return { icon:'', imageUrl: trimmed, label:'' };
+    return { icon: trimmed, imageUrl:'', label:'' };
   }
   if (typeof source !== 'object') return null;
   const icon = typeof source.icon === 'string'
@@ -386,12 +381,9 @@ function normalizeContextBadge(source){
   const imageUrlRaw = typeof source.imageUrl === 'string' ? source.imageUrl
     : (typeof source.iconUrl === 'string' ? source.iconUrl : '');
   const imageUrl = String(imageUrlRaw || '').trim();
-  const presetRaw = typeof source.presetKey === 'string' ? source.presetKey
-    : (typeof source.preset === 'string' ? source.preset : '');
-  const presetKey = String(presetRaw || '').trim();
   const label = typeof source.label === 'string' ? source.label.trim() : '';
   if (!icon && !imageUrl) return null;
-  return { icon, imageUrl, iconUrl: imageUrl, presetKey: presetKey || null, label };
+  return { icon, imageUrl, label };
 }
 
 // --- Kontext-Badge (Header) im Modul-Scope ---
@@ -469,7 +461,7 @@ function renderContextBadge(){
   const badge = currentDeviceBadgeMeta;
   if (mediaWrap && mediaImage && mediaIcon){
     const iconText = (badge?.icon || '').trim();
-    const imageUrl = (badge?.imageUrl || badge?.iconUrl || '').trim();
+    const imageUrl = (badge?.imageUrl || '').trim();
     if (badge && (iconText || imageUrl)){
       if (imageUrl){
         mediaImage.src = imageUrl;

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -32,9 +32,9 @@ const DEFAULT_ENABLED_COMPONENTS = {
 };
 
 const DEFAULT_BADGE_LIBRARY = [
-  { id:'bdg_classic', icon:'🌿', label:'Klassisch', imageUrl:'', iconUrl:'', presetKey:'classic' },
-  { id:'bdg_event', icon:'⭐', label:'Event', imageUrl:'', iconUrl:'', presetKey:'event' },
-  { id:'bdg_ritual', icon:'🔥', label:'Ritual', imageUrl:'', iconUrl:'', presetKey:'ritual' }
+  { id:'bdg_classic', icon:'🌿', label:'Klassisch', imageUrl:'' },
+  { id:'bdg_event', icon:'⭐', label:'Event', imageUrl:'' },
+  { id:'bdg_ritual', icon:'🔥', label:'Ritual', imageUrl:'' }
 ];
 
 const DEFAULT_STYLE_SETS = {

--- a/webroot/admin/js/ui/grid.js
+++ b/webroot/admin/js/ui/grid.js
@@ -52,10 +52,7 @@ function getBadgeLibrary(){
     const imageUrlRaw = typeof entry.imageUrl === 'string' ? entry.imageUrl
       : (typeof entry.iconUrl === 'string' ? entry.iconUrl : '');
     const imageUrl = String(imageUrlRaw || '').trim();
-    const presetRaw = typeof entry.presetKey === 'string' ? entry.presetKey
-      : (typeof entry.preset === 'string' ? entry.preset : '');
-    const presetKey = String(presetRaw || '').trim();
-    out.push({ id, icon, label, imageUrl, iconUrl: imageUrl, presetKey: presetKey || null });
+    out.push({ id, icon, label, imageUrl });
     seen.add(id);
   });
   return out;
@@ -134,7 +131,7 @@ function renderBadgePicker(selectedIds = []){
       selectedBadges.forEach(entry => {
         const chip = document.createElement('span');
         chip.className = 'badge-picker-chip';
-        const imageUrl = (entry.imageUrl || entry.iconUrl || '').trim();
+        const imageUrl = (entry.imageUrl || '').trim();
         const iconText = (entry.icon || '').trim();
         if (imageUrl || iconText){
           const media = document.createElement('span');
@@ -196,7 +193,7 @@ function renderBadgePicker(selectedIds = []){
     label.textContent = badge.label || badge.id;
 
     option.appendChild(input);
-    const imageUrl = (badge.imageUrl || badge.iconUrl || '').trim();
+    const imageUrl = (badge.imageUrl || '').trim();
     const iconText = (badge.icon || '').trim();
     if (imageUrl || iconText){
       const media = document.createElement('span');

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -845,10 +845,11 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     const iconStr = String(icon || '').trim();
     const iconUrlStr = String(iconUrl || '').trim();
     const imageUrlStr = String(imageUrl || '').trim();
+    const finalImageUrl = imageUrlStr || iconUrlStr;
     const preferLabelId = (!entry || (fallbackStr && id === fallbackStr && /^(?:row:|idx:|cell:|legacy$)/i.test(fallbackStr)));
-    const finalId = preferLabelId ? (labelStr || iconStr || iconUrlStr || imageUrlStr || id) : (id || labelStr || iconStr || iconUrlStr || imageUrlStr);
-    if (!finalId || (!labelStr && !iconStr && !iconUrlStr && !imageUrlStr)) return null;
-    return { id: finalId, label: labelStr, icon: iconStr, iconUrl: iconUrlStr, imageUrl: imageUrlStr };
+    const finalId = preferLabelId ? (labelStr || iconStr || finalImageUrl || id) : (id || labelStr || iconStr || finalImageUrl);
+    if (!finalId || (!labelStr && !iconStr && !finalImageUrl)) return null;
+    return { id: finalId, label: labelStr, icon: iconStr, imageUrl: finalImageUrl };
   }
 
   function getBadgeLookup(){
@@ -895,7 +896,7 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     const addBadge = (badge) => {
       if (!badge) return;
       const idKey = (typeof badge.id === 'string') ? badge.id.trim().toLowerCase() : '';
-      const composite = [badge.label, badge.icon, badge.iconUrl, badge.imageUrl]
+      const composite = [badge.label, badge.icon, badge.imageUrl]
         .map(v => String(v || '').trim().toLowerCase())
         .join('|');
       const dedupeKey = idKey || composite;
@@ -1005,7 +1006,7 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     const uniqueBadges = [];
     list.forEach(badge => {
       const idKey = (typeof badge.id === 'string') ? badge.id.trim().toLowerCase() : '';
-      const composite = [badge.label, badge.icon, badge.iconUrl, badge.imageUrl]
+      const composite = [badge.label, badge.icon, badge.imageUrl]
         .map(v => String(v || '').trim().toLowerCase())
         .join('|');
       const dedupeKey = idKey || composite;
@@ -1023,12 +1024,12 @@ document.body.dataset.chipOverflow = f.chipOverflowMode || 'scale';
     const nodes = [];
     uniqueBadges.forEach(badge => {
       const iconChar = String(badge.icon || '').trim();
-      const iconUrl = String(badge.iconUrl || '').trim();
+      const imageUrl = String(badge.imageUrl || '').trim();
       const label = String(badge.label || '').trim();
       const bits = [];
-      if (iconUrl) {
+      if (imageUrl) {
         bits.push(h('span', { class: 'badge-icon badge-icon--image', 'aria-hidden': 'true' }, [
-          h('img', { src: iconUrl, alt: '' })
+          h('img', { src: imageUrl, alt: '' })
         ]));
       } else {
         const glyph = iconChar || defaultIcon;


### PR DESCRIPTION
## Summary
- remove preset handling and trim badge objects to id, label, icon and imageUrl
- simplify the badge editor to emoji and image controls and adjust the layout styling
- update grid handling and slideshow rendering for the streamlined badge metadata

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cedfbefae48320b16c727849d30925