### PR TITLE
Make admin sidebar two-column layout

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -103,11 +103,8 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
 .settings-stack{ display:flex; flex-direction:column; gap:16px; margin-bottom:18px; }
 .settings-grid{ display:grid; gap:16px; margin-bottom:18px; }
-.settings-grid.two-col{ grid-template-columns:1fr; }
-@media (min-width: 1100px){
-  .settings-grid.two-col{ grid-template-columns:repeat(2, minmax(0,1fr)); }
-}
-.settings-card.span-2{ grid-column:1 / -1; }
+.settings-grid.two-col{ grid-template-columns:repeat(auto-fit, minmax(300px, 1fr)); }
+.span-2{ grid-column:1 / -1; }
 .type-list{ display:flex; flex-wrap:wrap; gap:6px; align-items:center; }
 .type-list label{ display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; border:1px solid var(--border); background:color-mix(in oklab, var(--panel) 94%, transparent); cursor:pointer; font-weight:600; }
 .type-list label.is-checked{ border-color:var(--btn-accent); background:color-mix(in oklab, var(--btn-accent) 15%, var(--panel)); color:color-mix(in oklab, var(--btn-accent) 75%, var(--fg)); }
@@ -245,7 +242,7 @@ body.device-mode .ctx-badge-close:focus-visible{
 main.layout{
   width:100%;
   display:grid;
-  grid-template-columns:minmax(0,1fr) minmax(420px, 920px);
+  grid-template-columns:minmax(0,1fr) minmax(320px, 860px);
   gap:14px; padding:16px 12px 18px 16px; align-items:start;
 }
 .leftcol{ display:flex; flex-direction:column; gap:16px; min-width:0; }
@@ -254,15 +251,16 @@ main.layout{
   max-height:calc(100svh - 64px);
   overflow:auto; padding-right:12px;
   justify-self:end;
-  width:min(920px, 100%);
-  max-width:920px;
-  min-width:min(520px, 100%);
+  width:min(860px, 100%);
+  max-width:860px;
+  min-width:min(360px, 100%);
 }
 
 .rightbar-columns{
   display:grid;
-  gap:14px;
+  gap:16px;
   grid-template-columns:repeat(auto-fit, minmax(320px, 1fr));
+  grid-auto-flow:row dense;
   align-content:start;
 }
 
@@ -271,11 +269,21 @@ main.layout{
   margin:0;
 }
 
-.rightbar-columns > .full{
+.rightbar-columns > .full,
+.rightbar-columns > .span-2{
   grid-column:1 / -1;
 }
 
-@media (max-width: 860px){
+.slides-master-top{ margin-bottom:18px; }
+.slides-master-columns{
+  display:grid;
+  gap:16px;
+  grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));
+  align-content:start;
+}
+.slides-master-columns > .span-2{ grid-column:1 / -1; }
+
+@media (max-width: 768px){
   .rightbar{ min-width:0; }
   .rightbar-columns{ grid-template-columns:minmax(0,1fr); }
 }

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -80,8 +80,8 @@
 
     <aside class="rightbar">
       <div class="rightbar-columns">
-<!-- Slides – Masterbox -->
-<details class="ac full" open id="slidesMaster">
+        <!-- Slides – Masterbox -->
+        <details class="ac full" open id="slidesMaster">
   <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Slides – Reihenfolge, Sichtbarkeit & Zeiten</div>
     <div class="actions">
@@ -89,7 +89,7 @@
     </div>
   </summary>
   <div class="content">
-    <div class="settings-stack">
+    <div class="settings-grid two-col slides-master-top">
       <div class="settings-card" id="slidesFlowCard">
         <div class="settings-card-head">
           <div class="settings-card-title">Ablauf &amp; Zeitsteuerung</div>
@@ -170,8 +170,9 @@
       </div>
     </div>
 
-    <!-- Unterbox 1: Saunen & Übersicht -->
-    <details class="ac sub" open id="boxSaunas">
+    <div class="slides-master-columns">
+      <!-- Unterbox 1: Saunen & Übersicht -->
+      <details class="ac sub span-2" open id="boxSaunas">
       <summary><div class="ttl">▶<span class="chev">⮞</span> Saunen & Übersicht</div>
  <div class="actions"><button class="btn sm" id="btnAddSauna">Sauna hinzufügen</button></div>
 </summary>      
@@ -210,7 +211,7 @@
     </details>
 
     <!-- Unterbox 2: Fußnoten & Badges -->
-    <details class="ac sub" id="boxFootnotes">
+      <details class="ac sub" id="boxFootnotes">
   <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Fußnoten &amp; Badges</div>
     <div class="actions"><button class="btn sm" id="fnAdd">Fußnote hinzufügen</button></div>
@@ -252,10 +253,10 @@
       </div>
     </div>
   </div>
-</details>
+        </details>
 
     <!-- Unterbox 4: Story-Slides -->
-    <details class="ac sub" id="boxStories">
+      <details class="ac sub" id="boxStories">
       <summary>
         <div class="ttl">▶<span class="chev">⮞</span> Informationen</div>
         <div class="actions"><button class="btn sm" id="btnStoryAdd">Information hinzufügen</button></div>
@@ -270,7 +271,7 @@
     </details>
 
     <!-- Unterbox 4: Medien-Slides -->
-    <details class="ac sub" id="boxImages">
+      <details class="ac sub span-2" id="boxImages">
 <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>
     <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button><button class="btn sm" id="btnSortSlides">Slides sortieren</button></div>
@@ -288,12 +289,13 @@
   </div>
     <div id="interList2"></div>
   </div>
-</details>
+      </details>
+    </div>
 
   </div>
 </details>
 
- <details class="ac full" id="boxSlidesText">
+        <details class="ac full" id="boxSlidesText">
         <summary>
           <div class="ttl">▶<span class="chev">⮞</span> Slideshow & Text</div>
           <div class="actions"><button class="btn sm ghost" id="resetSlides">Standardwerte</button></div>
@@ -521,7 +523,7 @@
         </div>
 </details>
 
-      <details class="ac full">
+        <details class="ac">
         <summary>
           <div class="ttl">▶<span class="chev">⮞</span> Farben (Übersicht & Zeitspalte)</div>
           <div class="actions"><button class="btn sm ghost" id="resetColors">Standardwerte</button></div>
@@ -529,7 +531,7 @@
         <div class="content color-cols" id="colorList"></div>
       </details>
 
-      <details class="ac">
+        <details class="ac">
         <summary>
           <div class="ttl">▶<span class="chev">⮞</span> System</div>
         </summary>


### PR DESCRIPTION
## Summary
- restructure the slides master detail into a two-column grid and group sub-sections with column spans
- place the colors and system panels within the sidebar grid so they can share the second column
- tune the admin layout CSS to support the responsive two-column sidebar while allowing a slimmer sidebar width

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfbbb554108320a5a594ae593bbee1