### PR TITLE
Fix badge library edits, remove slide sort overlay, and improve sidebar

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -303,7 +303,7 @@ main.layout{
   left:calc(var(--sidebar-resizer-hit, 18px) / -2);
   width:var(--sidebar-resizer-hit, 18px);
   display:flex;
-  align-items:center;
+  align-items:stretch;
   justify-content:center;
   cursor:col-resize;
   touch-action:none;
@@ -313,7 +313,8 @@ main.layout{
   content:"";
   display:block;
   width:3px;
-  height:48px;
+  height:100%;
+  min-height:48px;
   border-radius:999px;
   background:color-mix(in oklab, var(--btn-accent) 45%, transparent);
   opacity:0.55;
@@ -517,25 +518,20 @@ details[open] .chev{ transform: rotate(90deg); }
 @layer overlays{
 .tip{ cursor:help; color:var(--muted); margin-left:4px; }
 
-#helpOverlay,
-#slideOrderOverlay{
+#helpOverlay{
   position:fixed; inset:0; z-index:100;
   background:rgba(0,0,0,.6);
   display:flex; align-items:center; justify-content:center;
 }
-#helpOverlay[hidden],
-#slideOrderOverlay[hidden]{ display:none; }
-#helpOverlay .panel,
-#slideOrderOverlay .panel{
+#helpOverlay[hidden]{ display:none; }
+#helpOverlay .panel{
   background:var(--panel); color:var(--fg);
   border:1px solid var(--border); border-radius:16px;
   padding:24px; max-width:700px; width:90%;
   position:relative;
 }
-#helpOverlay .panel h2,
-#slideOrderOverlay .panel h2{ margin-top:0; }
-#helpClose,
-#slideOrderClose{ position:absolute; top:8px; right:8px; }
+#helpOverlay .panel h2{ margin-top:0; }
+#helpClose{ position:absolute; top:8px; right:8px; }
 .btn.ghost:hover{ background: color-mix(in oklab, var(--ghost-fg) 6%, transparent); }
 }
 
@@ -544,185 +540,6 @@ details[open] .chev{ transform: rotate(90deg); }
   display:flex;
   flex-direction:column;
   gap:8px;
