### PR TITLE
Adjust sauna tile layout and spacing

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -468,6 +468,7 @@
                 <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
                 <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
                 <div class="kv"><label>Kachel-Höhen-Scale</label><input id="tileHeightScale" class="input" type="number" step="0.05" min="0.5" max="2" value="1"></div>
+                <div class="kv"><label>Innenabstand (Faktor)</label><input id="tilePaddingScale" class="input" type="number" step="0.05" min="0.4" max="1.6" value="0.85"></div>
                 <div class="kv"><label>Badge-Farbe</label>
                   <input id="badgeColor" class="input" type="color" value="#5C3101" title="Badge-Farbe">
                 </div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -905,6 +905,7 @@ function renderSlidesBox(){
   setV('#tileMin',       settings.slides?.tileMinScale ?? 0.25);
   setV('#tileMax',       settings.slides?.tileMaxScale ?? 0.57);
   setV('#tileHeightScale', settings.slides?.tileHeightScale ?? DEFAULTS.slides.tileHeightScale ?? 1);
+  setV('#tilePaddingScale', settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.85);
   setV('#badgeScale', settings.slides?.badgeScale ?? DEFAULTS.slides.badgeScale ?? 1);
   setV('#badgeDescriptionScale', settings.slides?.badgeDescriptionScale ?? DEFAULTS.slides.badgeDescriptionScale ?? 1);
   const overlayCheckbox = document.getElementById('tileOverlayEnabled');
@@ -996,6 +997,7 @@ function renderSlidesBox(){
     setV('#tileMin',       DEFAULTS.slides.tileMinScale);
     setV('#tileMax',       DEFAULTS.slides.tileMaxScale);
     setV('#tileHeightScale', DEFAULTS.slides.tileHeightScale);
+    setV('#tilePaddingScale', DEFAULTS.slides.tilePaddingScale);
     setV('#badgeScale',    DEFAULTS.slides.badgeScale);
     setV('#badgeDescriptionScale', DEFAULTS.slides.badgeDescriptionScale);
     setV('#badgeColor',    DEFAULTS.slides.infobadgeColor);
@@ -1312,6 +1314,11 @@ function collectSettings(){
           const raw = Number($('#tileHeightScale')?.value);
           if (!Number.isFinite(raw)) return settings.slides?.tileHeightScale ?? DEFAULTS.slides.tileHeightScale ?? 1;
           return clamp(0.5, raw, 2);
+        })(),
+        tilePaddingScale:(() => {
+          const raw = Number($('#tilePaddingScale')?.value);
+          if (!Number.isFinite(raw)) return settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.85;
+          return clamp(0.4, raw, 1.6);
         })(),
         badgeScale:(() => {
           const raw = Number($('#badgeScale')?.value);

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -61,6 +61,7 @@ const DEFAULT_STYLE_SETS = {
       badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
       badgeScale:1,
       badgeDescriptionScale:1,
+      tilePaddingScale:0.85,
       customBadgeEmojis:[]
     }
   },
@@ -97,6 +98,7 @@ const DEFAULT_STYLE_SETS = {
       badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
       badgeScale:1,
       badgeDescriptionScale:1,
+      tilePaddingScale:0.85,
       customBadgeEmojis:[]
     }
   }
@@ -111,6 +113,7 @@ export const DEFAULTS = {
     tileMinScale:0.25,
     tileMaxScale:0.57,
     tileHeightScale:1,
+    tilePaddingScale:0.85,
     tileOverlayEnabled:true,
     tileOverlayStrength:1,
     infobadgeColor:'#5C3101',

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -36,7 +36,7 @@ const STYLE_FONT_KEYS = [
 ];
 const STYLE_SLIDE_KEYS = [
   'infobadgeColor','badgeLibrary','customBadgeEmojis','badgeScale','badgeDescriptionScale',
-  'tileHeightScale','tileOverlayEnabled','tileOverlayStrength'
+  'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength'
 ];
 
 const SUGGESTED_BADGE_EMOJIS = [

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -481,37 +481,44 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   align-items:flex-start;
   min-width:0;
 }
-.card-meta{
+.card-meta,
+.tile .title{
   display:flex;
+  flex-wrap:wrap;
   align-items:baseline;
-  gap:.5em;
+  column-gap:.5em;
+  row-gap:.2em;
   font-size:calc(40px*var(--scale)*var(--tileTextScale));
   font-weight:var(--tileWeight);
   line-height:1.05;
-  white-space:nowrap;
 }
-.card-meta .time{
+.card-meta{white-space:nowrap;}
+.card-meta .time,
+.tile .title .time{
+  display:inline-flex;
+  align-items:baseline;
   font-size:calc(.65em*var(--tileMetaScale,1));
   letter-spacing:.12em;
   text-transform:uppercase;
   opacity:.8;
   white-space:nowrap;
 }
-.card-meta .sep{
+.card-meta .sep,
+.tile .title .sep{
   opacity:.7;
   font-size:.8em;
+  flex:0 0 auto;
 }
-.tile .title{
-  display:flex;
-  flex-wrap:wrap;
+.tile .title{min-width:0;}
+.tile .title .label{
+  display:inline-flex;
   align-items:baseline;
-  gap:.5em;
-  font-size:calc(40px*var(--scale)*var(--tileTextScale));
-  font-weight:var(--tileWeight);
-  line-height:1.05;
+  gap:.35em;
+  flex-wrap:wrap;
   min-width:0;
+  flex:1 1 auto;
+  white-space:normal;
 }
-.tile .title .label{display:flex;align-items:baseline;gap:.35em;flex-wrap:wrap;min-width:0;}
 .tile .title .label .notewrap{flex:0 0 auto;}
 .card-content .description{
   display:block;
@@ -546,6 +553,14 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   gap:var(--tileChipGapPx, calc(8px*var(--vwScale)));
 }
 .badge-row .badge{margin:0;}
+.tile .badge-row{
+  flex-wrap:nowrap;
+  min-width:0;
+}
+.tile .badge-row .badge{
+  flex:0 0 auto;
+  white-space:nowrap;
+}
 .tile .badge{
   display:inline-flex;
   align-items:center;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -2409,10 +2409,18 @@ function renderStorySlide(story = {}, region = 'left') {
     const clamp = (min, val, max) => Math.min(Math.max(val, min), max);
 
     const iconSize = clamp(56, t * 0.16, 200);
-    const padY = useIcons ? clamp(14, t * 0.045, 44) : clamp(10, t * 0.035, 32);
-    const padX = useIcons
-      ? Math.max(clamp(20, t * 0.07, 68), padY + 6)
-      : Math.max(clamp(18, t * 0.06, 48), padY + 4);
+    const basePadY = useIcons ? clamp(12, t * 0.04, 40) : clamp(9, t * 0.032, 28);
+    const basePadX = useIcons
+      ? Math.max(clamp(18, t * 0.062, 64), basePadY + 6)
+      : Math.max(clamp(16, t * 0.055, 44), basePadY + 4);
+    const padScale = Number.isFinite(+settings?.slides?.tilePaddingScale)
+      ? clamp(0.4, +settings.slides.tilePaddingScale, 1.6)
+      : 0.85;
+    const padY = clamp(6, basePadY * padScale, basePadY * 1.6);
+    const padX = Math.max(
+      clamp(10, basePadX * padScale, basePadX * 1.6),
+      padY + (useIcons ? 6 : 4)
+    );
     const gap = useIcons ? clamp(16, t * 0.05, 38) : clamp(12, t * 0.04, 30);
     const contentGap = useIcons ? clamp(8, t * 0.03, 26) : clamp(6, t * 0.022, 18);
     const chipGap = useIcons ? clamp(6, t * 0.022, 22) : clamp(4, t * 0.018, 16);
@@ -2434,8 +2442,8 @@ function renderStorySlide(story = {}, region = 'left') {
     const flameSize = useIcons ? clamp(22, t * 0.03, 42) : clamp(18, t * 0.026, 32);
     const iconColumn = useIcons ? clamp(44, iconSize * 0.78, iconSize * 1.52) : 0;
     const tileMinHeight = useIcons
-      ? clamp(92, iconSize * 0.9, iconSize * 1.18)
-      : clamp(80, padY * 3.4, 132);
+      ? clamp(78, iconSize * 0.9, iconSize * 1.12)
+      : clamp(66, padY * 3.1, 120);
     const iconHeightScale = useIcons
       ? clamp(0.72, tileMinHeight / Math.max(iconSize, 1), 1.05)
       : 0;
@@ -2721,6 +2729,10 @@ function renderStorySlide(story = {}, region = 'left') {
       }
 
       const titleNode = h('div', { class: 'title' });
+      if (it.time) {
+        titleNode.appendChild(h('span', { class: 'time' }, it.time + ' Uhr'));
+        titleNode.appendChild(h('span', { class: 'sep', 'aria-hidden': 'true' }, '–'));
+      }
       const labelNode = h('span', { class: 'label' }, baseTitle);
       const supNote = noteSup(it, notes);
       if (supNote) {
@@ -2732,22 +2744,16 @@ function renderStorySlide(story = {}, region = 'left') {
       titleNode.appendChild(labelNode);
 
       const badgeRowNode = createBadgeRow(it.badges, 'badge-row');
-      const metaColumn = h('div', { class: 'card-meta' });
-      if (it.time) {
-        metaColumn.appendChild(h('span', { class: 'time' }, it.time + ' Uhr'));
-        metaColumn.appendChild(h('span', { class: 'sep', 'aria-hidden': 'true' }, '–'));
-      }
-
       const mainColumn = h('div', { class: 'card-main' });
-      const contentChildren = [];
-      let hasMetaColumn = false;
-      if (metaColumn.childNodes.length) {
-        contentChildren.push(metaColumn);
-        hasMetaColumn = true;
-      }
-      contentChildren.push(mainColumn);
-      const contentBlock = h('div', { class: 'card-content' }, contentChildren);
-      if (hasMetaColumn) contentBlock.classList.add('card-content--with-meta');
+      const contentBlock = h('div', { class: 'card-content' }, [mainColumn]);
+      let metaColumn = null;
+      const ensureMetaColumn = () => {
+        if (metaColumn) return metaColumn;
+        metaColumn = h('div', { class: 'card-meta' });
+        contentBlock.insertBefore(metaColumn, mainColumn);
+        contentBlock.classList.add('card-content--with-meta');
+        return metaColumn;
+      };
 
       const componentDefs = [
         { key: 'title', node: titleNode, target: 'main' },
@@ -2761,8 +2767,11 @@ function renderStorySlide(story = {}, region = 'left') {
         componentDefs,
         (anyEnabled) => h('div', { class: 'card-empty' }, anyEnabled ? 'Keine Details hinterlegt.' : 'Alle Komponenten deaktiviert.'),
         (node, def) => {
-          const target = (def && def.target === 'meta') ? metaColumn : mainColumn;
-          target.appendChild(node);
+          if (def && def.target === 'meta') {
+            ensureMetaColumn().appendChild(node);
+          } else {
+            mainColumn.appendChild(node);
+          }
         }
       );
 


### PR DESCRIPTION
## Summary
- inline sauna tile times with titles, keep badges on one row, and tighten default padding/height
- expose a tile padding scale control in the admin UI and defaults so spacing can be tuned

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfe34c8e9c8320982bec2484e5f5a5