### PR TITLE
Restructure admin settings layout

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -101,6 +101,13 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 
 @layer layout{
 .row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+.settings-stack{ display:flex; flex-direction:column; gap:16px; margin-bottom:18px; }
+.settings-grid{ display:grid; gap:16px; margin-bottom:18px; }
+.settings-grid.two-col{ grid-template-columns:1fr; }
+@media (min-width: 1100px){
+  .settings-grid.two-col{ grid-template-columns:repeat(2, minmax(0,1fr)); }
+}
+.settings-card.span-2{ grid-column:1 / -1; }
 .type-list{ display:flex; flex-wrap:wrap; gap:6px; align-items:center; }
 .type-list label{ display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; border:1px solid var(--border); background:color-mix(in oklab, var(--panel) 94%, transparent); cursor:pointer; font-weight:600; }
 .type-list label.is-checked{ border-color:var(--btn-accent); background:color-mix(in oklab, var(--btn-accent) 15%, var(--panel)); color:color-mix(in oklab, var(--btn-accent) 75%, var(--fg)); }
@@ -259,6 +266,23 @@ body.devices-pinned #devicesPane{ position:sticky; top:0; z-index:40; }
   background:var(--panel); border:1px solid var(--border);
   border-radius:16px; box-shadow:0 8px 20px rgba(0,0,0,.06);
 }
