### PR TITLE
Refactor admin core helpers

### DIFF
--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -10,188 +10,40 @@
 'use strict';
 
 // === Modular imports =========================================================
-import { $, $$, preloadImg, genId, deepClone } from './core/utils.js';
+import { $, $$, preloadImg, genId, deepClone, deepEqual } from './core/utils.js';
 import { DEFAULTS } from './core/defaults.js';
 import { initGridUI, renderGrid as renderGridUI } from './ui/grid.js';
 import { initSlidesMasterUI, renderSlidesMaster, getActiveDayKey, collectSlideOrderStream } from './ui/slides_master.js';
 import { initGridDayLoader } from './ui/grid_day_loader.js';
 import { uploadGeneric } from './core/upload.js';
+import { createSafeLocalStorage } from './core/safe_storage.js';
+import {
+  PAGE_CONTENT_TYPES,
+  PAGE_CONTENT_TYPE_KEYS,
+  PAGE_SOURCE_KEYS,
+  SOURCE_PLAYLIST_LIMITS,
+  playlistKeyFromSanitizedEntry,
+  sanitizePagePlaylist,
+  sanitizeBadgeLibrary,
+  normalizeSettings,
+  sanitizeScheduleForCompare,
+  sanitizeSettingsForCompare
+} from './core/config.js';
 
 const SLIDESHOW_ORIGIN = window.SLIDESHOW_ORIGIN || location.origin;
 const THUMB_FALLBACK = '/assets/img/thumb_fallback.svg';