-}
-
-.slide-order-grid{
-  display:grid;
-  gap:12px;
-  grid-template-columns:repeat(auto-fill, minmax(120px,1fr));
-  margin-top:16px;
-}
-
-.slide-order-tile{
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  border:1px solid var(--border);
-  border-radius:12px;
-  padding:8px;
-  background:var(--panel);
-  cursor:grab;
-  gap:6px;
-  position:relative;
-}
-
-.slide-order-tile.is-disabled{
-  background:color-mix(in oklab, var(--panel) 70%, transparent);
-  border-color:color-mix(in oklab, var(--border) 55%, transparent);
-  box-shadow:inset 0 0 0 1px color-mix(in oklab, var(--border) 35%, transparent);
-}
-
-.slide-order-tile.is-unselected{
-  opacity:0.6;
-  cursor:pointer;
-}
-
-.slide-order-tile.is-unselected:hover{
-  opacity:0.85;
-}
-
-.slide-order-tile.is-unselected.is-disabled{
-  cursor:not-allowed;
-}
-
-.slide-order-tile.is-disabled img{
-  filter:saturate(0) brightness(0.82);
-  opacity:0.55;
-}
-
-.slide-order-tile.is-disabled .title{
-  color:color-mix(in oklab, var(--muted) 82%, var(--fg));
-}
-
-.slide-order-tile.dragging{
-  opacity:0.6;
-  cursor:grabbing;
-  box-shadow:0 12px 24px rgba(15, 23, 42, 0.25);
-}
-
-.slide-order-tile:is(.drop-before, .drop-after){
-  position:relative;
-  box-shadow:0 0 0 2px rgba(124, 58, 237, 0.25);
-}
-
-.slide-order-tile:is(.drop-before, .drop-after)::after{
-  content:'';
-  position:absolute;
-  left:12px;
-  right:12px;
-  height:4px;
-  border-radius:999px;
-  background:var(--btn-accent);
-}
-
-.slide-order-tile.drop-before::after{ top:-6px; }
-.slide-order-tile.drop-after::after{ bottom:-6px; }
-
-.slide-order-tile:is(.drop-before, .drop-after)::before{
-  content:'';
-  position:absolute;
-  left:50%;
-  transform:translateX(-50%);
-  border:6px solid transparent;
-}
-
-.slide-order-tile.drop-before::before{
-  top:-13px;
-  border-bottom-color:var(--btn-accent);
-}
-
-.slide-order-tile.drop-after::before{
-  bottom:-13px;
-  border-top-color:var(--btn-accent);
-}
-
-.slide-order-tile img{
-  width:100%;
-  height:80px;
-  object-fit:cover;
-  border-radius:8px;
-}
-
-.slide-order-tile .title{
-  font-weight:600;
-  margin-bottom:2px;
-  text-align:center;
-}
-
-.slide-order-tile .slide-status{
-  font-size:12px;
-  font-weight:600;
-  line-height:1.3;
-  padding:4px 8px;
-  border-radius:999px;
-  text-align:center;
-  width:100%;
-  border-color:color-mix(in oklab, var(--btn-accent) 45%, var(--border));
-  color:color-mix(in oklab, var(--btn-accent) 70%, var(--fg));
-  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
-}
-
-.slide-order-tile .reorder-controls{
-  display:flex;
-  justify-content:center;
-  gap:8px;
-  margin-top:8px;
-  width:100%;
-}
-
-.slide-order-tile .playlist-state{
-  position:absolute;
-  top:8px;
-  left:8px;
-  font-size:11px;
-  font-weight:600;
-  padding:2px 8px;
-  border-radius:999px;
-  background:color-mix(in oklab, var(--btn-accent) 15%, var(--panel));
-  color:color-mix(in oklab, var(--btn-accent) 80%, var(--fg));
-  border:1px solid color-mix(in oklab, var(--btn-accent) 35%, var(--border));
-}
-
-.slide-order-tile.is-unselected .playlist-state{
-  background:color-mix(in oklab, var(--panel) 92%, transparent);
-  color:var(--muted);
-  border-color:color-mix(in oklab, var(--border) 65%, transparent);
-}
-
-.slide-order-tile .reorder-btn{
-  --btn-size:28px;
-  flex:0 0 auto;
-  inline-size:var(--btn-size);
-  block-size:var(--btn-size);
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  border-radius:999px;
-  border:1px solid var(--ghost-border);
-  background:var(--ghost-bg);
-  color:var(--fg);
-  cursor:pointer;
-  padding:0;
-  transition:background-color .2s ease, border-color .2s ease, box-shadow .2s ease;
-}
-
-.slide-order-tile .reorder-btn svg{
-  width:16px;
-  height:16px;
-  fill:currentColor;
-  pointer-events:none;
-}
-
-.slide-order-tile .reorder-btn span{ pointer-events:none; }
-
-.slide-order-tile .reorder-btn:focus-visible{
-  outline:0;
-  box-shadow:0 0 0 3px color-mix(in oklab, var(--input-focus) 30%, transparent);
-  border-color:var(--input-focus);
-}
-
-.slide-order-tile .reorder-btn:active{
-  background: color-mix(in oklab, var(--ghost-fg, var(--fg)) 6%, transparent);
 }
 
 /* Toggle */

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -283,7 +283,7 @@
     <details class="ac sub" id="boxImages">
 <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button><button class="btn sm" id="btnSortSlides">Slides sortieren</button></div>
+    <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button></div>
   </summary>
 <small class="help">* Dauer nur sichtbar, wenn „Individuell pro Slide“ gewählt ist.</small>
   <div class="content">
@@ -660,14 +660,6 @@
     <small class="mut" style="display:block;margin-top:8px">
       Live-Ansicht des ausgewählten Geräts (nur Lesen; kein Pairing, keine Speicherung).
     </small>
