### PR TITLE
Fix badge persistence and simplify split layout configuration

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -330,15 +330,6 @@
                   <div class="fieldset layout-page" id="layoutLeft">
                     <div class="legend">Linke Seite</div>
                     <div class="kv">
-                      <label>Quelle</label>
-                      <select id="pageLeftSource" class="input">
-                        <option value="master">Alle Inhalte</option>
-                        <option value="schedule">Aufgussplan</option>
-                        <option value="media">Medien</option>
-                        <option value="story">Erklärungen</option>
-                      </select>
-                    </div>
-                    <div class="kv">
                       <label>Timer (Sekunden)</label>
                       <input id="pageLeftTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">
                     </div>
@@ -350,15 +341,6 @@
                   </div>
                   <div class="fieldset layout-page" id="layoutRight">
                     <div class="legend">Rechte Seite</div>
-                    <div class="kv">
-                      <label>Quelle</label>
-                      <select id="pageRightSource" class="input">
-                        <option value="media">Medien</option>
-                        <option value="master">Alle Inhalte</option>
-                        <option value="schedule">Aufgussplan</option>
-                        <option value="story">Erklärungen</option>
-                      </select>
-                    </div>
                     <div class="kv">
                       <label>Timer (Sekunden)</label>
                       <input id="pageRightTimer" class="input num3" type="number" min="0" max="600" step="1" placeholder="0 = global">

--- a/webroot/admin/js/ui/grid.js
+++ b/webroot/admin/js/ui/grid.js
@@ -3,6 +3,7 @@
 // Abhängigkeiten: utils ($,$$,parseTime) + Zugriff auf schedule/settings via init(ctx).
 
 import { $, $$, parseTime } from '../core/utils.js';
+import { sanitizeBadgeLibrary } from '../core/config.js';
 
 let ctx = null;           // { getSchedule, getSettings }
 let curRow = 0, curCol = 0;
@@ -40,7 +41,7 @@ function normalizeText(value){
 
 function getBadgeLibrary(){
   const settings = ctx?.getSettings?.();
-  const list = Array.isArray(settings?.slides?.badgeLibrary) ? settings.slides.badgeLibrary : [];
+  const list = sanitizeBadgeLibrary(settings?.slides?.badgeLibrary, { assignMissingIds: false }) || [];
   const seen = new Set();
   const out = [];
   list.forEach(entry => {


### PR DESCRIPTION
## Summary
- sanitize badge libraries when loading settings and in the admin grid so custom emojis remain available everywhere
- simplify split-layout configuration by removing source dropdowns and keeping existing sources while playlists stay editable in place
- expand slideshow filtering so selected playlist items are shown even when the page source previously hid those content types

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40378fa548320bd6edb554ccbdfb2