### PR TITLE
Add sauna flame controls and improve tile layout

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -462,6 +462,7 @@
                   </select>
                 </div>
                 <div class="kv"><label>Uhrzeit Scale</label><input id="tileTimeScale" class="input" type="number" step="0.05" min="0.5" max="2" value="1"></div>
+                <div class="kv"><label>Flammen in Kacheln anzeigen</label><input id="saunaFlames" type="checkbox" checked></div>
                 <div class="kv"><label>Badge-Scale (Faktor)</label><input id="badgeScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Beschreibung-Scale (Faktor)</label><input id="badgeDescriptionScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -21,7 +21,6 @@ import {
   PAGE_CONTENT_TYPES,
   PAGE_CONTENT_TYPE_KEYS,
   PAGE_SOURCE_KEYS,
-  SOURCE_PLAYLIST_LIMITS,
   playlistKeyFromSanitizedEntry,
   sanitizePagePlaylist,
   sanitizeBadgeLibrary,
@@ -529,8 +528,6 @@ function renderSlidesBox(){
     const { entries: baseEntries, hiddenSaunas } = collectSlideOrderStream({ normalizeSortOrder: false });
     const showOverview = settings?.slides?.showOverview !== false;
     const heroEnabled = !!(settings?.slides?.heroEnabled);
-    const allowedSetRaw = source && SOURCE_PLAYLIST_LIMITS[source] ? SOURCE_PLAYLIST_LIMITS[source] : (SOURCE_PLAYLIST_LIMITS[pageState.source] || null);
-    const allowedSet = allowedSetRaw instanceof Set ? allowedSetRaw : null;
 
     const entryList = [];
     const entryMap = new Map();
@@ -595,15 +592,6 @@ function renderSlidesBox(){
           disabled: entry.item?.enabled === false,
           statusText: entry.item?.enabled === false ? 'Deaktiviert' : null
         });
-      }
-    });
-
-    entryList.forEach(entry => {
-      if (!allowedSet) return;
-      const typeKey = entry.kind;
-      if (!allowedSet.has(typeKey)) {
-        entry.disabled = true;
-        entry.statusText = entry.statusText || 'Nicht verfügbar (Quelle)';
       }
     });
 
