### PR TITLE
Add optional time suffix control and expand heading width

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -472,6 +472,7 @@
                   </select>
                 </div>
                 <div class="kv"><label>Uhrzeit Scale</label><input id="tileTimeScale" class="input" type="number" step="0.05" min="0.5" max="2" value="1"></div>
+                <div class="kv"><label>„Uhr“ hinter Uhrzeiten anzeigen</label><input id="timeSuffixToggle" type="checkbox"></div>
                 <div class="kv"><label>Flammen in Kacheln anzeigen</label><input id="saunaFlames" type="checkbox" checked></div>
                 <div class="kv"><label>Flammen-Größe (Faktor)</label><input id="tileFlameSizeScale" class="input" type="number" step="0.05" min="0.4" max="3" value="1"></div>
                 <div class="kv"><label>Flammen-Abstand (Faktor)</label><input id="tileFlameGapScale" class="input" type="number" step="0.05" min="0" max="3" value="1"></div>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -881,6 +881,7 @@ function renderSlidesBox(){
   setV('#h1Scale',    f.h1Scale ?? 1);
   setV('#h2Scale',    f.h2Scale ?? 1);
   setV('#tileTimeScale', f.tileMetaScale ?? 1);
+  setC('#timeSuffixToggle', settings.slides?.appendTimeSuffix === true);
   setV('#tileFlameSizeScale', settings.slides?.tileFlameSizeScale ?? DEFAULTS.slides.tileFlameSizeScale ?? 1);
   setV('#tileFlameGapScale', settings.slides?.tileFlameGapScale ?? DEFAULTS.slides.tileFlameGapScale ?? 1);
   const saunaFlameControls = ['#tileFlameSizeScale', '#tileFlameGapScale'].map(sel => document.querySelector(sel));
@@ -1389,6 +1390,7 @@ function collectSettings(){
           if (!Number.isFinite(raw)) return settings.slides?.tilePaddingScale ?? DEFAULTS.slides.tilePaddingScale ?? 0.75;
           return clamp(0.25, raw, 1.5);
         })(),
+        appendTimeSuffix: !!document.getElementById('timeSuffixToggle')?.checked,
         saunaTitleMaxWidthPercent:(() => {
           const raw = Number($('#saunaHeadingWidth')?.value);
           if (!Number.isFinite(raw)) return settings.slides?.saunaTitleMaxWidthPercent ?? DEFAULTS.slides.saunaTitleMaxWidthPercent ?? 100;

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -120,6 +120,7 @@ export const DEFAULTS = {
     tileMaxScale:0.57,
     tileHeightScale:1,
     tilePaddingScale:0.75,
+    appendTimeSuffix:false,
     tileFlameSizeScale:1,
     tileFlameGapScale:1,
     saunaTitleMaxWidthPercent:100,

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -37,7 +37,7 @@ const STYLE_FONT_KEYS = [
 const STYLE_SLIDE_KEYS = [
   'infobadgeColor','badgeLibrary','customBadgeEmojis','badgeScale','badgeDescriptionScale',
   'tileHeightScale','tilePaddingScale','tileOverlayEnabled','tileOverlayStrength','badgeInlineColumn',
-  'tileFlameSizeScale','tileFlameGapScale','saunaTitleMaxWidthPercent'
+  'tileFlameSizeScale','tileFlameGapScale','saunaTitleMaxWidthPercent','appendTimeSuffix'
 ];
 
 const SUGGESTED_BADGE_EMOJIS = [

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -144,6 +144,9 @@ body[data-layout='single'] #stage-right{display:none;}
   position:relative;
   z-index:1;
 }
+.container.has-right.full-heading .headings{
+  max-width:var(--saunaHeadingMaxWidth, 100%);
+}
 .h1{font-weight:800;letter-spacing:.02em;line-height:1.1;font-size:calc(56px*var(--scale)*var(--h1Scale));margin:0 0 10px;hyphens:auto;overflow-wrap:break-word;word-break:normal;}
 .h2{font-weight:700;letter-spacing:.01em;opacity:.95;font-size:calc(36px*var(--scale)*var(--h2Scale));margin:0 0 14px}
 .overview .h1{line-height:1.1;font-size:calc(56px*var(--scale)*var(--h1Scale)*var(--ovAuto))}


### PR DESCRIPTION
## Summary
- add a formatting helper so times omit "Uhr" by default while supporting an optional suffix across overview, sauna, hero, and story views
- expose the suffix toggle in the admin UI and defaults so the preference is persisted and available to style sets
- let sauna slide headings reach full width when their max-width slider is set to 100%

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2d6bbb4c08320bd63f94418f6434a