### PR TITLE
Fix badge library persistence and improve sidebar resize

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -309,6 +309,9 @@ main.layout{
   touch-action:none;
   z-index:5;
 }
+.rightbar.resize-hover{
+  cursor:col-resize;
+}
 .rightbar .layout-resizer::before{
   content:"";
   display:block;


### PR DESCRIPTION
## Summary
- sync badge library and custom emoji edits into the active style set so saved data stays up to date
- reuse a central helper when badge rows change to keep unsaved state and device previews in sync
- invert the sidebar drag direction, allow dragging from any point on the left edge, and refresh the cursor state

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d41235bc948320885a160eeb840fd4