-const PAGE_CONTENT_TYPES = [
-  ['overview','Übersicht'],
-  ['sauna','Saunen'],
-  ['hero-timeline','Hero-Timeline'],
-  ['story','Erklärungen'],
-  ['image','Bilder'],
-  ['video','Videos'],
-  ['url','Webseiten']
-];
-const PAGE_CONTENT_TYPE_KEYS = new Set(PAGE_CONTENT_TYPES.map(([key]) => key));
-const PAGE_SOURCE_KEYS = ['master','schedule','media','story'];
-const SOURCE_PLAYLIST_LIMITS = {
-  master: null,
-  schedule: new Set(['overview', 'sauna', 'hero-timeline']),
-  media: new Set(['media']),
-  story: new Set(['story'])
-};
-
-function playlistKeyFromSanitizedEntry(entry){
-  if (!entry || typeof entry !== 'object') return null;
-  switch (entry.type) {
-    case 'overview':
-    case 'hero-timeline':
-      return entry.type;
-    case 'sauna':
-      return entry.name ? 'sauna:' + entry.name : null;
-    case 'story':
-      return entry.id != null ? 'story:' + String(entry.id) : null;
-    case 'media':
-      return entry.id != null ? 'media:' + String(entry.id) : null;
-    default:
-      return null;
-  }
-}
-
-function playlistEntryKey(entry){
-  if (!entry || typeof entry !== 'object') return null;
-  let type = String(entry.type || '').trim();
-  if (!type) return null;
-  if (type === 'image' || type === 'video' || type === 'url') type = 'media';
-  switch (type) {
-    case 'overview':
-    case 'hero-timeline':
-      return type;
-    case 'sauna': {
-      const name = typeof entry.name === 'string' ? entry.name : (typeof entry.sauna === 'string' ? entry.sauna : '');
-      return name ? 'sauna:' + name : null;
+const safeStorage = createSafeLocalStorage({
+  onFallback: () => {
+    if (typeof alert === 'function') {
+      alert('Speicher voll – Daten werden nur temporär gespeichert.');
     }
-    case 'story': {
-      const rawId = entry.id ?? entry.storyId;
-      return rawId != null ? 'story:' + String(rawId) : null;
-    }
-    case 'media': {
-      const rawId = entry.id ?? entry.mediaId ?? entry.__id ?? entry.slug;
-      return rawId != null ? 'media:' + String(rawId) : null;
-    }
-    default:
-      return null;
-  }
-}
+  },
+  logger: (method, error) => console.warn(`[admin] localStorage.${method} failed`, error)
+});
 
-function sanitizePagePlaylist(list = []){
-  if (!Array.isArray(list)) return [];
-  const normalized = [];
-  const seen = new Set();
-  for (const entry of list){
-    const key = playlistEntryKey(entry);
-    if (!key || seen.has(key)) continue;
-    const [prefix, rest] = key.split(':');
-    switch (prefix) {
-      case 'overview':
-      case 'hero-timeline':
-        normalized.push({ type: prefix });
-        seen.add(key);
-        break;
-      case 'sauna':
-        if (rest) {
-          normalized.push({ type: 'sauna', name: rest });
-          seen.add(key);
-        }
-        break;
-      case 'story':
-        if (rest) {
-          normalized.push({ type: 'story', id: rest });
-          seen.add(key);
-        }
-        break;
-      case 'media':
-        if (rest) {
-          normalized.push({ type: 'media', id: rest });
-          seen.add(key);
-        }
-        break;
-      default:
-        break;
-    }
-  }
-  return normalized;
-}
-
-function sanitizeBadgeLibrary(list, { assignMissingIds = false, fallback } = {}) {
-  const seen = new Set();
-  const normalized = [];
-  const pushEntry = (entry, assignId = false) => {
-    if (!entry || typeof entry !== 'object') return;
-    let id = String(entry.id ?? '').trim();
-    if (!id && assignId) id = genId('bdg_');
-    if (!id || seen.has(id)) return;
-    const icon = typeof entry.icon === 'string' ? entry.icon.trim() : '';
-    const label = typeof entry.label === 'string' ? entry.label.trim() : '';
-    const imageUrlRaw = typeof entry.imageUrl === 'string' ? entry.imageUrl
-      : (typeof entry.iconUrl === 'string' ? entry.iconUrl : '');
-    const imageUrl = String(imageUrlRaw || '').trim();
-    const record = {
-      id,
-      icon,
-      label,
-      imageUrl
-    };
-    normalized.push(record);
-    seen.add(id);
-  };
-
-  if (Array.isArray(list)){
-    list.forEach(entry => pushEntry(entry, assignMissingIds));
-  }
-
-  if (!normalized.length && Array.isArray(fallback)){
-    fallback.forEach(entry => pushEntry(entry, true));
-  }
-
-  return normalized;
-}
-
-// Lokaler Speicher mit Fallback bei DOMException (z.B. QuotaExceeded)
-const LS_MEM = {};
-let lsWarned = false;
-function lsNotice(){
-  if (lsWarned) return;
-  lsWarned = true;
-  alert('Speicher voll – Daten werden nur temporär gespeichert.');
-}
-function lsGet(key) {
-  try { return localStorage.getItem(key); }
-  catch (e) {
-    if (e instanceof DOMException) {
-      console.warn('[admin] localStorage.getItem failed', e);
-      lsNotice();
-      return LS_MEM[key] ?? null;
-    }
-    return null;
-  }
-}
-function lsSet(key, val) {
-  try { localStorage.setItem(key, val); }
-  catch (e) {
-    if (e instanceof DOMException) {
-      console.warn('[admin] localStorage.setItem failed', e);
-      lsNotice();
-      LS_MEM[key] = String(val);
-    }
-  }
-}
-function lsRemove(key) {
-  try { localStorage.removeItem(key); }
-  catch (e) {
-    if (e instanceof DOMException) {
-      console.warn('[admin] localStorage.removeItem failed', e);
-      lsNotice();
-    }
-  }
-  delete LS_MEM[key];
-}
+const lsGet = (key) => safeStorage.getItem(key);
+const lsSet = (key, value) => safeStorage.setItem(key, value);
+const lsRemove = (key) => safeStorage.removeItem(key);
 
 // === Global State ============================================================
 let schedule = null;
@@ -221,70 +73,6 @@ let _unsavedInputListener = null;
 let _unsavedBlurListener = null;
 let _unsavedEvalTimer = 0;
 
-function normalizeSettings(source, { assignMissingIds = false } = {}) {
-  const src = source ? deepClone(source) : {};
-  src.slides        = { ...DEFAULTS.slides,   ...(src.slides || {}) };
-  src.display       = { ...DEFAULTS.display,  ...(src.display || {}) };
-  src.theme         = { ...DEFAULTS.theme,    ...(src.theme || {}) };
-  src.fonts         = { ...DEFAULTS.fonts,    ...(src.fonts || {}) };
-  src.assets        = { ...DEFAULTS.assets,   ...(src.assets || {}) };
-  src.h2            = { ...DEFAULTS.h2,       ...(src.h2 || {}) };
-  src.highlightNext = { ...DEFAULTS.highlightNext, ...(src.highlightNext || {}) };
-  src.footnotes     = Array.isArray(src.footnotes) ? src.footnotes : (DEFAULTS.footnotes || []);
-  src.interstitials = Array.isArray(src.interstitials)
-    ? src.interstitials.map(it => {
-        const next = {
-          id: it?.id || null,
-          name: it?.name || '',
-          enabled: (it?.enabled !== false),
-          type: it?.type || 'image',
-          url: it?.url || '',
-          thumb: it?.thumb || it?.url || '',
-          dwellSec: Number.isFinite(it?.dwellSec) ? it.dwellSec : 6
-        };
-        if (!next.id && assignMissingIds) next.id = genId('im_');
-        return next;
-      })
-    : [];
-  src.presets       = src.presets || {};
-
-  const defaultDisplayPages = DEFAULTS.display?.pages || {};
-  const sanitizePageConfig = (page, defaults = {}) => {
-    const cfg = page && typeof page === 'object' ? { ...page } : {};
-    const def = defaults && typeof defaults === 'object' ? defaults : {};
-    cfg.source = PAGE_SOURCE_KEYS.includes(cfg.source) ? cfg.source : (PAGE_SOURCE_KEYS.includes(def.source) ? def.source : 'master');
-    const timerNum = Number(cfg.timerSec);
-    cfg.timerSec = Number.isFinite(timerNum) && timerNum > 0 ? Math.max(1, Math.round(timerNum)) : null;
-    const rawList = Array.isArray(cfg.contentTypes) ? cfg.contentTypes : def.contentTypes;
-    const filtered = Array.isArray(rawList) ? rawList.filter(type => PAGE_CONTENT_TYPE_KEYS.has(type)) : [];
-    const defaultTypes = Array.isArray(def.contentTypes) ? def.contentTypes.slice() : PAGE_CONTENT_TYPES.map(([key]) => key);
-    cfg.contentTypes = filtered.length ? Array.from(new Set(filtered)) : defaultTypes;
-    const rawPlaylist = Array.isArray(cfg.playlist) ? cfg.playlist : def.playlist;
-    cfg.playlist = sanitizePagePlaylist(rawPlaylist);
-    return cfg;
-  };
-  const pagesRaw = src.display?.pages || {};
-  src.display.layoutMode = (src.display.layoutMode === 'split') ? 'split' : 'single';
-  src.display.pages = {
-    left: sanitizePageConfig(pagesRaw.left, defaultDisplayPages.left),
-    right: sanitizePageConfig(pagesRaw.right, defaultDisplayPages.right)
-  };
-  const hasBadgeArray = Array.isArray(src.slides?.badgeLibrary);
-  src.slides.badgeLibrary = sanitizeBadgeLibrary(src.slides.badgeLibrary, {
-    assignMissingIds,
-    fallback: hasBadgeArray ? undefined : DEFAULTS.slides?.badgeLibrary
-  });
-  return src;
-}
-
-function sanitizeScheduleForCompare(src) {
-  return deepClone(src || {});
-}
-
-function sanitizeSettingsForCompare(src) {
-  return normalizeSettings(src || {}, { assignMissingIds: false });
-}
-
 function updateBaseline(scheduleSrc, settingsSrc) {
   baselineSchedule = sanitizeScheduleForCompare(scheduleSrc);
   baselineSettings = sanitizeSettingsForCompare(settingsSrc);
@@ -295,34 +83,6 @@ function getActiveBaselineSources(){
     return { schedule: deviceBaseSchedule, settings: deviceBaseSettings };
   }
   return { schedule: baseSchedule, settings: baseSettings };
-}
-
-function deepEqual(a, b) {
-  if (a === b) return true;
-  if (a === null || b === null) return a === b;
-  if (typeof a !== typeof b) return false;
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (!deepEqual(a[i], b[i])) return false;
-    }
-    return true;
-  }
-  if (typeof a === 'object') {
-    if (Array.isArray(b)) return false;
-    const keysA = Object.keys(a).filter(k => typeof a[k] !== 'undefined').sort();
-    const keysB = Object.keys(b).filter(k => typeof b[k] !== 'undefined').sort();
-    if (keysA.length !== keysB.length) return false;
-    for (let i = 0; i < keysA.length; i++) {
-      if (keysA[i] !== keysB[i]) return false;
-    }
-    for (const key of keysA) {
-      if (!deepEqual(a[key], b[key])) return false;
-    }
-    return true;
-  }
-  if (Number.isNaN(a) && Number.isNaN(b)) return true;
-  return false;
 }
 
 function matchesBaseline() {

--- a/webroot/admin/js/core/config.js
+++ b/webroot/admin/js/core/config.js
@@ -1,0 +1,221 @@
+// /admin/js/core/config.js
+// Gemeinsame Konstanten & Sanitizer für Einstellungen und Playlists.
+
+'use strict';
+
+import { DEFAULTS } from './defaults.js';
+import { deepClone, genId } from './utils.js';
+
+export const PAGE_CONTENT_TYPES = [
+  ['overview', 'Übersicht'],
+  ['sauna', 'Saunen'],
+  ['hero-timeline', 'Hero-Timeline'],
+  ['story', 'Erklärungen'],
+  ['image', 'Bilder'],
+  ['video', 'Videos'],
+  ['url', 'Webseiten']
+];
+
+export const PAGE_CONTENT_TYPE_KEYS = new Set(PAGE_CONTENT_TYPES.map(([key]) => key));
+
+export const PAGE_SOURCE_KEYS = ['master', 'schedule', 'media', 'story'];
+
+export const SOURCE_PLAYLIST_LIMITS = {
+  master: null,
+  schedule: new Set(['overview', 'sauna', 'hero-timeline']),
+  media: new Set(['media']),
+  story: new Set(['story'])
+};
+
+export function playlistKeyFromSanitizedEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  switch (entry.type) {
+    case 'overview':
+    case 'hero-timeline':
+      return entry.type;
+    case 'sauna':
+      return entry.name ? 'sauna:' + entry.name : null;
+    case 'story':
+      return entry.id != null ? 'story:' + String(entry.id) : null;
+    case 'media':
+      return entry.id != null ? 'media:' + String(entry.id) : null;
+    default:
+      return null;
+  }
+}
+
+function playlistEntryKey(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  let type = String(entry.type || '').trim();
+  if (!type) return null;
+  if (type === 'image' || type === 'video' || type === 'url') type = 'media';
+  switch (type) {
+    case 'overview':
+    case 'hero-timeline':
+      return type;
+    case 'sauna': {
+      const name = typeof entry.name === 'string'
+        ? entry.name
+        : (typeof entry.sauna === 'string' ? entry.sauna : '');
+      return name ? 'sauna:' + name : null;
+    }
+    case 'story': {
+      const rawId = entry.id ?? entry.storyId;
+      return rawId != null ? 'story:' + String(rawId) : null;
+    }
+    case 'media': {
+      const rawId = entry.id ?? entry.mediaId ?? entry.__id ?? entry.slug;
+      return rawId != null ? 'media:' + String(rawId) : null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function sanitizePagePlaylist(list = []) {
+  if (!Array.isArray(list)) return [];
+  const normalized = [];
+  const seen = new Set();
+  for (const entry of list) {
+    const key = playlistEntryKey(entry);
+    if (!key || seen.has(key)) continue;
+    const [prefix, rest] = key.split(':');
+    switch (prefix) {
+      case 'overview':
+      case 'hero-timeline':
+        normalized.push({ type: prefix });
+        seen.add(key);
+        break;
+      case 'sauna':
+        if (rest) {
+          normalized.push({ type: 'sauna', name: rest });
+          seen.add(key);
+        }
+        break;
+      case 'story':
+        if (rest) {
+          normalized.push({ type: 'story', id: rest });
+          seen.add(key);
+        }
+        break;
+      case 'media':
+        if (rest) {
+          normalized.push({ type: 'media', id: rest });
+          seen.add(key);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return normalized;
+}
+
+export function sanitizeBadgeLibrary(list, { assignMissingIds = false, fallback } = {}) {
+  const seen = new Set();
+  const normalized = [];
+
+  const pushEntry = (entry, assignId = false) => {
+    if (!entry || typeof entry !== 'object') return;
+    let id = String(entry.id ?? '').trim();
+    if (!id && assignId) id = genId('bdg_');
+    if (!id || seen.has(id)) return;
+    const icon = typeof entry.icon === 'string' ? entry.icon.trim() : '';
+    const label = typeof entry.label === 'string' ? entry.label.trim() : '';
+    const imageUrlRaw = typeof entry.imageUrl === 'string' ? entry.imageUrl
+      : (typeof entry.iconUrl === 'string' ? entry.iconUrl : '');
+    const imageUrl = String(imageUrlRaw || '').trim();
+    const record = {
+      id,
+      icon,
+      label,
+      imageUrl
+    };
+    normalized.push(record);
+    seen.add(id);
+  };
+
+  if (Array.isArray(list)) {
+    list.forEach((entry) => pushEntry(entry, assignMissingIds));
+  }
+
+  if (!normalized.length && Array.isArray(fallback)) {
+    fallback.forEach((entry) => pushEntry(entry, true));
+  }
+
+  return normalized;
+}
+
+export function normalizeSettings(source, { assignMissingIds = false } = {}) {
+  const src = source ? deepClone(source) : {};
+  src.slides = { ...DEFAULTS.slides, ...(src.slides || {}) };
+  src.display = { ...DEFAULTS.display, ...(src.display || {}) };
+  src.theme = { ...DEFAULTS.theme, ...(src.theme || {}) };
+  src.fonts = { ...DEFAULTS.fonts, ...(src.fonts || {}) };
+  src.assets = { ...DEFAULTS.assets, ...(src.assets || {}) };
+  src.h2 = { ...DEFAULTS.h2, ...(src.h2 || {}) };
+  src.highlightNext = { ...DEFAULTS.highlightNext, ...(src.highlightNext || {}) };
+  src.footnotes = Array.isArray(src.footnotes) ? src.footnotes : (DEFAULTS.footnotes || []);
+  src.interstitials = Array.isArray(src.interstitials)
+    ? src.interstitials.map((it) => {
+        const next = {
+          id: it?.id || null,
+          name: it?.name || '',
+          enabled: (it?.enabled !== false),
+          type: it?.type || 'image',
+          url: it?.url || '',
+          thumb: it?.thumb || it?.url || '',
+          dwellSec: Number.isFinite(it?.dwellSec) ? it.dwellSec : 6
+        };
+        if (!next.id && assignMissingIds) next.id = genId('im_');
+        return next;
+      })
+    : [];
+  src.presets = src.presets || {};
+
+  const defaultDisplayPages = DEFAULTS.display?.pages || {};
+  const sanitizePageConfig = (page, defaults = {}) => {
+    const cfg = page && typeof page === 'object' ? { ...page } : {};
+    const def = defaults && typeof defaults === 'object' ? defaults : {};
+    cfg.source = PAGE_SOURCE_KEYS.includes(cfg.source)
+      ? cfg.source
+      : (PAGE_SOURCE_KEYS.includes(def.source) ? def.source : 'master');
+    const timerNum = Number(cfg.timerSec);
+    cfg.timerSec = Number.isFinite(timerNum) && timerNum > 0
+      ? Math.max(1, Math.round(timerNum))
+      : null;
+    const rawList = Array.isArray(cfg.contentTypes) ? cfg.contentTypes : def.contentTypes;
+    const filtered = Array.isArray(rawList)
+      ? rawList.filter((type) => PAGE_CONTENT_TYPE_KEYS.has(type))
+      : [];
+    const defaultTypes = Array.isArray(def.contentTypes)
+      ? def.contentTypes.slice()
+      : PAGE_CONTENT_TYPES.map(([key]) => key);
+    cfg.contentTypes = filtered.length ? Array.from(new Set(filtered)) : defaultTypes;
+    const rawPlaylist = Array.isArray(cfg.playlist) ? cfg.playlist : def.playlist;
+    cfg.playlist = sanitizePagePlaylist(rawPlaylist);
+    return cfg;
+  };
+
+  const pagesRaw = src.display?.pages || {};
+  src.display.layoutMode = (src.display.layoutMode === 'split') ? 'split' : 'single';
+  src.display.pages = {
+    left: sanitizePageConfig(pagesRaw.left, defaultDisplayPages.left),
+    right: sanitizePageConfig(pagesRaw.right, defaultDisplayPages.right)
+  };
+
+  const hasBadgeArray = Array.isArray(src.slides?.badgeLibrary);
+  src.slides.badgeLibrary = sanitizeBadgeLibrary(src.slides.badgeLibrary, {
+    assignMissingIds,
+    fallback: hasBadgeArray ? undefined : DEFAULTS.slides?.badgeLibrary
+  });
+  return src;
+}
+
+export function sanitizeScheduleForCompare(src) {
+  return deepClone(src || {});
+}
+
+export function sanitizeSettingsForCompare(src) {
+  return normalizeSettings(src || {}, { assignMissingIds: false });
+}

--- a/webroot/admin/js/core/safe_storage.js
+++ b/webroot/admin/js/core/safe_storage.js
@@ -1,0 +1,92 @@
+// /admin/js/core/safe_storage.js
+// Resiliente localStorage-Hülle mit Speicher-Fallback.
+
+'use strict';
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+function resolveStore() {
+  try {
+    if (typeof globalThis !== 'undefined' && globalThis.localStorage) {
+      return globalThis.localStorage;
+    }
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch (err) {
+    /* no-op */
+  }
+  return null;
+}
+
+export function createSafeLocalStorage({ onFallback, logger } = {}) {
+  const memory = Object.create(null);
+  const store = resolveStore();
+  let fallbackTriggered = false;
+
+  const notifyFallback = (method, error) => {
+    if (fallbackTriggered) return;
+    fallbackTriggered = true;
+    if (typeof logger === 'function') {
+      try {
+        logger(method, error);
+      } catch (logError) {
+        console.warn('[admin] localStorage logger failed', logError);
+      }
+    } else if (error) {
+      console.warn(`[admin] localStorage.${method} failed`, error);
+    }
+    if (typeof onFallback === 'function') {
+      try {
+        onFallback(error);
+      } catch (callbackError) {
+        console.warn('[admin] localStorage fallback handler failed', callbackError);
+      }
+    }
+  };
+
+  return {
+    getItem(key) {
+      if (store) {
+        try {
+          return store.getItem(key);
+        } catch (error) {
+          notifyFallback('getItem', error);
+        }
+      }
+      return hasOwn(memory, key) ? memory[key] : null;
+    },
+    setItem(key, value) {
+      if (store) {
+        try {
+          store.setItem(key, value);
+          if (hasOwn(memory, key)) delete memory[key];
+          return;
+        } catch (error) {
+          notifyFallback('setItem', error);
+        }
+      }
+      memory[key] = String(value);
+    },
+    removeItem(key) {
+      if (store) {
+        try {
+          store.removeItem(key);
+        } catch (error) {
+          notifyFallback('removeItem', error);
+        }
+      }
+      if (hasOwn(memory, key)) delete memory[key];
+    },
+    clearMemory() {
+      for (const key of Object.keys(memory)) {
+        delete memory[key];
+      }
+    },
+    isFallbackActive() {
+      return fallbackTriggered;
+    }
+  };
+}
+
+export default createSafeLocalStorage;

--- a/webroot/admin/js/core/utils.js
+++ b/webroot/admin/js/core/utils.js
@@ -31,3 +31,31 @@ export function escapeHtml(str) {
 
 // simple Deep-Clone (JSON-basiert, reicht für unsere Datenstrukturen)
 export const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === 'object') {
+    if (Array.isArray(b)) return false;
+    const keysA = Object.keys(a).filter((key) => typeof a[key] !== 'undefined').sort();
+    const keysB = Object.keys(b).filter((key) => typeof b[key] !== 'undefined').sort();
+    if (keysA.length !== keysB.length) return false;
+    for (let i = 0; i < keysA.length; i++) {
+      if (keysA[i] !== keysB[i]) return false;
+    }
+    for (const key of keysA) {
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+    return true;
+  }
+  if (Number.isNaN(a) && Number.isNaN(b)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- extract playlist, settings and page sanitizers into a reusable admin config module
- add a reusable safe localStorage wrapper and share it across the admin bootstrap
- expose a shared deepEqual helper for comparing schedule/settings snapshots

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ceed4c220483209f57d646ebc906d9