@@ -870,6 +858,7 @@ function renderSlidesBox(){
   setV('#h1Scale',    f.h1Scale ?? 1);
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#tileTimeScale', f.tileMetaScale ?? 1);
+  setC('#saunaFlames', (settings.slides?.showSaunaFlames !== false));
   setV('#chipOverflowMode', f.chipOverflowMode ?? 'scale');
   setV('#flamePct',         f.flamePct         ?? 55);
   setV('#flameGap',         f.flameGapScale    ?? 0.14);
@@ -1000,6 +989,7 @@ function renderSlidesBox(){
     setV('#tilePaddingScale', DEFAULTS.slides.tilePaddingScale);
     setV('#badgeScale',    DEFAULTS.slides.badgeScale);
     setV('#badgeDescriptionScale', DEFAULTS.slides.badgeDescriptionScale);
+    setC('#saunaFlames', DEFAULTS.slides.showSaunaFlames !== false);
     setV('#badgeColor',    DEFAULTS.slides.infobadgeColor);
     setC('#tileOverlayEnabled', DEFAULTS.slides.tileOverlayEnabled);
     setV('#tileOverlayStrength', Math.round((DEFAULTS.slides.tileOverlayStrength ?? 1) * 100));
@@ -1343,6 +1333,7 @@ function collectSettings(){
           if (!Number.isFinite(raw)) return settings.slides?.tileOverlayStrength ?? DEFAULTS.slides.tileOverlayStrength ?? 1;
           return clamp(0, raw, 200) / 100;
         })(),
+        showSaunaFlames: !!$('#saunaFlames')?.checked,
         badgeLibrary: (() => {
           const sanitized = sanitizeBadgeLibrary(settings.slides?.badgeLibrary, { assignMissingIds: true });
           (settings.slides ||= {}).badgeLibrary = sanitized;

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -116,6 +116,7 @@ export const DEFAULTS = {
     tilePaddingScale:0.75,
     tileOverlayEnabled:true,
     tileOverlayStrength:1,
+    showSaunaFlames:true,
     infobadgeColor:'#5C3101',
     badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
     badgeScale:1,

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -105,9 +105,6 @@ body[data-layout='split'] .stage{gap:calc(18px*var(--vwScale));}
 body[data-layout='split'] .stage-area{display:flex}
 body[data-layout='single'] .stage{gap:0;}
 body[data-layout='single'] #stage-right{display:none;}
-body[data-layout='split'] .stage-area .container.has-right{padding-right:calc(32px*var(--vwScale));}
-body[data-layout='split'] .stage-area .container.has-right .headings{max-width:100%;}
-body[data-layout='split'] .stage-area .rightPanel{display:none;}
 
 .fade{opacity:0;transition:opacity .5s}
 .fade.show{opacity:1}
@@ -692,14 +689,20 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .flames{
   display:flex;
   gap:10px;
-  align-items:center;
+  align-items:flex-start;
   justify-content:flex-end;
   justify-self:end;
-  align-self:center;
+  align-self:flex-start;
   grid-column:3;
   min-width:0;
 }
 .tile.tile--compact .flames{grid-column:2;}
+.tile.tile--no-flames{grid-template-columns:minmax(0, var(--tileIconColumnPx, var(--tileIconSizePx, calc(84px*var(--vwScale))))) minmax(0,1fr);}
+.tile.tile--no-flames.tile--compact{grid-template-columns:minmax(0,1fr);}
+.tile.tile--no-flames .flames{display:none;}
+body.sauna-hide-flames .tile .flames{display:none;}
+body.sauna-hide-flames .tile{grid-template-columns:minmax(0, var(--tileIconColumnPx, var(--tileIconSizePx, calc(84px*var(--vwScale))))) minmax(0,1fr);}
+body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
  
 .flame{width:calc(var(--flameSizePx)*1px*var(--scale)); height:calc(var(--flameSizePx)*1px*var(--scale))}
 .flame img,.flame svg{width:100%;height:100%;object-fit:contain}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -359,6 +359,8 @@ async function loadDeviceResolved(id){
 
     const showOverviewFlames = fonts.overviewShowFlames !== false;
     document.body.classList.toggle('overview-hide-flames', !showOverviewFlames);
+    const showSaunaFlames = slidesCfg.showSaunaFlames !== false;
+    document.body.classList.toggle('sauna-hide-flames', !showSaunaFlames);
 
     setVars({
       '--chipFlamePct': Math.max(0.3, Math.min(1, (fonts.flamePct || 55) / 100)),
@@ -2710,6 +2712,7 @@ function renderStorySlide(story = {}, region = 'left') {
     const colIdx = (schedule.saunas || []).indexOf(name);
     const hiddenSaunas = new Set(settings?.slides?.hiddenSaunas || []);
     const componentFlags = getSlideComponentFlags();
+    const showSaunaFlames = settings?.slides?.showSaunaFlames !== false;
     const iconVariantMap = (settings?.slides?.iconVariants && typeof settings.slides.iconVariants === 'object')
       ? settings.slides.iconVariants
       : null;
@@ -2897,7 +2900,11 @@ function renderStorySlide(story = {}, region = 'left') {
         tileChildren.push(stripeNode);
       }
       tileChildren.push(contentBlock);
-      tileChildren.push(flamesWrap(it.flames));
+      if (showSaunaFlames) {
+        tileChildren.push(flamesWrap(it.flames));
+      } else {
+        tileClasses.push('tile--no-flames');
+      }
 
       const tile = h('div', { class: tileClasses.join(' '), 'data-time': it.time }, tileChildren);
       tile.style.setProperty('--tile-index', String(list.children.length));


### PR DESCRIPTION
## Summary
- add a sauna flame visibility toggle in the admin UI and persist the choice through defaults and slideshow rendering
- let playlist selectors show every available slide regardless of the configured source
- adjust sauna tile styling to align or hide flames and allow the diagonal right-panel image to appear in split layouts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d02dde73e88320a94d49a42d6aaf20