### PR TITLE
Fix story slide layout controls and scaling

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -824,7 +824,7 @@ body.sauna-hide-flames .tile.tile--compact{grid-template-columns:minmax(0,1fr);}
 .story-section-media{
   flex:0 0 auto;
   width:100%;
-  max-height:var(--story-section-media-height);
+  max-height:calc(var(--story-section-media-height) * var(--story-section-scale));
   display:flex;
   flex-direction:column;
 }


### PR DESCRIPTION
## Summary
- preserve media alignment and column assignments when converting story builder sections
- add automatic sizing for story slides to keep all sections visible and react to image loads
- scale story media blocks with the computed section scale for consistent layouts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d043359a248320a7e42213501fa45a