### PR TITLE
Add story builder with column layout controls

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -978,6 +978,114 @@ body.mode-uniform #ovSec{ display:none !important; }
 }
 .badge-lib-row.has-icon .badge-lib-chip{ font-weight:500; }
 .badge-lib-row.has-image .badge-lib-chip{ gap:6px; }
+
+/* ---------- Story Builder ---------- */
+.story-builder-pane{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.story-builder-pane .help{ margin-top:-4px; }
+.story-builder{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+.story-builder-list{ display:grid; gap:16px; }
+.story-editor.fieldset{
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+.story-layout-toggle{ align-items:center; }
+.story-layout-toggle .btn.is-active{
+  border-color:color-mix(in oklab, var(--btn-accent) 60%, var(--ghost-border));
+  background:color-mix(in oklab, var(--btn-accent) 14%, var(--panel));
+  color:color-mix(in oklab, var(--btn-accent) 70%, var(--fg));
+}
+.story-columns-editor{
+  display:grid;
+  gap:12px;
+  grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));
+}
+.story-column-card{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding:12px;
+  border-radius:var(--radius-sm);
+  border:1px solid color-mix(in oklab, var(--border) 85%, transparent);
+  background:color-mix(in oklab, var(--panel) 96%, transparent);
+  box-shadow:0 6px 16px rgba(15,23,42,.04);
+}
+.story-column-card.is-collapsed{
+  border-style:dashed;
+  opacity:0.9;
+}
+.story-column-head{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:8px;
+  flex-wrap:wrap;
+}
+.story-column-title{
+  font-weight:700;
+  font-size:15px;
+}
+.story-column-placeholder{
+  color:var(--muted);
+  font-size:0.92em;
+  padding:8px 10px;
+  border-radius:var(--radius-sm);
+  background:color-mix(in oklab, var(--panel) 94%, transparent);
+}
+.story-column-empty{
+  color:var(--muted);
+  font-style:italic;
+}
+.story-section-list{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.story-section-card{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  padding:12px;
+  border-radius:var(--radius-sm);
+  border:1px solid color-mix(in oklab, var(--border) 80%, transparent);
+  background:color-mix(in oklab, var(--panel) 98%, transparent);
+}
+.story-section-card.is-full-image{
+  background:color-mix(in oklab, var(--panel) 90%, var(--btn-accent) 6%);
+}
+.story-section-card-head{
+  justify-content:space-between;
+  align-items:center;
+  gap:8px;
+}
+.story-section-card-controls .btn{ padding-inline:8px; }
+.story-section-card-preview{
+  width:140px;
+  height:100px;
+  object-fit:cover;
+  border-radius:8px;
+  box-shadow:inset 0 0 0 1px color-mix(in oklab, var(--border) 70%, transparent);
+  background:color-mix(in oklab, var(--panel) 85%, transparent);
+}
+.story-fullimage-toggle{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-weight:600;
+}
+.story-fullimage-toggle input{ margin:0; }
+.story-column-card.is-collapsed .story-section-list{ opacity:0.6; }
+.story-column-card.is-collapsed .story-section-card{
+  background:color-mix(in oklab, var(--panel) 94%, transparent);
+}
 .badge-lib-chip-media{
   display:inline-flex;
   align-items:center;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -215,12 +215,15 @@
     <!-- Unterbox 4: Story-Slides -->
     <details class="ac sub" id="boxStories">
       <summary>
-        <div class="ttl">▶<span class="chev">⮞</span> Saunen & Aufgüsse erklärt</div>
-        <div class="actions"><button class="btn sm" id="btnStoryAdd">Erklärung hinzufügen</button></div>
+        <div class="ttl">▶<span class="chev">⮞</span> Informationen</div>
+        <div class="actions"><button class="btn sm" id="btnStoryAdd">Information hinzufügen</button></div>
       </summary>
-      <div class="content">
-        <div class="help">Beschreibungen mit Einführung, Ritual, Tipps, FAQ und automatischer „Heute verfügbar“-Liste.</div>
-        <div id="storyList"></div>
+      <div class="content story-builder-pane">
+        <div class="subh">Informationen</div>
+        <div class="help">Pflege Texte, Bilder und Layout für erklärende Slides in einem flexiblen Spalten-Baukasten.</div>
+        <div class="story-builder" id="storyBuilder">
+          <div class="story-builder-list" id="storyList"></div>
+        </div>
       </div>
     </details>
 


### PR DESCRIPTION
## Summary
- rename the admin "Saunen & Aufgüsse erklärt" area to "Informationen" and wrap it with containers for the new builder
- migrate story slide data to the new heading/layout/column model while keeping legacy fields in sync
- rebuild the story editor UI with column management, media uploads and full-image toggles plus add supporting styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cee6a3cf588320bafba18afd8cec42