### PR TITLE
Adjust sauna layout and collapse footnote editor

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -1169,6 +1169,74 @@ body.mode-uniform #ovSec{ display:none !important; }
 .badge-lib-row.has-icon .badge-lib-chip{ font-weight:500; }
 .badge-lib-chip-icon{ font-size:16px; line-height:1; }
 
+/* ---------- Fußnoten-Editor ---------- */
+.footnote-section{
+  margin-top:16px;
+  padding-top:12px;
+  border-top:1px solid var(--inbr);
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.footnote-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  flex-wrap:wrap;
+}
+.footnote-toggle{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  border-radius:999px;
+  border:1px solid var(--ghost-border);
+  background:var(--panel);
+  color:var(--ghost-fg);
+  padding:4px 12px;
+  font-size:13px;
+  cursor:pointer;
+  transition:background .18s ease, border-color .18s ease, color .18s ease;
+}
+.footnote-toggle::after{
+  content:'▾';
+  font-size:12px;
+  transition:transform .2s ease;
+}
+.footnote-toggle:hover,
+.footnote-toggle:focus-visible{
+  border-color:var(--btn-accent);
+  color:var(--btn-accent);
+}
+.footnote-toggle:focus-visible{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+.footnote-section.is-open .footnote-toggle::after{ transform:rotate(180deg); }
+.footnote-body{
+  overflow:hidden;
+  max-height:0;
+  opacity:0;
+  pointer-events:none;
+  transition:max-height .26s ease, opacity .2s ease;
+  will-change:max-height;
+}
+.footnote-section.is-open .footnote-body{
+  max-height:min(60vh, 420px);
+  opacity:1;
+  pointer-events:auto;
+  overflow-y:auto;
+  overscroll-behavior:contain;
+  scrollbar-gutter:stable;
+}
+.footnote-body-inner{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  padding:2px 0;
+}
+.footnote-body-inner .kv{ margin:0; }
+
 /* ---------- Story Builder ---------- */
 .story-builder-pane{
   display:flex;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -217,7 +217,16 @@
     <div class="actions"><button class="btn sm" id="fnAdd">Fußnote hinzufügen</button></div>
   </summary>
   <div class="content">
-    <div id="fnList"></div>
+    <div class="footnote-section" id="footnoteSection">
+      <div class="footnote-header">
+        <button class="footnote-toggle" type="button" id="footnoteToggle" aria-expanded="false" aria-controls="footnoteBody">Fußnoten verwalten</button>
+      </div>
+      <div class="footnote-body" id="footnoteBody" aria-hidden="true">
+        <div class="footnote-body-inner">
+          <div id="fnList"></div>
+        </div>
+      </div>
+    </div>
     <div class="subh">Darstellung</div>
     <div class="kv">
       <label>Fußnoten-Layout <span class="tip" title="Legt fest, wie mehrere Fußnoten dargestellt werden.">❔</span></label>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -1224,12 +1224,40 @@ function ensureColorTools(){
 // ============================================================================
 function renderFootnotes(){
   const host=$('#fnList'); if (!host) return;
+  const section = $('#footnoteSection');
+  const toggle = $('#footnoteToggle');
+  const body = $('#footnoteBody');
+
+  const getExpanded = () => !!(toggle && toggle.getAttribute('aria-expanded') === 'true');
+  const setExpanded = (expanded) => {
+    const isExpanded = !!expanded;
+    if (toggle){ toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false'); }
+    if (body){ body.setAttribute('aria-hidden', isExpanded ? 'false' : 'true'); }
+    if (section){ section.classList.toggle('is-open', isExpanded); }
+  };
+
+  if (toggle && !toggle.dataset.bound){
+    toggle.dataset.bound = '1';
+    toggle.addEventListener('click', () => {
+      setExpanded(!getExpanded());
+    });
+  }
+
+  const forceOpen = (body && body.dataset.forceOpen === '1');
+  if (body) delete body.dataset.forceOpen;
+  setExpanded(forceOpen ? true : getExpanded());
+
   host.innerHTML='';
   const layoutSel = document.getElementById('footnoteLayout');
   if (layoutSel){ layoutSel.value = settings.footnoteLayout || 'one-line'; layoutSel.onchange = ()=>{ settings.footnoteLayout = layoutSel.value; }; }
   const list = settings.footnotes || [];
+  if (section) section.classList.toggle('has-items', list.length > 0);
   list.forEach((fn,i)=> host.appendChild(fnRow(fn,i)));
-  $('#fnAdd').onclick=()=>{ (settings.footnotes ||= []).push({id:genId(), label:'*', text:''}); renderFootnotes(); };
+  $('#fnAdd').onclick=()=>{
+    (settings.footnotes ||= []).push({id:genId(), label:'*', text:''});
+    if (body) body.dataset.forceOpen = '1';
+    renderFootnotes();
+  };
 }
 
 function fnRow(fn,i){

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -140,7 +140,7 @@ body[data-layout='single'] #stage-right{display:none;}
   position:relative;
   z-index:1;
 }
-.h1{font-weight:800;letter-spacing:.02em;line-height:1.1;font-size:calc(56px*var(--scale)*var(--h1Scale));margin:0 0 10px;hyphens:auto;overflow-wrap:anywhere;}
+.h1{font-weight:800;letter-spacing:.02em;line-height:1.1;font-size:calc(56px*var(--scale)*var(--h1Scale));margin:0 0 10px;hyphens:auto;overflow-wrap:break-word;word-break:normal;}
 .h2{font-weight:700;letter-spacing:.01em;opacity:.95;font-size:calc(36px*var(--scale)*var(--h2Scale));margin:0 0 14px}
 .overview .h1{line-height:1.1;font-size:calc(56px*var(--scale)*var(--h1Scale)*var(--ovAuto))}
 .overview .h2{font-size:calc(36px*var(--scale)*var(--h2Scale)*var(--ovAuto))}
@@ -575,44 +575,28 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .card-main{
   display:flex;
   flex-direction:column;
-  gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
+  row-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
   justify-content:center;
   align-items:flex-start;
   min-width:0;
+}
+.card-main__content{
+  display:flex;
+  flex-direction:column;
+  row-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
+  align-items:flex-start;
+  min-width:0;
+  width:100%;
 }
 .tile .title{
   font-size:calc(40px*var(--scale)*var(--tileTextScale));
   font-weight:var(--tileWeight);
   line-height:1.05;
   min-width:0;
-}
-.tile .title:not(.title--with-time){
   display:flex;
   flex-wrap:wrap;
   align-items:baseline;
-  gap:.5em;
-}
-.tile .title.title--with-time{
-  display:grid;
-  grid-template-columns:max-content max-content minmax(0,1fr);
-  column-gap:calc(0.35em + 2px*var(--vwScale));
-  align-items:baseline;
-}
-.tile .title .time{
-  display:inline-block;
-  min-width:calc(var(--tileTimeWidthCh, 9) * 1ch);
-  font-size:calc(.65em*var(--tileMetaScale,1));
-  letter-spacing:.12em;
-  text-transform:uppercase;
-  opacity:.8;
-  white-space:nowrap;
-  font-variant-numeric:tabular-nums;
-}
-.tile .title .sep{
-  opacity:.7;
-  font-size:.8em;
-  min-width:calc(1.5ch);
-  text-align:center;
+  gap:.35em;
 }
 .tile .title .label{
   display:flex;
@@ -622,6 +606,41 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   min-width:0;
 }
 .tile .title .label .notewrap{flex:0 0 auto;}
+.tile.tile--has-time .card-main{
+  display:grid;
+  grid-template-columns:max-content minmax(0,1fr);
+  column-gap:calc(0.35em + 2px*var(--vwScale));
+  row-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
+  align-items:start;
+  justify-content:flex-start;
+  align-content:center;
+}
+.tile.tile--has-time .card-main > .time{
+  grid-column:1;
+  grid-row:1;
+  display:inline-block;
+  min-width:calc(var(--tileTimeWidthCh, 9) * 1ch);
+  font-size:calc(.65em*var(--tileMetaScale,1));
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  opacity:.8;
+  white-space:nowrap;
+  font-variant-numeric:tabular-nums;
+}
+.tile.tile--has-time .card-main__content{
+  grid-column:2;
+  grid-row:auto;
+}
+.tile.tile--has-time .title{
+  grid-column:2;
+  grid-row:1;
+}
+.tile.tile--has-time .title::before{
+  content:'–';
+  opacity:.7;
+  font-size:.8em;
+  margin-right:calc(0.35em + 2px*var(--vwScale));
+}
 .card-content .description{
   display:block;
   font-size:calc(22px*var(--scale)*var(--tileDescriptionScale, var(--tileMetaScale,1)));

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -2982,6 +2982,8 @@ function renderStorySlide(story = {}, region = 'left') {
         if (iconVariant === 'overlay') tileClasses.push('tile--icon-overlay');
       }
 
+      if (it.time) tileClasses.push('tile--has-time');
+
       const titleNode = h('div', { class: 'title' });
       const labelNode = h('span', { class: 'label' }, baseTitle);
       const supNote = noteSup(it, notes);
@@ -2991,12 +2993,9 @@ function renderStorySlide(story = {}, region = 'left') {
       } else if (hasStar) {
         labelNode.appendChild(h('span', { class: 'notewrap' }, [h('sup', { class: 'note legacy' }, '*')]));
       }
-      if (it.time) {
-        titleNode.classList.add('title--with-time');
-        titleNode.appendChild(h('span', { class: 'time' }, it.time + ' Uhr'));
-        titleNode.appendChild(h('span', { class: 'sep', 'aria-hidden': 'true' }, '–'));
-      }
       titleNode.appendChild(labelNode);
+
+      const timeNode = it.time ? h('span', { class: 'time' }, it.time + ' Uhr') : null;
 
       const badgeRowNode = createBadgeRow(it.badges, 'badge-row');
       if (badgeRowNode && inlineBadgeColumn) badgeRowNode.classList.add('badge-row--stacked');
@@ -3010,6 +3009,9 @@ function renderStorySlide(story = {}, region = 'left') {
       const badgeColumn = inlineBadgeColumn ? h('div', { class: 'card-badges card-badges--inline' }) : null;
 
       const mainColumn = h('div', { class: 'card-main' });
+      const mainContent = h('div', { class: 'card-main__content' });
+      if (timeNode) mainColumn.appendChild(timeNode);
+      mainColumn.appendChild(mainContent);
       const contentBlock = h('div', { class: 'card-content' }, [mainColumn]);
 
       const componentDefs = [
@@ -3029,9 +3031,17 @@ function renderStorySlide(story = {}, region = 'left') {
             badgeColumn.appendChild(node);
             return;
           }
-          mainColumn.appendChild(node);
+          if (def?.key === 'title') {
+            mainColumn.insertBefore(node, mainContent);
+            return;
+          }
+          mainContent.appendChild(node);
         }
       );
+
+      if (!mainContent.childNodes.length) {
+        mainContent.remove();
+      }
 
       const hasBadgeColumn = !!(badgeColumn && badgeColumn.childNodes.length);
 


### PR DESCRIPTION
## Summary
- realign sauna card descriptions and badges beneath the infusion title by restructuring the markup and CSS grid layout
- relax sauna slide H1 wrapping so hyphenation reaches toward the angled hero image
- add a collapsible footnote editor section in the admin interface that mirrors the badge accordion styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c57b507483208c47f7077eab500e