### PR TITLE
Fix sauna tile alignment and add flame controls

### DIFF
--- a/webroot/admin/api/load_settings.php
+++ b/webroot/admin/api/load_settings.php
@@ -27,8 +27,10 @@ echo json_encode([
   'slides'=>[
     'overviewDurationSec'=>10,'saunaDurationSec'=>6,'transitionMs'=>500,
     'tileWidthPercent'=>45,'tileMinScale'=>0.25,'tileMaxScale'=>0.57,
+    'tileFlameSizeScale'=>1,'tileFlameGapScale'=>1,
     'durationMode'=>'uniform','globalDwellSec'=>6,'loop'=>true,
-    'order'=>['overview']
+    'order'=>['overview'],
+    'saunaTitleMaxWidthPercent'=>100
   ],
   'assets'=>['rightImages'=>[], 'flameImage'=>'/assets/img/flame_test.svg'],
   'footnotes'=>[ ['id'=>'star','label'=>'*','text'=>'Nur am Fr und Sa'] ],

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -473,12 +473,15 @@
                 </div>
                 <div class="kv"><label>Uhrzeit Scale</label><input id="tileTimeScale" class="input" type="number" step="0.05" min="0.5" max="2" value="1"></div>
                 <div class="kv"><label>Flammen in Kacheln anzeigen</label><input id="saunaFlames" type="checkbox" checked></div>
+                <div class="kv"><label>Flammen-Größe (Faktor)</label><input id="tileFlameSizeScale" class="input" type="number" step="0.05" min="0.4" max="3" value="1"></div>
+                <div class="kv"><label>Flammen-Abstand (Faktor)</label><input id="tileFlameGapScale" class="input" type="number" step="0.05" min="0" max="3" value="1"></div>
                 <div class="kv"><label>Badge-Scale (Faktor)</label><input id="badgeScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Beschreibung-Scale (Faktor)</label><input id="badgeDescriptionScale" class="input" type="number" step="0.05" min="0.3" max="3" value="1"></div>
                 <div class="kv"><label>Badges neben Aufguss anzeigen</label><input id="badgeInlineColumn" type="checkbox"></div>
                 <div class="kv"><label>Kachel‑Breite % (sichtbarer Bereich)</label><input id="tilePct" class="input" type="number" min="1" max="100" value="45"></div>
                 <div class="kv"><label>Kachel‑Breite min (Faktor)</label><input id="tileMin" class="input" type="number" min="0" max="1" step="0.01" value="0.25"></div>
                 <div class="kv"><label>Kachel‑Breite max (Faktor)</label><input id="tileMax" class="input" type="number" min="0" max="1" step="0.01" value="0.57"></div>
+                <div class="kv"><label>H1 Max-Breite (%)</label><input id="saunaHeadingWidth" class="input" type="number" min="10" max="100" value="100"></div>
                 <div class="kv"><label>Kachel-Höhen-Scale</label><input id="tileHeightScale" class="input" type="number" step="0.05" min="0.5" max="2" value="1"></div>
                 <div class="kv"><label>Innenabstand (Faktor)</label><input id="tilePaddingScale" class="input" type="number" step="0.05" min="0.25" max="1.5" value="0.75"></div>
                 <div class="kv"><label>Badge-Farbe</label>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -881,7 +881,18 @@ function renderSlidesBox(){
   setV('#h1Scale',    f.h1Scale ?? 1);
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#tileTimeScale', f.tileMetaScale ?? 1);
-  setC('#saunaFlames', (settings.slides?.showSaunaFlames !== false));
+  setV('#tileFlameSizeScale', settings.slides?.tileFlameSizeScale ?? DEFAULTS.slides.tileFlameSizeScale ?? 1);
+  setV('#tileFlameGapScale', settings.slides?.tileFlameGapScale ?? DEFAULTS.slides.tileFlameGapScale ?? 1);
+  const saunaFlameControls = ['#tileFlameSizeScale', '#tileFlameGapScale'].map(sel => document.querySelector(sel));
+  const saunaFlamesToggle = document.getElementById('saunaFlames');
+  const saunaFlamesEnabled = (settings.slides?.showSaunaFlames !== false);
+  setC('#saunaFlames', saunaFlamesEnabled);
+  const applySaunaFlameState = (enabled) => { saunaFlameControls.forEach(el => { if (el) el.disabled = !enabled; }); };
+  applySaunaFlameState(saunaFlamesEnabled);
+  if (saunaFlamesToggle && !saunaFlamesToggle.dataset.bound) {
+    saunaFlamesToggle.addEventListener('change', () => applySaunaFlameState(saunaFlamesToggle.checked));
+    saunaFlamesToggle.dataset.bound = '1';
+  }
   setC('#badgeInlineColumn', settings.slides?.badgeInlineColumn === true);
   setV('#chipOverflowMode', f.chipOverflowMode ?? 'scale');
   setV('#flamePct',         f.flamePct         ?? 55);
@@ -917,6 +928,7 @@ function renderSlidesBox(){
   setV('#tilePct',       settings.slides?.tileWidthPercent ?? 45);
   setV('#tileMin',       settings.slides?.tileMinScale ?? 0.25);
   setV('#tileMax',       settings.slides?.tileMaxScale ?? 0.57);
+  setV('#saunaHeadingWidth', settings.slides?.saunaTitleMaxWidthPercent ?? DEFAULTS.slides.saunaTitleMaxWidthPercent ?? 100);
   setV('#tileHeightScale', settings.slides?.tileHeightScale ?? DEFAULTS.slides.tileHeightScale ?? 1);
   setV('#tilePaddingScale', settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.75);
   setV('#badgeScale', settings.slides?.badgeScale ?? DEFAULTS.slides.badgeScale ?? 1);
@@ -1009,11 +1021,15 @@ function renderSlidesBox(){
     setV('#tilePct',       DEFAULTS.slides.tileWidthPercent);
     setV('#tileMin',       DEFAULTS.slides.tileMinScale);
     setV('#tileMax',       DEFAULTS.slides.tileMaxScale);
+    setV('#tileFlameSizeScale', DEFAULTS.slides.tileFlameSizeScale);
+    setV('#tileFlameGapScale', DEFAULTS.slides.tileFlameGapScale);
+    setV('#saunaHeadingWidth', DEFAULTS.slides.saunaTitleMaxWidthPercent);
     setV('#tileHeightScale', DEFAULTS.slides.tileHeightScale);
     setV('#tilePaddingScale', DEFAULTS.slides.tilePaddingScale);
     setV('#badgeScale',    DEFAULTS.slides.badgeScale);
     setV('#badgeDescriptionScale', DEFAULTS.slides.badgeDescriptionScale);
     setC('#saunaFlames', DEFAULTS.slides.showSaunaFlames !== false);
+    applySaunaFlameState(DEFAULTS.slides.showSaunaFlames !== false);
     setC('#badgeInlineColumn', DEFAULTS.slides.badgeInlineColumn === true);
     setV('#badgeColor',    DEFAULTS.slides.infobadgeColor);
     setC('#tileOverlayEnabled', DEFAULTS.slides.tileOverlayEnabled);
@@ -1353,6 +1369,16 @@ function collectSettings(){
         tileWidthPercent:+($('#tilePct')?.value || 45),
         tileMinScale:+($('#tileMin')?.value || 0.25),
         tileMaxScale:+($('#tileMax')?.value || 0.57),
+        tileFlameSizeScale:(() => {
+          const raw = Number($('#tileFlameSizeScale')?.value);
+          if (!Number.isFinite(raw)) return settings.slides?.tileFlameSizeScale ?? DEFAULTS.slides.tileFlameSizeScale ?? 1;
+          return clamp(0.4, raw, 3);
+        })(),
+        tileFlameGapScale:(() => {
+          const raw = Number($('#tileFlameGapScale')?.value);
+          if (!Number.isFinite(raw)) return settings.slides?.tileFlameGapScale ?? DEFAULTS.slides.tileFlameGapScale ?? 1;
+          return clamp(0, raw, 3);
+        })(),
         tileHeightScale:(() => {
           const raw = Number($('#tileHeightScale')?.value);
           if (!Number.isFinite(raw)) return settings.slides?.tileHeightScale ?? DEFAULTS.slides.tileHeightScale ?? 1;
@@ -1362,6 +1388,11 @@ function collectSettings(){
           const raw = Number($('#tilePaddingScale')?.value);
           if (!Number.isFinite(raw)) return settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.75;
           return clamp(0.25, raw, 1.5);
+        })(),
+        saunaTitleMaxWidthPercent:(() => {
+          const raw = Number($('#saunaHeadingWidth')?.value);
+          if (!Number.isFinite(raw)) return settings.slides?.saunaTitleMaxWidthPercent ?? DEFAULTS.slides.saunaTitleMaxWidthPercent ?? 100;
+          return clamp(10, raw, 100);
         })(),
         badgeScale:(() => {
           const raw = Number($('#badgeScale')?.value);

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -62,7 +62,10 @@ const DEFAULT_STYLE_SETS = {
       badgeScale:1,
       badgeDescriptionScale:1,
       tilePaddingScale:0.75,
-      customBadgeEmojis:[]
+      customBadgeEmojis:[],
+      tileFlameSizeScale:1,
+      tileFlameGapScale:1,
+      saunaTitleMaxWidthPercent:100
     }
   },
   fresh:{
@@ -99,7 +102,10 @@ const DEFAULT_STYLE_SETS = {
       badgeScale:1,
       badgeDescriptionScale:1,
       tilePaddingScale:0.75,
-      customBadgeEmojis:[]
+      customBadgeEmojis:[],
+      tileFlameSizeScale:1,
+      tileFlameGapScale:1,
+      saunaTitleMaxWidthPercent:100
     }
   }
 };
@@ -114,6 +120,9 @@ export const DEFAULTS = {
     tileMaxScale:0.57,
     tileHeightScale:1,
     tilePaddingScale:0.75,
+    tileFlameSizeScale:1,
+    tileFlameGapScale:1,
+    saunaTitleMaxWidthPercent:100,
     tileOverlayEnabled:true,
     tileOverlayStrength:1,
     showSaunaFlames:true,

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -36,7 +36,8 @@ const STYLE_FONT_KEYS = [
 ];
 const STYLE_SLIDE_KEYS = [
   'infobadgeColor','badgeLibrary','customBadgeEmojis','badgeScale','badgeDescriptionScale',
-  'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength','badgeInlineColumn'
+  'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength','badgeInlineColumn',
+  'tileFlameSizeScale','tileFlameGapScale','saunaTitleMaxWidthPercent'
 ];
 
 const SUGGESTED_BADGE_EMOJIS = [

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -25,6 +25,8 @@
   --chipFlameGap:calc(var(--chipH) * var(--chipFlameGapScale));
   --ovAuto:1; /* overview-only autoscale factor */
   --ovTimeWidth:10ch;
+  --tileFlameGapPx:calc(10px*var(--vwScale));
+  --saunaHeadingMaxWidth:100%;
 
   /* right panel shape */
   --rightW:38%; --cutTop:28%; --cutBottom:12%;
@@ -55,7 +57,6 @@
   --badgeFg:var(--boxfg);
   --flameSizePxOv:18; /* kleine Flames in Übersicht-Chips */
   --ovTitleScale:1; /* nur H1 der Übersicht */
-  --flamesColW: calc(var(--flameSizePx)*1px*var(--scale)*3 + 24px);
   --tileEnterDuration:600ms;
   --tileEnterDelay:80ms;
   --heroTimelineItemMs:500ms;
@@ -135,7 +136,10 @@ body[data-layout='single'] #stage-right{display:none;}
 .container.overview{padding-right:32px}
 .headings{width:100%;}
 .container.has-right .headings{
-  max-width:calc(100% - (var(--rightW) * (1 - var(--cutTopRatio))));
+  max-width:min(
+    calc(100% - (var(--rightW) * (1 - var(--cutTopRatio)))),
+    var(--saunaHeadingMaxWidth, 100%)
+  );
   padding-right:calc(16px * var(--vwScale));
   position:relative;
   z-index:1;
@@ -593,10 +597,13 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   font-weight:var(--tileWeight);
   line-height:1.05;
   min-width:0;
+  width:100%;
+  max-width:100%;
   display:flex;
   flex-wrap:wrap;
   align-items:baseline;
   gap:.35em;
+  overflow-wrap:anywhere;
 }
 .tile .title .label{
   display:flex;
@@ -604,6 +611,8 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   gap:.35em;
   flex-wrap:wrap;
   min-width:0;
+  flex:1 1 auto;
+  overflow-wrap:anywhere;
 }
 .tile .title .label .notewrap{flex:0 0 auto;}
 .tile.tile--has-time .card-main{
@@ -611,14 +620,17 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   grid-template-columns:max-content minmax(0,1fr);
   column-gap:calc(0.35em + 2px*var(--vwScale));
   row-gap:var(--tileContentGapPx, calc(10px*var(--vwScale)));
-  align-items:start;
+  align-items:center;
   justify-content:flex-start;
   align-content:center;
 }
 .tile.tile--has-time .card-main > .time{
   grid-column:1;
   grid-row:1;
-  display:inline-block;
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:calc(0.35em + 2px*var(--vwScale));
   min-width:calc(var(--tileTimeWidthCh, 9) * 1ch);
   font-size:calc(.65em*var(--tileMetaScale,1));
   letter-spacing:.12em;
@@ -627,6 +639,13 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
   white-space:nowrap;
   font-variant-numeric:tabular-nums;
 }
+.tile.tile--has-time .card-main > .time::after{
+  content:'–';
+  display:inline-flex;
+  align-items:center;
+  opacity:.7;
+  font-size:.8em;
+}
 .tile.tile--has-time .card-main__content{
   grid-column:2;
   grid-row:auto;
@@ -634,12 +653,7 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .tile.tile--has-time .title{
   grid-column:2;
   grid-row:1;
-}
-.tile.tile--has-time .title::before{
-  content:'–';
-  opacity:.7;
-  font-size:.8em;
-  margin-right:calc(0.35em + 2px*var(--vwScale));
+  align-self:center;
 }
 .card-content .description{
   display:block;
@@ -746,13 +760,18 @@ body.overview-hide-flames .overview .chip-flames{display:none;}
 .tile.is-hidden .card-chip--status{filter:none;}
 .flames{
   display:flex;
-  gap:10px;
+  gap:var(--tileFlameGapPx, calc(10px*var(--vwScale)));
   align-items:center;
   justify-content:flex-end;
   justify-self:end;
   align-self:center;
   grid-column:3;
   min-width:0;
+}
+.flames > span{
+  display:block;
+  width:calc(var(--flameSizePx)*1px*var(--scale));
+  height:calc(var(--flameSizePx)*1px*var(--scale));
 }
 .tile.tile--badge-column .flames{grid-column:4;}
 .tile.tile--badge-column.tile--compact .flames{grid-column:3;}

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -319,6 +319,9 @@ async function loadDeviceResolved(id){
     const overlayOpacity = overlayEnabled ? clamp(0, 0.9 * overlayStrength, 1) : 0;
     const overlayLight = overlayEnabled ? clamp(0, 0.12 * overlayStrength, 1) : 0;
     const overlayShadow = overlayEnabled ? clamp(0, 0.42 * overlayStrength, 1) : 0;
+    const headingWidthPct = Number.isFinite(+slidesCfg.saunaTitleMaxWidthPercent)
+      ? clamp(10, +slidesCfg.saunaTitleMaxWidthPercent, 100)
+      : 100;
 
     setVars({
       '--bg': t.bg, '--fg': t.fg, '--accent': t.accent,
@@ -356,7 +359,8 @@ async function loadDeviceResolved(id){
       '--heroTimelineItemMs': msVar(slidesCfg.heroTimelineItemMs, 500),
       '--heroTimelineItemDelay': msVar(slidesCfg.heroTimelineItemDelayMs, 140),
       '--heroTimelineFillMs': msVar(slidesCfg.heroTimelineFillMs, 8000),
-      '--heroTimelineDelayMs': msVar(slidesCfg.heroTimelineDelayMs, 400)
+      '--heroTimelineDelayMs': msVar(slidesCfg.heroTimelineDelayMs, 400),
+      '--saunaHeadingMaxWidth': headingWidthPct + '%'
     });
     if (fonts.family) document.documentElement.style.setProperty('--font', fonts.family);
 
@@ -2690,7 +2694,16 @@ function renderStorySlide(story = {}, region = 'left') {
     const heightScale = Number.isFinite(+settings?.slides?.tileHeightScale)
       ? clamp(0.5, +settings.slides.tileHeightScale, 2)
       : 1;
-    const flameSize = useIcons ? clamp(22, t * 0.03, 42) : clamp(18, t * 0.026, 32);
+    const userFlameSizeScale = Number.isFinite(+settings?.slides?.tileFlameSizeScale)
+      ? clamp(0.4, +settings.slides.tileFlameSizeScale, 3)
+      : 1;
+    const userFlameGapScale = Number.isFinite(+settings?.slides?.tileFlameGapScale)
+      ? clamp(0, +settings.slides.tileFlameGapScale, 3)
+      : 1;
+    const baseFlameSize = useIcons ? clamp(22, t * 0.03, 42) : clamp(18, t * 0.026, 32);
+    const baseFlameGap = useIcons ? clamp(6, t * 0.016, 22) : clamp(5, t * 0.014, 20);
+    const flameSize = baseFlameSize * userFlameSizeScale;
+    const flameGap = Math.max(0, baseFlameGap * userFlameGapScale);
     const iconColumn = useIcons ? clamp(40, iconSize * 0.75, iconSize * 1.45) : 0;
     const tileMinHeight = useIcons
       ? clamp(64, iconSize * 0.82, iconSize * 1.08)
@@ -2712,6 +2725,7 @@ function renderStorySlide(story = {}, region = 'left') {
     container.style.setProperty('--tileBadgeScale', (combinedMeta * userBadgeScale).toFixed(3));
     container.style.setProperty('--tileDescriptionScale', (combinedMeta * userBadgeDescriptionScale).toFixed(3));
     container.style.setProperty('--flameSizePx', flameSize.toFixed(2));
+    container.style.setProperty('--tileFlameGapPx', flameGap.toFixed(2) + 'px');
     container.style.setProperty('--tileIconColumnPx', useIcons ? (iconColumn.toFixed(2) + 'px') : '0px');
     container.style.setProperty('--tileHeightScale', heightScale.toFixed(3));
     container.style.setProperty('--tileMinHeightPx', (tileMinHeight * heightScale).toFixed(2) + 'px');


### PR DESCRIPTION
## Summary
- rework sauna tile layout so time content re-centres, hyphen stays with the time, and long titles wrap cleanly
- add admin controls for sauna flame size/gap and H1 max width while wiring the new settings through defaults and runtime styling
- tidy unused tile code and ensure placeholder flames keep spacing consistent

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d2d0995d508320aa3a035c356c1681