-  </div>
-</div>
-
-<div id="slideOrderOverlay" hidden>
-  <div class="panel">
-    <button id="slideOrderClose" class="btn icon" aria-label="Schließen">✕</button>
-    <h2>Slides sortieren</h2>
-    <div id="slideOrderGrid" class="slide-order-grid"></div>
   </div>
 </div>
 

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -193,7 +193,7 @@ function initSidebarResize(){
   resizer.addEventListener('pointermove', (ev) => {
     if (!dragState.active || ev.pointerId !== dragState.pointerId) return;
     const delta = ev.clientX - dragState.startX;
-    applyWidth(dragState.startWidth + delta, { store: false });
+    applyWidth(dragState.startWidth - delta, { store: false });
   });
 
   const finishDrag = (store = true) => {
@@ -220,16 +220,16 @@ function initSidebarResize(){
     const step = ev.shiftKey ? 48 : 24;
     if (ev.key === 'ArrowLeft') {
       ev.preventDefault();
-      applyWidth(baseWidth - step);
+      applyWidth(baseWidth + step);
     } else if (ev.key === 'ArrowRight') {
       ev.preventDefault();
-      applyWidth(baseWidth + step);
+      applyWidth(baseWidth - step);
     } else if (ev.key === 'Home') {
       ev.preventDefault();
-      applyWidth(minPx);
+      applyWidth(maxPx);
     } else if (ev.key === 'End') {
       ev.preventDefault();
-      applyWidth(maxPx);
+      applyWidth(minPx);
     }
   });
 
@@ -970,8 +970,19 @@ function renderSlidesBox(){
   renderPagePlaylist('pageRightPlaylist', rightCfg.playlist, { pageKey: 'right' });
   const layoutModeSelect = document.getElementById('layoutMode');
   const applyLayoutVisibility = (mode) => {
+    const isSplit = (mode === 'split');
     const rightWrap = document.getElementById('layoutRight');
-    if (rightWrap) rightWrap.hidden = (mode !== 'split');
+    if (rightWrap) rightWrap.hidden = !isSplit;
+    const leftLegend = document.querySelector('#layoutLeft .legend');
+    if (leftLegend) {
+      if (isSplit) {
+        leftLegend.textContent = 'Linke Seite';
+        leftLegend.hidden = false;
+      } else {
+        leftLegend.textContent = '';
+        leftLegend.hidden = true;
+      }
+    }
   };
   applyLayoutVisibility(layoutMode);
   if (layoutModeSelect) {

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -1711,7 +1711,7 @@ function renderStorySlidesPanel(hostId='storyList'){
 }
 
 // ============================================================================
-// 6b) Slide Order View
+// 6b) Slide Order Stream
 // ============================================================================
 export function collectSlideOrderStream({ normalizeSortOrder = true } = {}){
   const settings = ctx.getSettings();
@@ -1766,232 +1766,6 @@ export function collectSlideOrderStream({ normalizeSortOrder = true } = {}){
   };
 }
 
-export function renderSlideOrderView(){
-  const settings = ctx.getSettings();
-  const host = document.getElementById('slideOrderGrid');
-  if (!host) return;
-
-  const { entries: combinedRaw, hiddenSaunas } = collectSlideOrderStream({ normalizeSortOrder: true });
-  let combined = combinedRaw.slice();
-
-  host.innerHTML = '';
-  combined.forEach((entry, idx) => {
-    const tile = document.createElement('div');
-    tile.className = 'slide-order-tile';
-    tile.draggable = true;
-    tile.dataset.idx = idx;
-    tile.dataset.type = entry.kind;
-
-    const isHiddenSauna = entry.kind === 'sauna' && hiddenSaunas.has(entry.name);
-    const isDisabledMedia = entry.kind === 'media' && entry.item?.enabled === false;
-    const isDisabledStory = entry.kind === 'story' && entry.item?.enabled === false;
-    if (isHiddenSauna) tile.classList.add('is-hidden');
-    if (isHiddenSauna || isDisabledMedia || isDisabledStory) tile.classList.add('is-disabled');
-
-    const title = document.createElement('div');
-    title.className = 'title';
-    let statusEl = null;
-    if (isHiddenSauna || isDisabledMedia || isDisabledStory){
-      statusEl = document.createElement('div');
-      statusEl.className = 'slide-status';
-      statusEl.dataset.state = 'hidden';
-      statusEl.textContent = 'Ausgeblendet';
-    }
-    if (entry.kind === 'sauna'){
-      tile.dataset.name = entry.name;
-      title.textContent = entry.name;
-      tile.appendChild(title);
-      if (statusEl) tile.appendChild(statusEl);
-      const imgSrc = settings.assets?.rightImages?.[entry.name] || '';
-      if (imgSrc){
-        const img = document.createElement('img');
-        img.src = imgSrc;
-        img.alt = entry.name || '';
-        tile.appendChild(img);
-      }
-    } else if (entry.kind === 'media') {
-      tile.dataset.id = entry.item.id;
-      title.textContent = entry.item.name || '(unbenannt)';
-      tile.appendChild(title);
-      if (statusEl) tile.appendChild(statusEl);
-      const img = document.createElement('img');
-      img.src = entry.item.thumb || entry.item.url || '';
-      img.alt = entry.item.name || '';
-      tile.appendChild(img);
-    } else {
-      tile.dataset.storyId = entry.item?.id || entry.key || '';
-      title.textContent = entry.item?.title || 'Story-Slide';
-      tile.appendChild(title);
-      if (statusEl) tile.appendChild(statusEl);
-      const img = document.createElement('img');
-      img.src = entry.item?.heroUrl || FALLBACK_HERO;
-      img.alt = entry.item?.heroAlt || '';
-      tile.appendChild(img);
-    }
-
-    const controls = document.createElement('div');
-    controls.className = 'reorder-controls';
-
-    const stopDragPropagation = ev => {
-      ev.stopPropagation();
-    };
-
-    const preventDragStart = ev => {
-      ev.preventDefault();
-    };
-
-    const makeCtrlButton = (dir, label) => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = `reorder-btn ${dir > 0 ? 'reorder-down' : 'reorder-up'}`;
-      btn.setAttribute('aria-label', label);
-      btn.title = label;
-      const iconMarkup = dir < 0
-        ? '<svg aria-hidden="true" viewBox="0 0 16 16" focusable="false"><path d="M8 3.5 12.5 8l-.7.7L8 4.9 4.2 8.7l-.7-.7Z"/></svg>'
-        : '<svg aria-hidden="true" viewBox="0 0 16 16" focusable="false"><path d="m8 12.5-4.5-4.5.7-.7L8 11.1l3.8-3.8.7.7Z"/></svg>';
-      btn.innerHTML = iconMarkup;
-      btn.draggable = false;
-      btn.addEventListener('pointerdown', stopDragPropagation);
-      btn.addEventListener('mousedown', stopDragPropagation);
-      btn.addEventListener('touchstart', stopDragPropagation);
-      btn.addEventListener('click', ev => {
-        ev.stopPropagation();
-        let moved = false;
-        if (dir < 0){
-          const prev = tile.previousElementSibling;
-          if (prev){
-            prev.before(tile);
-            moved = true;
-          }
-        } else {
-          const next = tile.nextElementSibling;
-          if (next){
-            next.after(tile);
-            moved = true;
-          }
-        }
-        if (!moved) return;
-        clearDropIndicators();
-        commitReorder();
-        window.__queueUnsaved?.();
-        window.dockPushDebounced?.();
-      });
-      btn.addEventListener('dragstart', preventDragStart);
-      return btn;
-    };
-
-    controls.appendChild(makeCtrlButton(-1, 'Nach oben verschieben'));
-    controls.appendChild(makeCtrlButton(1, 'Nach unten verschieben'));
-    tile.appendChild(controls);
-
-    host.appendChild(tile);
-  });
-
-  let dragged = null;
-  const DROP_BEFORE = 'drop-before';
-  const DROP_AFTER = 'drop-after';
-
-  const clearDropIndicators = () => {
-    host.querySelectorAll('.slide-order-tile').forEach(el => {
-      el.classList.remove(DROP_BEFORE, DROP_AFTER);
-    });
-  };
-
-  const commitReorder = () => {
-    const tiles = Array.from(host.children);
-    const reordered = tiles.map(el => combined[+el.dataset.idx]);
-    combined = reordered;
-    tiles.forEach((el, i) => { el.dataset.idx = i; });
-
-    const newSaunas = [];
-    const newMedia = [];
-    const newStories = [];
-    const sortOrder = [];
-    for (const entry of reordered){
-      if (entry.kind === 'sauna'){
-        newSaunas.push(entry.name);
-        sortOrder.push({ type:'sauna', name: entry.name });
-      } else if (entry.kind === 'media') {
-        newMedia.push(entry.item);
-        sortOrder.push({ type:'media', id: entry.item.id });
-      } else if (entry.kind === 'story') {
-        newStories.push(entry.item);
-        sortOrder.push({ type:'story', id: entry.item?.id ?? entry.key });
-      }
-    }
-    schedule.saunas = newSaunas;
-    settings.interstitials = newMedia;
-    settings.slides.storySlides = newStories;
-    settings.slides ||= {};
-    settings.slides.sortOrder = sortOrder;
-    window.__queueUnsaved?.();
-    window.dockPushDebounced?.();
-  };
-
-  const updateDropIndicator = (target, before) => {
-    if (!target || target === dragged) return;
-    host.querySelectorAll('.slide-order-tile').forEach(el => {
-      if (el !== target) el.classList.remove(DROP_BEFORE, DROP_AFTER);
-    });
-    target.classList.remove(DROP_BEFORE, DROP_AFTER);
-    target.classList.add(before ? DROP_BEFORE : DROP_AFTER);
-  };
-
-  const isBeforeTarget = (event, target) => {
-    const rect = target.getBoundingClientRect();
-    const horizontal = rect.width > rect.height;
-    return horizontal
-      ? (event.clientX < rect.left + rect.width / 2)
-      : (event.clientY < rect.top + rect.height / 2);
-  };
-
-  host.querySelectorAll('.slide-order-tile').forEach(tile => {
-    tile.addEventListener('dragstart', e => {
-      dragged = tile;
-      tile.classList.add('dragging');
-      e.dataTransfer.effectAllowed = 'move';
-    });
-    tile.addEventListener('dragenter', e => {
-      if (!dragged || tile === dragged) return;
-      e.preventDefault();
-      const before = isBeforeTarget(e, tile);
-      updateDropIndicator(tile, before);
-    });
-    tile.addEventListener('dragover', e => {
-      e.preventDefault();
-      const target = tile;
-      if (target === dragged) return;
-      const before = isBeforeTarget(e, target);
-      updateDropIndicator(target, before);
-      if (before) target.before(dragged);
-      else target.after(dragged);
-    });
-    tile.addEventListener('dragleave', e => {
-      if (tile.contains(e.relatedTarget)) return;
-      tile.classList.remove(DROP_BEFORE, DROP_AFTER);
-    });
-    tile.addEventListener('drop', e => {
-      e.preventDefault();
-      clearDropIndicators();
-    });
-    tile.addEventListener('dragend', () => {
-      clearDropIndicators();
-      tile.classList.remove('dragging');
-      commitReorder();
-      dragged = null;
-    });
-  });
-
-  host.addEventListener('drop', e => {
-    e.preventDefault();
-    clearDropIndicators();
-    if (dragged) dragged.classList.remove('dragging');
-  });
-
-  host.addEventListener('dragover', e => {
-    e.preventDefault();
-  });
-}
 
 // ============================================================================
 // 7) Haupt-Renderer
@@ -2395,12 +2169,18 @@ export function renderSlidesMaster(){
         notifyChange();
       });
 
-      labelInput.addEventListener('input', updatePreview);
-      labelInput.addEventListener('change', () => {
-        badge.label = labelInput.value.trim();
-        labelInput.value = badge.label;
+      labelInput.addEventListener('input', () => {
+        badge.label = labelInput.value;
         updatePreview();
         notifyChange();
+      });
+      labelInput.addEventListener('change', () => {
+        const trimmed = labelInput.value.trim();
+        const prev = badge.label;
+        badge.label = trimmed;
+        labelInput.value = badge.label;
+        updatePreview();
+        if (prev !== trimmed) notifyChange();
       });
 
       removeBtn.addEventListener('click', () => {
@@ -2677,25 +2457,6 @@ if (durPer) durPer.onchange = () => {
   // Medien-Slides
   renderInterstitialsPanel('interList2');
 
-  const sortBtn = $('#btnSortSlides');
-  const orderOverlay = $('#slideOrderOverlay');
-  const closeOrder = $('#slideOrderClose');
-  if (sortBtn) sortBtn.onclick = () => {
-    if (orderOverlay) {
-      orderOverlay.hidden = false;
-      renderSlideOrderView();
-    }
-  };
-  if (closeOrder) closeOrder.onclick = () => {
-    if (orderOverlay) orderOverlay.hidden = true;
-    renderSlidesMaster();
-  };
-  if (orderOverlay) orderOverlay.addEventListener('click', e => {
-    if (e.target === orderOverlay) {
-      orderOverlay.hidden = true;
-      renderSlidesMaster();
-    }
-  });
 
   // Reset & Add Sauna
   const rs = $('#resetTiming');


### PR DESCRIPTION
## Summary
- update badge library label inputs to persist immediately and trim values on blur
- remove the unused slide sorting overlay markup, styles, and handlers
- adjust the sidebar resizer to drag along its full height with inverted direction and hide the left legend in single-column mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d40b865d348320b2f6a4f5c293217e