### PR TITLE
Ensure slide reorders update unsaved state

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -1937,6 +1937,8 @@ export function renderSlideOrderView(){
         if (!moved) return;
         clearDropIndicators();
         commitReorder();
+        window.__queueUnsaved?.();
+        window.dockPushDebounced?.();
       });
       btn.addEventListener('dragstart', preventDragStart);
       return btn;
@@ -1986,6 +1988,8 @@ export function renderSlideOrderView(){
     settings.slides.storySlides = newStories;
     settings.slides ||= {};
     settings.slides.sortOrder = sortOrder;
+    window.__queueUnsaved?.();
+    window.dockPushDebounced?.();
   };
 
   const updateDropIndicator = (target, before) => {


### PR DESCRIPTION
## Summary
- trigger the unsaved marker and dock push after committing a slide reorder
- repeat the same hooks for the touch up/down controls so manual moves surface immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee99881c483208b721ed510c5b4ce