+.settings-card{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:14px;
+  box-shadow:0 6px 16px rgba(0,0,0,.05);
+  padding:14px 16px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.settings-card-head{ display:flex; flex-direction:column; gap:4px; }
+.settings-card-title{ font-weight:700; letter-spacing:0.01em; font-size:14px; }
+.settings-card-description{ margin:0; color:var(--muted); font-size:13px; line-height:1.4; }
+.settings-card-body{ display:flex; flex-direction:column; gap:10px; }
+.settings-card-body .kv{ margin-bottom:0; }
+.settings-card-body .help{ margin:0; }
+.settings-card-body .fieldset{ margin:6px 0; }
 .content > details.ac.sub{ margin-top:12px; }
 .card .content, .content{ padding:12px 14px; }
 summary{

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -88,57 +88,86 @@
     </div>
   </summary>
   <div class="content">
+    <div class="settings-stack">
+      <div class="settings-card" id="slidesFlowCard">
+        <div class="settings-card-head">
+          <div class="settings-card-title">Ablauf &amp; Zeitsteuerung</div>
+          <p class="settings-card-description">Bestimme Dauer, Übergänge und Verhalten beim Abspielen.</p>
+        </div>
+        <div class="settings-card-body">
+          <!-- Dauer-Modus (global, gilt für Saunen + Bilder) -->
+          <div class="kv" id="rowDurMode">
+            <label>Dauer-Modus <span class="tip" title="Bestimmt, ob alle Slides dieselbe Dauer haben oder individuell gesteuert werden.">❔</span></label>
+            <div class="row">
+              <label class="btn sm ghost" style="gap:6px"><input type="radio" name="durMode" id="durUniform" value="uniform"> Einheitlich</label>
+              <label class="btn sm ghost" style="gap:6px"><input type="radio" name="durMode" id="durPer" value="per"> Individuell pro Slide</label>
+            </div>
+          </div>
 
-<!-- Dauer-Modus (global, gilt für Saunen + Bilder) -->
-<div class="kv" id="rowDurMode">
-  <label>Dauer-Modus <span class="tip" title="Bestimmt, ob alle Slides dieselbe Dauer haben oder individuell gesteuert werden.">❔</span></label>
-  <div class="row">
-    <label class="btn sm ghost" style="gap:6px"><input type="radio" name="durMode" id="durUniform" value="uniform"> Einheitlich</label>
-    <label class="btn sm ghost" style="gap:6px"><input type="radio" name="durMode" id="durPer" value="per"> Individuell pro Slide</label>
-  </div>
-</div>
+          <div class="kv" id="rowDwellAll">
+            <label>Dauer (einheitlich)</label>
+            <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+              <span class="mut" style="min-width:14ch;">alle außer Übersicht</span>
+              <input id="dwellAll" class="input num3" type="number" min="1" max="120" step="1" />
 
-<div class="kv" id="rowDwellAll">
-  <label>Dauer (einheitlich)</label>
-  <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
-    <span class="mut" style="min-width:14ch;">alle außer Übersicht</span>
-    <input id="dwellAll" class="input num3" type="number" min="1" max="120" step="1" />
+              <span class="mut" style="min-width:10ch;">Übersicht</span>
+              <input id="ovSecGlobal" class="input num3" type="number" min="1" max="120" step="1" />
+            </div>
+          </div>
 
-    <span class="mut" style="min-width:10ch;">Übersicht</span>
-    <input id="ovSecGlobal" class="input num3" type="number" min="1" max="120" step="1" />
-  </div>
-</div>
+          <!-- Transition -->
+          <div class="kv">
+            <label>Transition (ms)</label>
+            <input id="transMs2" class="input" type="number" min="0" value="500">
+          </div>
 
-<!-- Transition -->
-<div class="kv"><label>Transition (ms)</label>
-  <input id="transMs2" class="input" type="number" min="0" value="500">
-</div>
+          <div class="kv">
+            <label>Weiter erst nach Video-Ende</label>
+            <input id="waitForVideo" type="checkbox">
+          </div>
+        </div>
+      </div>
 
-<div class="kv"><label>Auto je Wochentag <span class="tip" title="Lädt beim Start automatisch das Preset des aktuellen Wochentags.">❔</span></label><input id="presetAuto" type="checkbox"></div>
-<div class="help">Wenn aktiv, wird beim Öffnen und beim Wechsel des Tabs automatisch das Preset des aktuellen Wochentags geladen (falls vorhanden).</div>
+      <div class="settings-card" id="slidesAutomationCard">
+        <div class="settings-card-head">
+          <div class="settings-card-title">Automatisierung</div>
+          <p class="settings-card-description">Lädt zu Start oder Tab-Wechsel automatisch passende Voreinstellungen.</p>
+        </div>
+        <div class="settings-card-body">
+          <div class="kv">
+            <label>Auto je Wochentag <span class="tip" title="Lädt beim Start automatisch das Preset des aktuellen Wochentags.">❔</span></label>
+            <input id="presetAuto" type="checkbox">
+          </div>
+          <div class="help">Wenn aktiv, wird beim Öffnen und beim Wechsel des Tabs automatisch das Preset des aktuellen Wochentags geladen (falls vorhanden).</div>
+        </div>
+      </div>
 
-<div class="kv"><label>Weiter erst nach Video-Ende</label><input id="waitForVideo" type="checkbox"></div>
-
-<div class="fieldset" id="heroTimelineBox">
-  <div class="legend">Hero-Timeline</div>
-  <div class="kv">
-    <label class="row" style="gap:8px;align-items:center">
-      <input id="heroTimelineEnabled" type="checkbox">
-      <span>Hero-Timeline anzeigen</span>
-    </label>
-  </div>
-  <div class="kv" id="heroTimelineSettings" hidden>
-    <label>Einstellungen</label>
-    <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
-      <span class="mut">Dauer (s)</span>
-      <input id="heroTimelineDuration" class="input num3" type="number" min="1" max="120" step="1">
-      <span class="mut">Basis-Minuten</span>
-      <input id="heroTimelineBase" class="input num3" type="number" min="1" max="120" step="1">
-      <span class="mut">Max. Einträge</span>
-      <input id="heroTimelineMax" class="input num3" type="number" min="1" max="50" step="1" placeholder="leer = alle">
+      <div class="settings-card" id="heroTimelineBox">
+        <div class="settings-card-head">
+          <div class="settings-card-title">Hero-Timeline</div>
+          <p class="settings-card-description">Optionaler Zeitstrahl für kommende Aufgüsse im rechten Bereich.</p>
+        </div>
+        <div class="settings-card-body">
+          <div class="kv">
+            <label class="row" style="gap:8px;align-items:center">
+              <input id="heroTimelineEnabled" type="checkbox">
+              <span>Hero-Timeline anzeigen</span>
+            </label>
+          </div>
+          <div class="kv" id="heroTimelineSettings" hidden>
+            <label>Einstellungen</label>
+            <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+              <span class="mut">Dauer (s)</span>
+              <input id="heroTimelineDuration" class="input num3" type="number" min="1" max="120" step="1">
+              <span class="mut">Basis-Minuten</span>
+              <input id="heroTimelineBase" class="input num3" type="number" min="1" max="120" step="1">
+              <span class="mut">Max. Einträge</span>
+              <input id="heroTimelineMax" class="input num3" type="number" min="1" max="50" step="1" placeholder="leer = alle">
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
 
     <!-- Unterbox 1: Saunen & Übersicht -->
     <details class="ac sub" open id="boxSaunas">
@@ -256,171 +285,215 @@
           <div class="actions"><button class="btn sm ghost" id="resetSlides">Standardwerte</button></div>
         </summary>
         <div class="content">
-          <div class="subh">Skalierung & 16:9</div>
-          <div class="kv"><label>Fit‑Modus</label>
-            <select id="fitMode" class="input">
-              <option value="auto">Auto</option>
-            </select>
-          </div>
-          <div class="help">Passt je nach Seitenverhältnis automatisch an (Cover oder Contain).</div>
-
-          <div class="subh">Schrift</div>
-          <div class="kv"><label>Schriftfamilie</label>
-            <select id="fontFamily" class="input">
-              <option value="system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif">System (Default)</option>
-              <option value="Montserrat, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif">Montserrat</option>
-              <option value="Roboto, system-ui, -apple-system, Segoe UI, Arial, sans-serif">Roboto</option>
-              <option value="'Open Sans', system-ui, -apple-system, Segoe UI, Arial, sans-serif">Open Sans</option>
-              <option value="Lato, system-ui, -apple-system, Segoe UI, Arial, sans-serif">Lato</option>
-            </select>
-          </div>
-          <div class="kv"><label>Globaler Scale</label><input id="fontScale" class="input" type="number" step="0.05" min="0.5" max="3" value="1"></div>
-          <div class="kv"><label>H1 Scale</label><input id="h1Scale" class="input" type="number" step="0.05" min="0.5" max="3.5" value="1"></div>
-          <div class="kv"><label>H2 Scale</label><input id="h2Scale" class="input" type="number" step="0.05" min="0.5" max="3.5" value="1"></div>
-          <div class="kv"><label>H2 Modus</label>
-            <select id="h2Mode" class="input">
-              <option value="none">— nichts —</option>
-              <option value="text" selected>Nur Text</option>
-              <option value="weekday">Wochentag</option>
-              <option value="date">Datum</option>
-              <option value="text+weekday">Text + Wochentag</option>
-              <option value="text+date">Text + Datum</option>
-            </select>
-          </div>
-          <div class="kv"><label>H2 Text</label><input id="h2Text" class="input" type="text" placeholder="Aufgusszeiten"></div>
-          <div class="kv"><label>H2 in Übersicht anzeigen</label><input id="h2ShowOverview" type="checkbox" checked></div>
-
-          <div class="subh">Übersicht (Tabelle)</div>
-          <div class="kv"><label>Übersichtstitel Scale</label><input id="ovTitleScale" class="input" type="number" step="0.05" min="0.4" max="4" value="1"></div>
-          <div class="kv"><label>Kopf‑Scale</label><input id="ovHeadScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.9"></div>
-          <div class="kv"><label>Zellen‑Scale</label><input id="ovCellScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.8"></div>
-          <div class="kv"><label>Chip‑Höhe (%)</label><input id="chipH" class="input" type="number" min="50" max="200" value="100"></div>
-          <div class="help">Chips sind immer gleich breit/hoch (füllen die Zelle) und zentriert.</div>
-<div class="kv"><label>Textüberlänge</label>
-  <select id="chipOverflowMode" class="input">
-    <option value="scale" selected>Automatisch skalieren</option>
-    <option value="ellipsis">Mit „…“ kürzen</option>
-  </select>
-</div>
-<div class="kv"><label>Flammen-Größe (% der Chip-Höhe)</label>
-  <input id="flamePct" class="input" type="number" min="30" max="100" value="55">
-</div>
-<div class="kv"><label>Flammen-Abstand (Faktor)</label>
-  <input id="flameGap" class="input" type="number" min="0" max="1" step="0.01" value="0.14">
-</div>
-
-          <div class="subh">Saunafolien (Kacheln)</div>
-          <div class="kv"><label>Text‑Scale</label><input id="tileTextScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.8"></div>
-          <div class="kv"><label>Font‑Weight</label>
-            <select id="tileWeight" class="input">
-              <option value="400">Normal (400)</option>
-              <option value="500">Medium (500)</option>
-              <option value="600" selected>Semibold (600)</option>
-              <option value="700">Bold (700)</option>
-              <option value="800">Extra Bold (800)</option>
-            </select>
-          </div>
-          <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
-          <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
-          <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
-          <div class="kv"><label>Badge-Farbe</label>
-            <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
-          </div>
-          <div class="kv">
-            <label>Komponenten auf Slides</label>
-            <div id="componentToggleWrap" class="component-toggle-wrap">
-              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="title"> Titel &amp; Uhrzeit</label>
-              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="description"> Beschreibung</label>
-              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="aromas"> Aromenliste</label>
-              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="facts"> Fakten/Chips</label>
-              <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="badges"> Badge-Leiste</label>
-            </div>
-            <div class="help">Gilt auch für die Verfügbarkeitsliste in Story-Slides.</div>
-          </div>
-          <div class="kv">
-            <label>Stil-Paletten</label>
-            <div class="style-set-controls">
-              <select id="styleSetSelect" class="input"></select>
-              <div class="row" style="gap:6px;flex-wrap:wrap">
-                <button class="btn sm" id="styleSetApply" type="button">Aktivieren</button>
-                <button class="btn sm ghost" id="styleSetSave" type="button">Aktualisieren</button>
-                <button class="btn sm ghost" id="styleSetCreate" type="button">Neu</button>
-                <button class="btn sm ghost" id="styleSetDelete" type="button">Löschen</button>
+          <div class="settings-grid two-col">
+            <div class="settings-card">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Skalierung &amp; 16:9</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>Fit‑Modus</label>
+                  <select id="fitMode" class="input">
+                    <option value="auto">Auto</option>
+                  </select>
+                </div>
+                <div class="help">Passt je nach Seitenverhältnis automatisch an (Cover oder Contain).</div>
               </div>
             </div>
-          </div>
-          <div class="kv"><label>Palettenname</label><input id="styleSetLabel" class="input" type="text" placeholder="Palette"></div>
-          <div class="help">Paletten speichern Farben, Typografie und Badge-Optionen. „Aktivieren“ übernimmt die Auswahl in die aktuellen Einstellungen.</div>
 
-          <div class="subh">Bildspalte / Schrägschnitt</div>
-          <div class="kv"><label>Breite rechts (%)</label><input id="rightW" class="input" type="number" min="0" max="70" value="38"></div>
-          <div class="kv"><label>Schnitt oben (%)</label><input id="cutTop" class="input" type="number" min="0" max="100" value="28"></div>
-          <div class="kv"><label>Schnitt unten (%)</label><input id="cutBottom" class="input" type="number" min="0" max="100" value="12"></div>
-          <div class="help">Bestimmt Breite der Bildspalte und die beiden Ankerpunkte (oben/unten) der diagonalen Schnittkante.</div>
+            <div class="settings-card">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Typografie – Basis</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>Schriftfamilie</label>
+                  <select id="fontFamily" class="input">
+                    <option value="system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue',sans-serif">System (Default)</option>
+                    <option value="Montserrat, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif">Montserrat</option>
+                    <option value="Roboto, system-ui, -apple-system, Segoe UI, Arial, sans-serif">Roboto</option>
+                    <option value="'Open Sans', system-ui, -apple-system, Segoe UI, Arial, sans-serif">Open Sans</option>
+                    <option value="Lato, system-ui, -apple-system, Segoe UI, Arial, sans-serif">Lato</option>
+                  </select>
+                </div>
+                <div class="kv"><label>Globaler Scale</label><input id="fontScale" class="input" type="number" step="0.05" min="0.5" max="3" value="1"></div>
+              </div>
+            </div>
 
-          <div class="subh">Layout &amp; Seiten</div>
-          <div class="kv">
-            <label>Darstellung</label>
-            <select id="layoutMode" class="input">
-              <option value="single">Einspaltig</option>
-              <option value="split">Zweispaltig</option>
-            </select>
-          </div>
-          <div class="fieldset layout-page" id="layoutLeft">
-            <div class="legend">Linke Seite</div>
-            <div class="kv">
-              <label>Quelle</label>
-              <select id="pageLeftSource" class="input">
-                <option value="master">Alle Inhalte</option>
-                <option value="schedule">Aufgussplan</option>
-                <option value="media">Medien</option>
-                <option value="story">Erklärungen</option>
-              </select>
+            <div class="settings-card">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Typografie – Überschriften</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>H1 Scale</label><input id="h1Scale" class="input" type="number" step="0.05" min="0.5" max="3.5" value="1"></div>
+                <div class="kv"><label>H2 Scale</label><input id="h2Scale" class="input" type="number" step="0.05" min="0.5" max="3.5" value="1"></div>
+                <div class="kv"><label>H2 Modus</label>
+                  <select id="h2Mode" class="input">
+                    <option value="none">— nichts —</option>
+                    <option value="text" selected>Nur Text</option>
+                    <option value="weekday">Wochentag</option>
+                    <option value="date">Datum</option>
+                    <option value="text+weekday">Text + Wochentag</option>
+                    <option value="text+date">Text + Datum</option>
+                  </select>
+                </div>
+                <div class="kv"><label>H2 Text</label><input id="h2Text" class="input" type="text" placeholder="Aufgusszeiten"></div>
+                <div class="kv"><label>H2 in Übersicht anzeigen</label><input id="h2ShowOverview" type="checkbox" checked></div>
+              </div>
             </div>
-            <div class="kv">
-              <label>Timer (Sekunden)</label>
-              <input id="pageLeftTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
-            </div>
-            <div class="kv">
-              <label>Playlist</label>
-              <div class="playlist-selector" id="pageLeftPlaylist"></div>
-              <div class="help">Klicken zum (De-)Aktivieren, Pfeile oder Ziehen für die Reihenfolge. Eine leere Playlist nutzt den Standardfilter.</div>
-            </div>
-          </div>
-          <div class="fieldset layout-page" id="layoutRight">
-            <div class="legend">Rechte Seite</div>
-            <div class="kv">
-              <label>Quelle</label>
-              <select id="pageRightSource" class="input">
-                <option value="media">Medien</option>
-                <option value="master">Alle Inhalte</option>
-                <option value="schedule">Aufgussplan</option>
-                <option value="story">Erklärungen</option>
-              </select>
-            </div>
-            <div class="kv">
-              <label>Timer (Sekunden)</label>
-              <input id="pageRightTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
-            </div>
-            <div class="kv">
-              <label>Playlist</label>
-              <div class="playlist-selector" id="pageRightPlaylist"></div>
-              <div class="help">Klicken zum (De-)Aktivieren, Pfeile oder Ziehen für die Reihenfolge.</div>
-            </div>
-            <div class="help">Wird verwendet, wenn das Zweispalten-Layout aktiv ist.</div>
-          </div>
 
-          <div class="subh">Flammen / Hervorhebungen</div>
-          <div class="kv"><label>Highlight aktiv</label><input id="hlEnabled" type="checkbox"></div>
-          <div class="kv"><label>Highlight‑Farbe (Hex)</label><div class="color-item"><div id="hlSw" class="swatch"></div><input id="hlColor" class="input" type="text" value="#FFDD66" placeholder="#RRGGBB"></div></div>
-          <div class="kv"><label>Min. vor Start</label><input id="hlBefore" class="input" type="number" min="0" max="120" value="15"></div>
-          <div class="kv"><label>Min. nach Start</label><input id="hlAfter" class="input" type="number" min="0" max="120" value="15"></div>
-          <div class="kv"><label>Flammen‑Bild</label>
-            <div class="row" style="gap:8px">
-              <img id="flamePrev" class="prev" alt="">
-              <input id="flameImg" type="hidden" />
-              <label class="btn sm ghost" style="position:relative;overflow:hidden"><input id="flameFile" type="file" accept="image/*" style="position:absolute;inset:0;opacity:0">Upload</label>
-              <button class="btn sm" id="resetFlame">Default</button>
+            <div class="settings-card">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Übersicht (Tabelle)</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>Übersichtstitel Scale</label><input id="ovTitleScale" class="input" type="number" step="0.05" min="0.4" max="4" value="1"></div>
+                <div class="kv"><label>Kopf‑Scale</label><input id="ovHeadScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.9"></div>
+                <div class="kv"><label>Zellen‑Scale</label><input id="ovCellScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.8"></div>
+                <div class="kv"><label>Chip‑Höhe (%)</label><input id="chipH" class="input" type="number" min="50" max="200" value="100"></div>
+                <div class="help">Chips sind immer gleich breit/hoch (füllen die Zelle) und zentriert.</div>
+                <div class="kv"><label>Textüberlänge</label>
+                  <select id="chipOverflowMode" class="input">
+                    <option value="scale" selected>Automatisch skalieren</option>
+                    <option value="ellipsis">Mit „…“ kürzen</option>
+                  </select>
+                </div>
+                <div class="kv"><label>Flammen-Größe (% der Chip-Höhe)</label>
+                  <input id="flamePct" class="input" type="number" min="30" max="100" value="55">
+                </div>
+                <div class="kv"><label>Flammen-Abstand (Faktor)</label>
+                  <input id="flameGap" class="input" type="number" min="0" max="1" step="0.01" value="0.14">
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-card span-2">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Saunafolien &amp; Komponenten</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>Text‑Scale</label><input id="tileTextScale" class="input" type="number" step="0.05" min="0.5" max="3" value="0.8"></div>
+                <div class="kv"><label>Font‑Weight</label>
+                  <select id="tileWeight" class="input">
+                    <option value="400">Normal (400)</option>
+                    <option value="500">Medium (500)</option>
+                    <option value="600" selected>Semibold (600)</option>
+                    <option value="700">Bold (700)</option>
+                    <option value="800">Extra Bold (800)</option>
+                  </select>
+                </div>
+                <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
+                <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
+                <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
+                <div class="kv"><label>Badge-Farbe</label>
+                  <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
+                </div>
+                <div class="kv">
+                  <label>Komponenten auf Slides</label>
+                  <div id="componentToggleWrap" class="component-toggle-wrap">
+                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="title"> Titel &amp; Uhrzeit</label>
+                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="description"> Beschreibung</label>
+                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="aromas"> Aromenliste</label>
+                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="facts"> Fakten/Chips</label>
+                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="badges"> Badge-Leiste</label>
+                  </div>
+                  <div class="help">Gilt auch für die Verfügbarkeitsliste in Story-Slides.</div>
+                </div>
+                <div class="kv">
+                  <label>Stil-Paletten</label>
+                  <div class="style-set-controls">
+                    <select id="styleSetSelect" class="input"></select>
+                    <div class="row" style="gap:6px;flex-wrap:wrap">
+                      <button class="btn sm" id="styleSetApply" type="button">Aktivieren</button>
+                      <button class="btn sm ghost" id="styleSetSave" type="button">Aktualisieren</button>
+                      <button class="btn sm ghost" id="styleSetCreate" type="button">Neu</button>
+                      <button class="btn sm ghost" id="styleSetDelete" type="button">Löschen</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="kv"><label>Palettenname</label><input id="styleSetLabel" class="input" type="text" placeholder="Palette"></div>
+                <div class="help">Paletten speichern Farben, Typografie und Badge-Optionen. „Aktivieren“ übernimmt die Auswahl in die aktuellen Einstellungen.</div>
+              </div>
+            </div>
+
+            <div class="settings-card span-2">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Bildspalte &amp; Layout</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>Breite rechts (%)</label><input id="rightW" class="input" type="number" min="0" max="70" value="38"></div>
+                <div class="kv"><label>Schnitt oben (%)</label><input id="cutTop" class="input" type="number" min="0" max="100" value="28"></div>
+                <div class="kv"><label>Schnitt unten (%)</label><input id="cutBottom" class="input" type="number" min="0" max="100" value="12"></div>
+                <div class="help">Bestimmt Breite der Bildspalte und die beiden Ankerpunkte (oben/unten) der diagonalen Schnittkante.</div>
+                <div class="kv">
+                  <label>Darstellung</label>
+                  <select id="layoutMode" class="input">
+                    <option value="single">Einspaltig</option>
+                    <option value="split">Zweispaltig</option>
+                  </select>
+                </div>
+                <div class="fieldset layout-page" id="layoutLeft">
+                  <div class="legend">Linke Seite</div>
+                  <div class="kv">
+                    <label>Quelle</label>
+                    <select id="pageLeftSource" class="input">
+                      <option value="master">Alle Inhalte</option>
+                      <option value="schedule">Aufgussplan</option>
+                      <option value="media">Medien</option>
+                      <option value="story">Erklärungen</option>
+                    </select>
+                  </div>
+                  <div class="kv">
+                    <label>Timer (Sekunden)</label>
+                    <input id="pageLeftTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
+                  </div>
+                  <div class="kv">
+                    <label>Playlist</label>
+                    <div class="playlist-selector" id="pageLeftPlaylist"></div>
+                    <div class="help">Klicken zum (De-)Aktivieren, Pfeile oder Ziehen für die Reihenfolge. Eine leere Playlist nutzt den Standardfilter.</div>
+                  </div>
+                </div>
+                <div class="fieldset layout-page" id="layoutRight">
+                  <div class="legend">Rechte Seite</div>
+                  <div class="kv">
+                    <label>Quelle</label>
+                    <select id="pageRightSource" class="input">
+                      <option value="media">Medien</option>
+                      <option value="master">Alle Inhalte</option>
+                      <option value="schedule">Aufgussplan</option>
+                      <option value="story">Erklärungen</option>
+                    </select>
+                  </div>
+                  <div class="kv">
+                    <label>Timer (Sekunden)</label>
+                    <input id="pageRightTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
+                  </div>
+                  <div class="kv">
+                    <label>Playlist</label>
+                    <div class="playlist-selector" id="pageRightPlaylist"></div>
+                    <div class="help">Klicken zum (De-)Aktivieren, Pfeile oder Ziehen für die Reihenfolge.</div>
+                  </div>
+                  <div class="help">Wird verwendet, wenn das Zweispalten-Layout aktiv ist.</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-card span-2">
+              <div class="settings-card-head">
+                <div class="settings-card-title">Flammen / Hervorhebungen</div>
+              </div>
+              <div class="settings-card-body">
+                <div class="kv"><label>Highlight aktiv</label><input id="hlEnabled" type="checkbox"></div>
+                <div class="kv"><label>Highlight‑Farbe (Hex)</label><div class="color-item"><div id="hlSw" class="swatch"></div><input id="hlColor" class="input" type="text" value="#FFDD66" placeholder="#RRGGBB"></div></div>
+                <div class="kv"><label>Min. vor Start</label><input id="hlBefore" class="input" type="number" min="0" max="120" value="15"></div>
+                <div class="kv"><label>Min. nach Start</label><input id="hlAfter" class="input" type="number" min="0" max="120" value="15"></div>
+                <div class="kv"><label>Flammen‑Bild</label>
+                  <div class="row" style="gap:8px">
+                    <img id="flamePrev" class="prev" alt="">
+                    <input id="flameImg" type="hidden" />
+                    <label class="btn sm ghost" style="position:relative;overflow:hidden"><input id="flameFile" type="file" accept="image/*" style="position:absolute;inset:0;opacity:0">Upload</label>
+                    <button class="btn sm" id="resetFlame">Default</button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- cluster the slideshow timing, automation, and hero timeline controls into a card-based stack for easier scanning
- reorganize the “Slideshow & Text” area into topic-specific cards within a responsive grid layout
- add shared styling helpers for the new settings cards and grid structure

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cf914195248320ac82505472dad93a