### PR TITLE
Add playlist selection UI for page layouts

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -409,6 +409,12 @@ details[open] .chev{ transform: rotate(90deg); }
 #slideOrderClose{ position:absolute; top:8px; right:8px; }
 .btn.ghost:hover{ background: color-mix(in oklab, var(--ghost-fg) 6%, transparent); }
 
+.playlist-selector{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
 .slide-order-grid{
   display:grid;
   gap:12px;
@@ -426,12 +432,26 @@ details[open] .chev{ transform: rotate(90deg); }
   background:var(--panel);
   cursor:grab;
   gap:6px;
+  position:relative;
 }
 
 .slide-order-tile.is-disabled{
   background:color-mix(in oklab, var(--panel) 70%, transparent);
   border-color:color-mix(in oklab, var(--border) 55%, transparent);
   box-shadow:inset 0 0 0 1px color-mix(in oklab, var(--border) 35%, transparent);
+}
+
+.slide-order-tile.is-unselected{
+  opacity:0.6;
+  cursor:pointer;
+}
+
+.slide-order-tile.is-unselected:hover{
+  opacity:0.85;
+}
+
+.slide-order-tile.is-unselected.is-disabled{
+  cursor:not-allowed;
 }
 
 .slide-order-tile.is-disabled img{
@@ -520,6 +540,25 @@ details[open] .chev{ transform: rotate(90deg); }
   gap:8px;
   margin-top:8px;
   width:100%;
+}
+
+.slide-order-tile .playlist-state{
+  position:absolute;
+  top:8px;
+  left:8px;
+  font-size:11px;
+  font-weight:600;
+  padding:2px 8px;
+  border-radius:999px;
+  background:color-mix(in oklab, var(--btn-accent) 15%, var(--panel));
+  color:color-mix(in oklab, var(--btn-accent) 80%, var(--fg));
+  border:1px solid color-mix(in oklab, var(--btn-accent) 35%, var(--border));
+}
+
+.slide-order-tile.is-unselected .playlist-state{
+  background:color-mix(in oklab, var(--panel) 92%, transparent);
+  color:var(--muted);
+  border-color:color-mix(in oklab, var(--border) 65%, transparent);
 }
 
 .slide-order-tile .reorder-btn{

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -380,8 +380,9 @@
               <input id="pageLeftTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
             </div>
             <div class="kv">
-              <label>Inhaltstypen</label>
-              <div class="type-list" id="pageLeftTypes"></div>
+              <label>Playlist</label>
+              <div class="playlist-selector" id="pageLeftPlaylist"></div>
+              <div class="help">Klicken zum (De-)Aktivieren, Pfeile oder Ziehen für die Reihenfolge. Eine leere Playlist nutzt den Standardfilter.</div>
             </div>
           </div>
           <div class="fieldset layout-page" id="layoutRight">
@@ -400,8 +401,9 @@
               <input id="pageRightTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
             </div>
             <div class="kv">
-              <label>Inhaltstypen</label>
-              <div class="type-list" id="pageRightTypes"></div>
+              <label>Playlist</label>
+              <div class="playlist-selector" id="pageRightPlaylist"></div>
+              <div class="help">Klicken zum (De-)Aktivieren, Pfeile oder Ziehen für die Reihenfolge.</div>
             </div>
             <div class="help">Wird verwendet, wenn das Zweispalten-Layout aktiv ist.</div>
           </div>

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -105,7 +105,29 @@ export const DEFAULTS = {
     styleSets:{ ...DEFAULT_STYLE_SETS },
     activeStyleSet:'classic'
   },
-  display:{ fit:'auto', baseW:1920, baseH:1080, rightWidthPercent:38, cutTopPercent:28, cutBottomPercent:12 },
+  display:{
+    fit:'auto',
+    baseW:1920,
+    baseH:1080,
+    rightWidthPercent:38,
+    cutTopPercent:28,
+    cutBottomPercent:12,
+    layoutMode:'single',
+    pages:{
+      left:{
+        source:'master',
+        timerSec:null,
+        contentTypes:['overview','sauna','hero-timeline','story','image','video','url'],
+        playlist:[]
+      },
+      right:{
+        source:'media',
+        timerSec:null,
+        contentTypes:['image','video','url'],
+        playlist:[]
+      }
+    }
+  },
   theme:{ ...DEFAULT_THEME },
   highlightNext:{ enabled:false, color:'#FFDD66', minutesBeforeNext:15, minutesAfterStart:15 },
   fonts:{ ...DEFAULT_FONTS },


### PR DESCRIPTION
## Summary
- replace layout content type checkboxes with a playlist selector that shows slide thumbnails and supports toggling and reordering
- persist per-page playlists in settings/defaults and expose the shared slide stream for reuse in the selector
- honor configured playlists during slideshow playback with a fallback to type filtering when no playlist is defined

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee240c3f083209a04ac2f4aa75b96