### PR TITLE
Align sauna schedule layout and add more badge emojis

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -64,7 +64,14 @@ const SUGGESTED_BADGE_EMOJIS = [
   { value:'🌊', label:'Meer & Gischt' },
   { value:'🌞', label:'Sonne & Wärme' },
   { value:'🌅', label:'Morgenstimmung' },
-  { value:'🍀', label:'Glück & Wohlbefinden' }
+  { value:'🍀', label:'Glück & Wohlbefinden' },
+  { value:'🌋', label:'Vulkan & Hitze' },
+  { value:'🌪️', label:'Wirbel & Intensität' },
+  { value:'🌬️', label:'Luft & Brise' },
+  { value:'🏔️', label:'Berg & Kristalle' },
+  { value:'🏝️', label:'Tropen & Urlaub' },
+  { value:'🪨', label:'Steine & Mineralien' },
+  { value:'🪷', label:'Lotus & Ruhe' }
 ];
 
 const cloneValue = (value) => {

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -559,17 +559,10 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .card-content{
   width:100%;
   min-width:0;
-}
-.card-content--with-meta{
-  display:grid;
-  grid-template-columns:minmax(0,1fr) auto;
-  column-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
-  align-items:center;
-}
-.card-content--with-meta .card-meta{
-  justify-self:flex-end;
-  justify-content:flex-end;
-  text-align:right;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:flex-start;
 }
 .card-badges{
   display:flex;
@@ -579,12 +572,6 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .card-badges--inline{
   align-self:stretch;
 }
-.card-content:not(.card-content--with-meta){
-  display:flex;
-  flex-direction:column;
-  justify-content:center;
-  align-items:flex-start;
-}
 .card-main{
   display:flex;
   flex-direction:column;
@@ -593,35 +580,39 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   align-items:flex-start;
   min-width:0;
 }
-.card-meta{
-  display:flex;
-  align-items:baseline;
-  gap:.5em;
+.tile .title{
   font-size:calc(40px*var(--scale)*var(--tileTextScale));
   font-weight:var(--tileWeight);
   line-height:1.05;
-  white-space:nowrap;
+  min-width:0;
 }
-.card-meta .time{
+.tile .title:not(.title--with-time){
+  display:flex;
+  flex-wrap:wrap;
+  align-items:baseline;
+  gap:.5em;
+}
+.tile .title.title--with-time{
+  display:grid;
+  grid-template-columns:max-content max-content minmax(0,1fr);
+  column-gap:calc(0.35em + 2px*var(--vwScale));
+  align-items:baseline;
+}
+.tile .title .time{
+  display:inline-block;
+  min-width:calc(var(--tileTimeWidthCh, 9) * 1ch);
   font-size:calc(.65em*var(--tileMetaScale,1));
   letter-spacing:.12em;
   text-transform:uppercase;
   opacity:.8;
   white-space:nowrap;
+  font-variant-numeric:tabular-nums;
 }
-.card-meta .sep{
+.tile .title .sep{
   opacity:.7;
   font-size:.8em;
-}
-.tile .title{
-  display:flex;
-  flex-wrap:wrap;
-  align-items:baseline;
-  gap:.5em;
-  font-size:calc(40px*var(--scale)*var(--tileTextScale));
-  font-weight:var(--tileWeight);
-  line-height:1.05;
-  min-width:0;
+  min-width:calc(1.5ch);
+  text-align:center;
 }
 .tile .title .label{
   display:flex;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -2991,6 +2991,11 @@ function renderStorySlide(story = {}, region = 'left') {
       } else if (hasStar) {
         labelNode.appendChild(h('span', { class: 'notewrap' }, [h('sup', { class: 'note legacy' }, '*')]));
       }
+      if (it.time) {
+        titleNode.classList.add('title--with-time');
+        titleNode.appendChild(h('span', { class: 'time' }, it.time + ' Uhr'));
+        titleNode.appendChild(h('span', { class: 'sep', 'aria-hidden': 'true' }, '–'));
+      }
       titleNode.appendChild(labelNode);
 
       const badgeRowNode = createBadgeRow(it.badges, 'badge-row');
@@ -3002,25 +3007,10 @@ function renderStorySlide(story = {}, region = 'left') {
         ? stripeSource.map(entry => ({ ...entry }))
         : [];
       const hasAnyBadgeImage = badgeStripeSource.some(entry => entry.imageUrl);
-      const metaColumn = h('div', { class: 'card-meta' });
       const badgeColumn = inlineBadgeColumn ? h('div', { class: 'card-badges card-badges--inline' }) : null;
-      if (it.time) {
-        metaColumn.appendChild(h('span', { class: 'time' }, it.time + ' Uhr'));
-        metaColumn.appendChild(h('span', { class: 'sep', 'aria-hidden': 'true' }, '–'));
-      }
 
       const mainColumn = h('div', { class: 'card-main' });
-      let hasMetaColumn = metaColumn.childNodes.length > 0;
-      const contentChildren = [mainColumn];
-      if (hasMetaColumn) contentChildren.push(metaColumn);
-      const contentBlock = h('div', { class: 'card-content' }, contentChildren);
-      if (hasMetaColumn) contentBlock.classList.add('card-content--with-meta');
-      const ensureMetaColumn = () => {
-        if (hasMetaColumn) return;
-        contentBlock.appendChild(metaColumn);
-        contentBlock.classList.add('card-content--with-meta');
-        hasMetaColumn = true;
-      };
+      const contentBlock = h('div', { class: 'card-content' }, [mainColumn]);
 
       const componentDefs = [
         { key: 'title', node: titleNode, target: 'main' },
@@ -3035,11 +3025,6 @@ function renderStorySlide(story = {}, region = 'left') {
         (anyEnabled) => h('div', { class: 'card-empty' }, anyEnabled ? 'Keine Details hinterlegt.' : 'Alle Komponenten deaktiviert.'),
         (node, def) => {
           const targetKey = def?.target;
-          if (targetKey === 'meta') {
-            ensureMetaColumn();
-            metaColumn.appendChild(node);
-            return;
-          }
           if (targetKey === 'badge' && badgeColumn) {
             badgeColumn.appendChild(node);
             return;


### PR DESCRIPTION
## Summary
- align the sauna tile header so the time, dash and title are rendered in one row with consistent spacing
- update the tile styling to support the new layout and keep badge columns and content alignment intact
- extend the suggested badge emoji library with additional sauna-themed icons (e.g. 🌋)

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c04c5f288320a1197bd4dd214207