### PR TITLE
Improve story slide layout scaling and double-column support

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -1174,6 +1174,11 @@ body.mode-uniform #ovSec{ display:none !important; }
   color:var(--muted);
   font-style:italic;
 }
+.story-sections-editor{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
 .story-section-list{
   display:flex;
   flex-direction:column;
@@ -1204,6 +1209,32 @@ body.mode-uniform #ovSec{ display:none !important; }
   border-radius:8px;
   box-shadow:inset 0 0 0 1px color-mix(in oklab, var(--border) 70%, transparent);
   background:color-mix(in oklab, var(--panel) 85%, transparent);
+}
+.story-section-align{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.story-align-toggle{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+}
+.story-align-toggle .btn.is-active,
+.story-column-toggle .btn.is-active{
+  border-color:color-mix(in oklab, var(--btn-accent) 60%, var(--ghost-border));
+  background:color-mix(in oklab, var(--btn-accent) 14%, var(--panel));
+  color:color-mix(in oklab, var(--btn-accent) 70%, var(--fg));
+}
+.story-section-column{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.story-column-toggle{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
 }
 .story-fullimage-toggle{
   display:inline-flex;

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -747,31 +747,59 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
 
 /* story slides */
 .story-slide{
+  --story-section-count:1;
+  --story-column-count:1;
+  --story-section-max-per-column:1;
+  --story-section-scale:1;
+  --story-section-media-basis:42%;
+  --story-section-media-height:clamp(160px, calc(68vh / var(--story-section-max-per-column, 1)), 520px);
   padding:clamp(20px, 4vw, 48px);
   display:flex;
   flex-direction:column;
-  gap:clamp(24px, 4vh, 40px);
+  gap:calc(clamp(24px, 4vh, 40px) * var(--story-section-scale));
 }
 
 .story-slide .story-heading{
   margin:0;
-  font-size:calc(64px*var(--scale));
+  font-size:calc(64px*var(--scale)*clamp(.72, var(--story-section-scale) + .25, 1.08));
   font-weight:800;
   line-height:1.05;
   letter-spacing:.01em;
 }
 
 .story-slide .story-sections{
+  width:100%;
+}
+
+.story-layout-single .story-sections{
   display:flex;
   flex-direction:column;
-  gap:clamp(24px, 3vh, 40px);
-  width:100%;
+  gap:calc(clamp(24px, 3vh, 40px) * var(--story-section-scale));
+}
+
+.story-sections--double{
+  display:grid;
+  grid-template-columns:repeat(var(--story-column-count, 2), minmax(0, 1fr));
+  gap:calc(clamp(24px, 4vw, 48px) * var(--story-section-scale));
+}
+
+.story-column{
+  display:flex;
+  flex-direction:column;
+  gap:calc(clamp(20px, 3vh, 36px) * var(--story-section-scale));
+  min-width:0;
+}
+
+.story-column--empty{ display:none; }
+
+.story-layout-double .story-section{
+  height:100%;
 }
 
 .story-section{
   display:flex;
   flex-direction:column;
-  gap:clamp(16px, 2vh, 24px);
+  gap:calc(clamp(16px, 2vh, 24px) * var(--story-section-scale));
   min-width:0;
 }
 
@@ -783,22 +811,30 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
   align-items:flex-start;
 }
 
+.story-section--media-full .story-section-media{
+  max-height:none;
+}
+
 .story-section-empty{
   margin:0;
-  font-size:calc(24px*var(--scale));
+  font-size:calc(24px*var(--scale)*var(--story-section-scale));
   opacity:.7;
 }
 
 .story-section-media{
   flex:0 0 auto;
   width:100%;
+  max-height:var(--story-section-media-height);
+  display:flex;
+  flex-direction:column;
 }
 
 .story-section-figure{
   margin:0;
   width:100%;
-  height:100%;
-  display:block;
+  height:auto;
+  display:flex;
+  flex-direction:column;
   border-radius:clamp(18px, 2.4vw, 30px);
   overflow:hidden;
   background:rgba(255,255,255,.08);
@@ -808,8 +844,10 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
 .story-section-figure img{
   display:block;
   width:100%;
-  height:100%;
+  height:auto;
+  max-height:100%;
   object-fit:cover;
+  flex:1 1 auto;
 }
 
 .story-section-figure figcaption{
@@ -817,7 +855,7 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
   padding:.75em 1.1em;
   background:rgba(0,0,0,.62);
   color:#fff;
-  font-size:calc(20px*var(--scale));
+  font-size:calc(20px*var(--scale)*var(--story-section-scale));
   line-height:1.35;
 }
 
@@ -828,7 +866,7 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
   min-height:160px;
   padding:1.4em;
   text-align:center;
-  font-size:calc(22px*var(--scale));
+  font-size:calc(22px*var(--scale)*var(--story-section-scale));
   line-height:1.4;
   color:rgba(255,255,255,.82);
 }
@@ -836,14 +874,14 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
 .story-section-content{
   display:flex;
   flex-direction:column;
-  gap:clamp(12px, 1.8vh, 20px);
-  font-size:calc(24px*var(--scale));
+  gap:calc(clamp(12px, 1.8vh, 20px) * var(--story-section-scale));
+  font-size:calc(24px*var(--scale)*var(--story-section-scale));
   line-height:1.45;
 }
 
 .story-section-kicker{
   margin:0;
-  font-size:calc(22px*var(--scale));
+  font-size:calc(22px*var(--scale)*var(--story-section-scale));
   font-weight:600;
   letter-spacing:.08em;
   text-transform:uppercase;
@@ -852,14 +890,14 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
 
 .story-section-heading{
   margin:0;
-  font-size:calc(42px*var(--scale));
+  font-size:calc(42px*var(--scale)*var(--story-section-scale));
   font-weight:700;
   line-height:1.12;
 }
 
 .story-section-subheading{
   margin:0;
-  font-size:calc(26px*var(--scale));
+  font-size:calc(26px*var(--scale)*var(--story-section-scale));
   opacity:.85;
 }
 
@@ -1063,18 +1101,17 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
     flex:1 1 0;
   }
   .story-section-media{
-    flex:0 0 40%;
-    max-width:40%;
+    flex:0 0 var(--story-section-media-basis);
+    max-width:var(--story-section-media-basis);
   }
   .story-section--media-right{
-    flex-direction:row-reverse;
   }
   .story-section--media-right .story-section-media{
-    margin-left:clamp(16px, 2vw, 32px);
+    margin-left:calc(clamp(16px, 2vw, 32px) * var(--story-section-scale));
     margin-right:0;
   }
   .story-section--media-left .story-section-media{
-    margin-right:clamp(16px, 2vw, 32px);
+    margin-right:calc(clamp(16px, 2vw, 32px) * var(--story-section-scale));
   }
   .story-section--media-bottom{
     flex-direction:column;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -1971,8 +1971,22 @@ function normalizeStoryForRender(story = {}) {
   const headingRaw = String(story.heading || story.title || '').trim();
   const subheadingRaw = String(story.subheading || story.subtitle || '').trim();
   if (Array.isArray(story.columns)) {
-    const columns = story.columns.map(normalizeStoryColumn).filter(col => col.sections.length);
-    const layout = normalizeStoryLayout(story.layout) || (columns.length > 1 ? 'double' : 'single');
+    const rawColumns = story.columns.map(normalizeStoryColumn);
+    const layoutNormalized = normalizeStoryLayout(story.layout);
+    let columns;
+    if (layoutNormalized === 'double') {
+      const findByRole = (role) => rawColumns.find(col => (col.role || '').toLowerCase() === role);
+      const left = findByRole('left') || { role: 'left', sections: [] };
+      const right = findByRole('right') || { role: 'right', sections: [] };
+      const extras = rawColumns.filter(col => {
+        const role = (col.role || '').toLowerCase();
+        return role !== 'left' && role !== 'right' && col.sections.length;
+      });
+      columns = [left, right, ...extras];
+    } else {
+      columns = rawColumns.filter(col => col.sections.length);
+    }
+    const layout = layoutNormalized || (columns.length > 1 ? 'double' : 'single');
     return {
       heading: headingRaw,
       subheading: subheadingRaw,
@@ -2034,32 +2048,65 @@ function renderStorySlide(story = {}, region = 'left') {
   container.appendChild(h('h1', { class: 'story-heading' }, headingText));
 
   const sectionsWrap = h('div', { class: 'story-sections' });
-  const appendSectionNode = (section, context) => {
+  let sectionCount = 0;
+  const columnSectionCounts = [];
+  const appendSectionNode = (section, context, parent) => {
     const node = buildStorySectionNode(section, context);
-    if (node) {
-      if (context && context.columnIndex != null) {
-        node.dataset.columnIndex = String(context.columnIndex);
-      }
-      if (context && context.sectionIndex != null) {
-        node.dataset.sectionIndex = String(context.sectionIndex);
-      }
-      sectionsWrap.appendChild(node);
+    if (!node) return false;
+    sectionCount += 1;
+    if (context && context.columnIndex != null) {
+      node.dataset.columnIndex = String(context.columnIndex);
     }
+    if (context && context.sectionIndex != null) {
+      node.dataset.sectionIndex = String(context.sectionIndex);
+    }
+    (parent || sectionsWrap).appendChild(node);
+    return true;
   };
 
-  (normalized.columns || []).forEach((column, columnIndex) => {
-    (column.sections || []).forEach((section, sectionIndex) => {
-      appendSectionNode(section, {
-        columnIndex,
-        sectionIndex,
-        normalizedStory: normalized,
-        rawStory: normalized.raw,
-        legacyStory: normalized.legacy
+  const columnsList = Array.isArray(normalized.columns) ? normalized.columns : [];
+  if (normalized.layout === 'double') {
+    sectionsWrap.classList.add('story-sections--double');
+    columnsList.forEach((column, columnIndex) => {
+      const columnEl = h('div', { class: 'story-column' });
+      columnEl.dataset.columnIndex = String(columnIndex);
+      if (column.role) columnEl.dataset.columnRole = String(column.role);
+      let columnCount = 0;
+      (column.sections || []).forEach((section, sectionIndex) => {
+        if (appendSectionNode(section, {
+          columnIndex,
+          sectionIndex,
+          normalizedStory: normalized,
+          rawStory: normalized.raw,
+          legacyStory: normalized.legacy
+        }, columnEl)) {
+          columnCount += 1;
+        }
       });
+      columnSectionCounts.push(columnCount);
+      if (!columnCount) columnEl.classList.add('story-column--empty');
+      sectionsWrap.appendChild(columnEl);
     });
-  });
+  } else {
+    columnsList.forEach((column, columnIndex) => {
+      let columnCount = 0;
+      (column.sections || []).forEach((section, sectionIndex) => {
+        if (appendSectionNode(section, {
+          columnIndex,
+          sectionIndex,
+          normalizedStory: normalized,
+          rawStory: normalized.raw,
+          legacyStory: normalized.legacy
+        })) {
+          columnCount += 1;
+        }
+      });
+      if (columnCount) columnSectionCounts.push(columnCount);
+    });
+  }
 
-  if (!sectionsWrap.childNodes.length) {
+  if (!sectionCount) {
+    sectionsWrap.innerHTML = '';
     sectionsWrap.appendChild(
       h('section', { class: 'story-section story-section--empty' }, [
         h('p', { class: 'story-section-empty' }, 'Keine Inhalte verfügbar.')
@@ -2068,6 +2115,26 @@ function renderStorySlide(story = {}, region = 'left') {
   }
 
   container.appendChild(sectionsWrap);
+  container.dataset.storySectionCount = String(sectionCount);
+  container.style.setProperty('--story-section-count', String(Math.max(sectionCount, 1)));
+  const rawColumnCount = columnsList.length;
+  const columnCount = normalized.layout === 'double' ? Math.max(rawColumnCount || 0, 2) : Math.max(rawColumnCount || 0, 1);
+  container.dataset.storyColumnCount = String(columnCount);
+  container.style.setProperty('--story-column-count', String(columnCount));
+  const maxPerColumnRaw = columnSectionCounts.reduce((max, value) => Math.max(max, value || 0), 0);
+  const singleDensity = Math.max(sectionCount, 1);
+  const maxPerColumnCount = normalized.layout === 'double'
+    ? Math.max(maxPerColumnRaw, 1)
+    : singleDensity;
+  container.dataset.storyMaxPerColumn = String(maxPerColumnCount);
+  container.style.setProperty('--story-section-max-per-column', String(maxPerColumnCount));
+  const density = normalized.layout === 'double' ? maxPerColumnCount : singleDensity;
+  const baseWidth = columnCount > 1 ? 40 : 48;
+  const mediaWidth = Math.max(18, baseWidth - Math.max(density - 1, 0) * 4);
+  container.style.setProperty('--story-section-media-basis', mediaWidth.toFixed(2) + '%');
+  const baseScale = columnCount > 1 ? 0.92 : 1;
+  const scale = Math.max(0.6, baseScale - Math.max(density - 1, 0) * 0.08);
+  container.style.setProperty('--story-section-scale', scale.toFixed(3));
   return container;
 
   function buildStorySectionNode(section, ctx) {


### PR DESCRIPTION
## Summary
- add a layout toggle and per-section column controls to the story editor while keeping slide columns in sync
- render story slides in a responsive single or double column grid with corrected media alignment and dynamic sizing
- tune story slide styles to shrink typography and imagery as section density grows and hide empty columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d033219f0883209d507ea0109aa2cf