### PR TITLE
Add inline badge column option for sauna slides

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -465,6 +465,7 @@
                 <div class="kv"><label>Flammen in Kacheln anzeigen</label><input id="saunaFlames" type="checkbox" checked></div>
                 <div class="kv"><label>Badge-Scale (Faktor)</label><input id="badgeScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Beschreibung-Scale (Faktor)</label><input id="badgeDescriptionScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
+                <div class="kv"><label>Badges neben Aufguss anzeigen</label><input id="badgeInlineColumn" type="checkbox"></div>
                 <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
                 <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
                 <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -758,6 +758,7 @@ function renderSlidesBox(){
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#tileTimeScale', f.tileMetaScale ?? 1);
   setC('#saunaFlames', (settings.slides?.showSaunaFlames !== false));
+  setC('#badgeInlineColumn', settings.slides?.badgeInlineColumn === true);
   setV('#chipOverflowMode', f.chipOverflowMode ?? 'scale');
   setV('#flamePct',         f.flamePct         ?? 55);
   setV('#flameGap',         f.flameGapScale    ?? 0.14);
@@ -889,6 +890,7 @@ function renderSlidesBox(){
     setV('#badgeScale',    DEFAULTS.slides.badgeScale);
     setV('#badgeDescriptionScale', DEFAULTS.slides.badgeDescriptionScale);
     setC('#saunaFlames', DEFAULTS.slides.showSaunaFlames !== false);
+    setC('#badgeInlineColumn', DEFAULTS.slides.badgeInlineColumn === true);
     setV('#badgeColor',    DEFAULTS.slides.infobadgeColor);
     setC('#tileOverlayEnabled', DEFAULTS.slides.tileOverlayEnabled);
     setV('#tileOverlayStrength', Math.round((DEFAULTS.slides.tileOverlayStrength ?? 1) * 100));
@@ -1219,6 +1221,7 @@ function collectSettings(){
           if (!Number.isFinite(raw)) return settings.slides?.badgeDescriptionScale ?? DEFAULTS.slides.badgeDescriptionScale ?? 1;
           return clamp(0.3, raw, 3);
         })(),
+        badgeInlineColumn: !!document.getElementById('badgeInlineColumn')?.checked,
         infobadgeColor:(() => {
           const el = document.getElementById('badgeColor');
           const fallback = settings.slides?.infobadgeColor || settings.theme?.accent || DEFAULTS.slides.infobadgeColor || '#5C3101';

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -117,6 +117,7 @@ export const DEFAULTS = {
     tileOverlayEnabled:true,
     tileOverlayStrength:1,
     showSaunaFlames:true,
+    badgeInlineColumn:false,
     infobadgeColor:'#5C3101',
     badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
     badgeScale:1,

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -36,7 +36,7 @@ const STYLE_FONT_KEYS = [
 ];
 const STYLE_SLIDE_KEYS = [
   'infobadgeColor','badgeLibrary','customBadgeEmojis','badgeScale','badgeDescriptionScale',
-  'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength'
+  'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength','badgeInlineColumn'
 ];
 
 const SUGGESTED_BADGE_EMOJIS = [

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -534,6 +534,25 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   min-height:auto;
 }
 .tile.tile--compact .tile-badge-stripe{ display:none; }
+.tile.tile--badge-column{
+  grid-template-columns:
+    minmax(0, var(--tileIconColumnPx, var(--tileIconSizePx, calc(84px*var(--vwScale)))))
+    minmax(0,1fr)
+    auto
+    auto;
+}
+.tile.tile--badge-column.tile--no-flames{
+  grid-template-columns:
+    minmax(0, var(--tileIconColumnPx, var(--tileIconSizePx, calc(84px*var(--vwScale)))))
+    minmax(0,1fr)
+    auto;
+}
+.tile.tile--badge-column.tile--compact{
+  grid-template-columns:minmax(0,1fr) auto auto;
+}
+.tile.tile--badge-column.tile--compact.tile--no-flames{
+  grid-template-columns:minmax(0,1fr) auto;
+}
 .container.no-card-icons:not(.has-badge-stripe){ --tileIconSizePx:0px; }
 .container.no-card-icons:not(.has-badge-stripe){ --tileIconColumnPx:0px; }
 .container.no-card-icons:not(.has-badge-stripe) .list{ gap:var(--tileGapPx, calc(14px*var(--vwScale))); }
@@ -546,6 +565,14 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   grid-template-columns:auto minmax(0,1fr);
   column-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
   align-items:center;
+}
+.card-badges{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+}
+.card-badges--inline{
+  align-self:stretch;
 }
 .card-content:not(.card-content--with-meta){
   display:flex;
@@ -630,6 +657,16 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   flex-wrap:wrap;
   align-items:center;
   gap:var(--tileChipGapPx, calc(8px*var(--vwScale)));
+}
+.badge-row--stacked{
+  flex-direction:column;
+  flex-wrap:nowrap;
+  align-items:flex-end;
+  justify-content:center;
+  text-align:right;
+}
+.badge-row--stacked .badge{
+  width:max-content;
 }
 .badge-row .badge{margin:0;}
 .tile .badge{


### PR DESCRIPTION
## Summary
- add an option in the admin UI to stack sauna badges beside the tiles and persist the preference
- update slideshow rendering and styles to insert a vertical badge column between the content and flames when enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2a88ee49c832092943fb457596cd9