### PR TITLE
Center sauna tile content and add flame spacing controls

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -473,6 +473,8 @@
                 </div>
                 <div class="kv"><label>Uhrzeit Scale</label><input id="tileTimeScale" class="input" type="number" step="0.05" min="0.5" max="2" value="1"></div>
                 <div class="kv"><label>Flammen in Kacheln anzeigen</label><input id="saunaFlames" type="checkbox" checked></div>
+                <div class="kv"><label>Flammen-Größe (Faktor)</label><input id="tileFlameSize" class="input" type="number" step="0.05" min="0.25" max="3" value="1"></div>
+                <div class="kv"><label>Flammen-Abstand (Faktor)</label><input id="tileFlameGap" class="input" type="number" step="0.05" min="0" max="4" value="1"></div>
                 <div class="kv"><label>Badge-Scale (Faktor)</label><input id="badgeScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Beschreibung-Scale (Faktor)</label><input id="badgeDescriptionScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Badges neben Aufguss anzeigen</label><input id="badgeInlineColumn" type="checkbox"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -881,7 +881,6 @@ function renderSlidesBox(){
   setV('#h1Scale',    f.h1Scale ?? 1);
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#tileTimeScale', f.tileMetaScale ?? 1);
-  setC('#saunaFlames', (settings.slides?.showSaunaFlames !== false));
   setC('#badgeInlineColumn', settings.slides?.badgeInlineColumn === true);
   setV('#chipOverflowMode', f.chipOverflowMode ?? 'scale');
   setV('#flamePct',         f.flamePct         ?? 55);
@@ -919,6 +918,8 @@ function renderSlidesBox(){
   setV('#tileMax',       settings.slides?.tileMaxScale ?? 0.57);
   setV('#tileHeightScale', settings.slides?.tileHeightScale ?? DEFAULTS.slides.tileHeightScale ?? 1);
   setV('#tilePaddingScale', settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.75);
+  setV('#tileFlameSize', settings.slides?.tileFlameSizeScale ?? DEFAULTS.slides.tileFlameSizeScale ?? 1);
+  setV('#tileFlameGap', settings.slides?.tileFlameGapScale ?? DEFAULTS.slides.tileFlameGapScale ?? 1);
   setV('#badgeScale', settings.slides?.badgeScale ?? DEFAULTS.slides.badgeScale ?? 1);
   setV('#badgeDescriptionScale', settings.slides?.badgeDescriptionScale ?? DEFAULTS.slides.badgeDescriptionScale ?? 1);
   const overlayCheckbox = document.getElementById('tileOverlayEnabled');
@@ -936,6 +937,18 @@ function renderSlidesBox(){
   if (overlayCheckbox && !overlayCheckbox.dataset.bound) {
     overlayCheckbox.addEventListener('change', () => applyOverlayState(overlayCheckbox.checked));
     overlayCheckbox.dataset.bound = '1';
+  }
+  const saunaFlameToggle = document.getElementById('saunaFlames');
+  const saunaFlameControls = ['#tileFlameSize', '#tileFlameGap'].map(sel => document.querySelector(sel));
+  const applySaunaFlameState = (enabled) => {
+    saunaFlameControls.forEach(el => { if (el) el.disabled = !enabled; });
+  };
+  const saunaFlamesEnabled = (settings.slides?.showSaunaFlames !== false);
+  setC('#saunaFlames', saunaFlamesEnabled);
+  applySaunaFlameState(saunaFlamesEnabled);
+  if (saunaFlameToggle && !saunaFlameToggle.dataset.bound) {
+    saunaFlameToggle.addEventListener('change', () => applySaunaFlameState(saunaFlameToggle.checked));
+    saunaFlameToggle.dataset.bound = '1';
   }
   const badgeColor = settings.slides?.infobadgeColor || settings.theme?.accent || DEFAULTS.slides.infobadgeColor;
   setV('#badgeColor', badgeColor);
@@ -1011,9 +1024,12 @@ function renderSlidesBox(){
     setV('#tileMax',       DEFAULTS.slides.tileMaxScale);
     setV('#tileHeightScale', DEFAULTS.slides.tileHeightScale);
     setV('#tilePaddingScale', DEFAULTS.slides.tilePaddingScale);
+    setV('#tileFlameSize', DEFAULTS.slides.tileFlameSizeScale);
+    setV('#tileFlameGap', DEFAULTS.slides.tileFlameGapScale);
     setV('#badgeScale',    DEFAULTS.slides.badgeScale);
     setV('#badgeDescriptionScale', DEFAULTS.slides.badgeDescriptionScale);
     setC('#saunaFlames', DEFAULTS.slides.showSaunaFlames !== false);
+    applySaunaFlameState(DEFAULTS.slides.showSaunaFlames !== false);
     setC('#badgeInlineColumn', DEFAULTS.slides.badgeInlineColumn === true);
     setV('#badgeColor',    DEFAULTS.slides.infobadgeColor);
     setC('#tileOverlayEnabled', DEFAULTS.slides.tileOverlayEnabled);
@@ -1362,6 +1378,16 @@ function collectSettings(){
           const raw = Number($('#tilePaddingScale')?.value);
           if (!Number.isFinite(raw)) return settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.75;
           return clamp(0.25, raw, 1.5);
+        })(),
+        tileFlameSizeScale:(() => {
+          const raw = Number($('#tileFlameSize')?.value);
+          if (!Number.isFinite(raw)) return settings.slides?.tileFlameSizeScale ?? DEFAULTS.slides.tileFlameSizeScale ?? 1;
+          return clamp(0.25, raw, 3);
+        })(),
+        tileFlameGapScale:(() => {
+          const raw = Number($('#tileFlameGap')?.value);
+          if (!Number.isFinite(raw)) return settings.slides?.tileFlameGapScale ?? DEFAULTS.slides.tileFlameGapScale ?? 1;
+          return clamp(0, raw, 4);
         })(),
         badgeScale:(() => {
           const raw = Number($('#badgeScale')?.value);

--- a/webroot/admin/js/core/config.js
+++ b/webroot/admin/js/core/config.js
@@ -229,6 +229,16 @@ export function normalizeSettings(source, { assignMissingIds = false } = {}) {
   src.slides.badgeDescriptionScale = Number.isFinite(badgeDescRaw)
     ? clamp(0.3, badgeDescRaw, 3)
     : defaultBadgeDescScale;
+  const defaultTileFlameSizeScale = DEFAULTS.slides?.tileFlameSizeScale ?? 1;
+  const defaultTileFlameGapScale = DEFAULTS.slides?.tileFlameGapScale ?? 1;
+  const tileFlameSizeRaw = Number(src.slides?.tileFlameSizeScale);
+  src.slides.tileFlameSizeScale = Number.isFinite(tileFlameSizeRaw)
+    ? clamp(0.25, tileFlameSizeRaw, 3)
+    : defaultTileFlameSizeScale;
+  const tileFlameGapRaw = Number(src.slides?.tileFlameGapScale);
+  src.slides.tileFlameGapScale = Number.isFinite(tileFlameGapRaw)
+    ? clamp(0, tileFlameGapRaw, 4)
+    : defaultTileFlameGapScale;
   src.slides.customBadgeEmojis = sanitizeEmojiList(src.slides?.customBadgeEmojis);
   return src;
 }

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -62,6 +62,8 @@ const DEFAULT_STYLE_SETS = {
       badgeScale:1,
       badgeDescriptionScale:1,
       tilePaddingScale:0.75,
+      tileFlameSizeScale:1,
+      tileFlameGapScale:1,
       customBadgeEmojis:[]
     }
   },
@@ -99,6 +101,8 @@ const DEFAULT_STYLE_SETS = {
       badgeScale:1,
       badgeDescriptionScale:1,
       tilePaddingScale:0.75,
+      tileFlameSizeScale:1,
+      tileFlameGapScale:1,
       customBadgeEmojis:[]
     }
   }
@@ -114,6 +118,8 @@ export const DEFAULTS = {
     tileMaxScale:0.57,
     tileHeightScale:1,
     tilePaddingScale:0.75,
+    tileFlameSizeScale:1,
+    tileFlameGapScale:1,
     tileOverlayEnabled:true,
     tileOverlayStrength:1,
     showSaunaFlames:true,

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -36,7 +36,8 @@ const STYLE_FONT_KEYS = [
 ];
 const STYLE_SLIDE_KEYS = [
   'infobadgeColor','badgeLibrary','customBadgeEmojis','badgeScale','badgeDescriptionScale',
-  'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength','badgeInlineColumn'
+  'tileHeightScale','tilePaddingScale','tileFlameSizeScale','tileFlameGapScale',
+  'tileOverlayEnabled','tileOverlayStrength','badgeInlineColumn'
 ];
 
 const SUGGESTED_BADGE_EMOJIS = [

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -16,7 +16,7 @@
   /* typography */
   --font:-apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   --baseScale:1; --vwScale:1; --scale:calc(var(--baseScale)*var(--vwScale)); --h1Scale:1; --h2Scale:1; --ovHeadScale:0.90; --ovCellScale:0.80;
-  --tileTextScale:0.80; --tileWeight:600; --flameSizePx:28;
+  --tileTextScale:0.80; --tileWeight:600; --flameSizePx:28; --tileFlameGapPx:calc(10px*var(--vwScale));
   --chipHBase:calc(44px*var(--scale));
   --chipHScale:1;
   --chipH:calc(var(--chipHBase)*var(--chipHScale));
@@ -55,7 +55,7 @@
   --badgeFg:var(--boxfg);
   --flameSizePxOv:18; /* kleine Flames in Übersicht-Chips */
   --ovTitleScale:1; /* nur H1 der Übersicht */
-  --flamesColW: calc(var(--flameSizePx)*1px*var(--scale)*3 + 24px);
+  --flamesColW: calc(var(--flameSizePx)*1px*var(--scale)*3 + var(--tileFlameGapPx, calc(10px*var(--vwScale))) * 2);
   --tileEnterDuration:600ms;
   --tileEnterDelay:80ms;
   --heroTimelineItemMs:500ms;
@@ -562,7 +562,8 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   display:flex;
   flex-direction:column;
   justify-content:center;
-  align-items:flex-start;
+  align-items:center;
+  text-align:center;
 }
 .card-badges{
   display:flex;
@@ -577,14 +578,14 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   flex-direction:column;
   row-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
   justify-content:center;
-  align-items:flex-start;
+  align-items:center;
   min-width:0;
 }
 .card-main__content{
   display:flex;
   flex-direction:column;
   row-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
-  align-items:flex-start;
+  align-items:center;
   min-width:0;
   width:100%;
 }
@@ -596,7 +597,9 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   display:flex;
   flex-wrap:wrap;
   align-items:baseline;
+  justify-content:center;
   gap:.35em;
+  text-align:center;
 }
 .tile .title .label{
   display:flex;
@@ -604,6 +607,8 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   gap:.35em;
   flex-wrap:wrap;
   min-width:0;
+  justify-content:center;
+  text-align:center;
 }
 .tile .title .label .notewrap{flex:0 0 auto;}
 .tile.tile--has-time .card-main{
@@ -618,7 +623,9 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .tile.tile--has-time .card-main > .time{
   grid-column:1;
   grid-row:1;
-  display:inline-block;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
   min-width:calc(var(--tileTimeWidthCh, 9) * 1ch);
   font-size:calc(.65em*var(--tileMetaScale,1));
   letter-spacing:.12em;
@@ -626,6 +633,14 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   opacity:.8;
   white-space:nowrap;
   font-variant-numeric:tabular-nums;
+  text-align:center;
+  gap:calc(0.35em + 2px*var(--vwScale));
+}
+.tile.tile--has-time .card-main > .time::after{
+  content:'–';
+  opacity:.7;
+  font-size:.8em;
+  display:inline-block;
 }
 .tile.tile--has-time .card-main__content{
   grid-column:2;
@@ -634,12 +649,6 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .tile.tile--has-time .title{
   grid-column:2;
   grid-row:1;
-}
-.tile.tile--has-time .title::before{
-  content:'–';
-  opacity:.7;
-  font-size:.8em;
-  margin-right:calc(0.35em + 2px*var(--vwScale));
 }
 .card-content .description{
   display:block;
@@ -654,6 +663,7 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   display:flex;
   flex-wrap:wrap;
   gap:var(--tileChipGapPx, calc(8px*var(--vwScale)));
+  justify-content:center;
   padding:0;
   margin:0;
   list-style:none;
@@ -671,6 +681,7 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   display:flex;
   flex-wrap:wrap;
   align-items:center;
+  justify-content:center;
   gap:var(--tileChipGapPx, calc(8px*var(--vwScale)));
 }
 .badge-row--stacked{
@@ -706,6 +717,7 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   display:flex;
   flex-wrap:wrap;
   gap:var(--tileChipGapPx, calc(8px*var(--vwScale)));
+  justify-content:center;
   padding:0;
   margin:0;
   list-style:none;
@@ -746,13 +758,40 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .tile.is-hidden .card-chip--status{filter:none;}
 .flames{
   display:flex;
-  gap:10px;
+  gap:var(--tileFlameGapPx, calc(10px*var(--vwScale)));
   align-items:center;
   justify-content:flex-end;
   justify-self:end;
   align-self:center;
   grid-column:3;
-  min-width:0;
+  min-width:var(--flamesColW, 0px);
+}
+.tile:not(.tile--badge-column) .card-content .description,
+.tile:not(.tile--badge-column) .card-main__content > *,
+.tile:not(.tile--badge-column) .badge-row{
+  text-align:center;
+}
+.tile.tile--badge-column .card-content{
+  align-items:flex-start;
+  text-align:left;
+}
+.tile.tile--badge-column .card-main{
+  align-items:flex-start;
+}
+.tile.tile--badge-column .card-main__content{
+  align-items:flex-start;
+}
+.tile.tile--badge-column .title,
+.tile.tile--badge-column .title .label{
+  justify-content:flex-start;
+  text-align:left;
+}
+.tile.tile--badge-column .badge-row{
+  justify-content:flex-start;
+}
+.tile.tile--badge-column .aroma-list,
+.tile.tile--badge-column .facts{
+  justify-content:flex-start;
 }
 .tile.tile--badge-column .flames{grid-column:4;}
 .tile.tile--badge-column.tile--compact .flames{grid-column:3;}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -2690,7 +2690,17 @@ function renderStorySlide(story = {}, region = 'left') {
     const heightScale = Number.isFinite(+settings?.slides?.tileHeightScale)
       ? clamp(0.5, +settings.slides.tileHeightScale, 2)
       : 1;
-    const flameSize = useIcons ? clamp(22, t * 0.03, 42) : clamp(18, t * 0.026, 32);
+    const userTileFlameSizeScale = Number.isFinite(+settings?.slides?.tileFlameSizeScale)
+      ? clamp(0.25, +settings.slides.tileFlameSizeScale, 3)
+      : 1;
+    const userTileFlameGapScale = Number.isFinite(+settings?.slides?.tileFlameGapScale)
+      ? clamp(0, +settings.slides.tileFlameGapScale, 4)
+      : 1;
+    const flameSizeBase = useIcons ? clamp(22, t * 0.03, 42) : clamp(18, t * 0.026, 32);
+    const flameSize = flameSizeBase * userTileFlameSizeScale;
+    const flameGapBase = useIcons ? clamp(6, t * 0.02, 22) : clamp(4, t * 0.018, 18);
+    const flameGap = Math.max(0, flameGapBase * userTileFlameGapScale);
+    const flameColumn = Math.max(0, (flameSize * 3) + (flameGap * 2));
     const iconColumn = useIcons ? clamp(40, iconSize * 0.75, iconSize * 1.45) : 0;
     const tileMinHeight = useIcons
       ? clamp(64, iconSize * 0.82, iconSize * 1.08)
@@ -2712,6 +2722,8 @@ function renderStorySlide(story = {}, region = 'left') {
     container.style.setProperty('--tileBadgeScale', (combinedMeta * userBadgeScale).toFixed(3));
     container.style.setProperty('--tileDescriptionScale', (combinedMeta * userBadgeDescriptionScale).toFixed(3));
     container.style.setProperty('--flameSizePx', flameSize.toFixed(2));
+    container.style.setProperty('--tileFlameGapPx', flameGap.toFixed(2) + 'px');
+    container.style.setProperty('--flamesColW', flameColumn.toFixed(2) + 'px');
     container.style.setProperty('--tileIconColumnPx', useIcons ? (iconColumn.toFixed(2) + 'px') : '0px');
     container.style.setProperty('--tileHeightScale', heightScale.toFixed(3));
     container.style.setProperty('--tileMinHeightPx', (tileMinHeight * heightScale).toFixed(2) + 'px');


### PR DESCRIPTION
## Summary
- center sauna tile titles, descriptions, badges, and time dash within their layout to prevent overlap
- add admin controls and defaults for sauna flame size and spacing and apply them in tile sizing
- update styling to respect new flame spacing variable while keeping badge-column layouts left-aligned

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2ca327dd08320ba74fac81188fc48