### PR TITLE
Center sauna flames vertically

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -689,10 +689,10 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .flames{
   display:flex;
   gap:10px;
-  align-items:flex-start;
+  align-items:center;
   justify-content:flex-end;
   justify-self:end;
-  align-self:flex-start;
+  align-self:center;
   grid-column:3;
   min-width:0;
 }


### PR DESCRIPTION
## Summary
- align the sauna flame container vertically in tiles by centering its flex alignment
- ensure flames column sits centered within the sauna tile grid layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d19a8e26ec83208d23e1552c094a40