### PR TITLE
Refine sauna tile layout

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -506,12 +506,48 @@ body[data-layout='split'] .stage-area .rightPanel{display:none;}
 .tile.tile--compact .tile-badge-stripe{ display:none; }
 .container.no-card-icons .list{ gap:var(--tileGapPx, calc(14px*var(--vwScale))); }
 .card-content{
+  width:100%;
+  min-width:0;
+}
+.card-content--with-meta{
+  display:grid;
+  grid-template-columns:auto minmax(0,1fr);
+  column-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
+  align-items:center;
+}
+.card-content:not(.card-content--with-meta){
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:flex-start;
+}
+.card-main{
   display:flex;
   flex-direction:column;
   gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
   justify-content:center;
   align-items:flex-start;
   min-width:0;
+}
+.card-meta{
+  display:flex;
+  align-items:baseline;
+  gap:.5em;
+  font-size:calc(40px*var(--scale)*var(--tileTextScale));
+  font-weight:var(--tileWeight);
+  line-height:1.05;
+  white-space:nowrap;
+}
+.card-meta .time{
+  font-size:calc(.65em*var(--tileMetaScale,1));
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  opacity:.8;
+  white-space:nowrap;
+}
+.card-meta .sep{
+  opacity:.7;
+  font-size:.8em;
 }
 .tile .title{
   display:flex;
@@ -522,17 +558,6 @@ body[data-layout='split'] .stage-area .rightPanel{display:none;}
   font-weight:var(--tileWeight);
   line-height:1.05;
   min-width:0;
-}
-.tile .title .time{
-  font-size:calc(.65em*var(--tileMetaScale,1));
-  letter-spacing:.12em;
-  text-transform:uppercase;
-  opacity:.8;
-  white-space:nowrap;
-}
-.tile .title .sep{
-  opacity:.7;
-  font-size:.8em;
 }
 .tile .title .label{display:flex;align-items:baseline;gap:.35em;flex-wrap:wrap;min-width:0;}
 .tile .title .label .notewrap{flex:0 0 auto;}


### PR DESCRIPTION
## Summary
- separate sauna tile metadata and title into dedicated columns while keeping detail components aligned with the title stack
- allow `renderComponentNodes` to direct rendered nodes via an optional callback hook
- update sauna tile styles to support the new grid layout and consistent padding

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cedfbd23d48320aeeb9761e747ce45