### PR TITLE
Refine slideshow styling controls

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -283,7 +283,7 @@
     <details class="ac sub" id="boxImages">
 <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>
-    <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button><button class="btn sm" id="btnSortSlides">Slides sortieren</button></div>
+    <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button></div>
   </summary>
 <small class="help">* Dauer nur sichtbar, wenn „Individuell pro Slide“ gewählt ist.</small>
   <div class="content">
@@ -359,15 +359,23 @@
           <div class="settings-grid two-col">
             <div class="settings-card">
               <div class="settings-card-head">
-                <div class="settings-card-title">Skalierung &amp; 16:9</div>
+                <div class="settings-card-title">Style Paletten</div>
               </div>
               <div class="settings-card-body">
-                <div class="kv"><label>Fit‑Modus</label>
-                  <select id="fitMode" class="input">
-                    <option value="auto">Auto</option>
-                  </select>
+                <div class="kv">
+                  <label>Stil-Paletten</label>
+                  <div class="style-set-controls">
+                    <select id="styleSetSelect" class="input"></select>
+                    <div class="row" style="gap:6px;flex-wrap:wrap">
+                      <button class="btn sm" id="styleSetApply" type="button">Aktivieren</button>
+                      <button class="btn sm ghost" id="styleSetSave" type="button">Aktualisieren</button>
+                      <button class="btn sm ghost" id="styleSetCreate" type="button">Neu</button>
+                      <button class="btn sm ghost" id="styleSetDelete" type="button">Löschen</button>
+                    </div>
+                  </div>
                 </div>
-                <div class="help">Passt je nach Seitenverhältnis automatisch an (Cover oder Contain).</div>
+                <div class="kv"><label>Palettenname</label><input id="styleSetLabel" class="input" type="text" placeholder="Palette"></div>
+                <div class="help">Paletten speichern Farben, Typografie und Badge-Optionen. „Aktivieren“ übernimmt die Auswahl in die aktuellen Einstellungen.</div>
               </div>
             </div>
 
@@ -477,26 +485,10 @@
                   <div id="componentToggleWrap" class="component-toggle-wrap">
                     <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="title"> Titel &amp; Uhrzeit</label>
                     <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="description"> Beschreibung</label>
-                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="aromas"> Aromenliste</label>
-                    <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="facts"> Fakten/Chips</label>
                     <label class="btn sm ghost component-toggle"><input type="checkbox" data-component="badges"> Badge-Leiste</label>
                   </div>
                   <div class="help">Gilt auch für die Verfügbarkeitsliste in Story-Slides.</div>
                 </div>
-                <div class="kv">
-                  <label>Stil-Paletten</label>
-                  <div class="style-set-controls">
-                    <select id="styleSetSelect" class="input"></select>
-                    <div class="row" style="gap:6px;flex-wrap:wrap">
-                      <button class="btn sm" id="styleSetApply" type="button">Aktivieren</button>
-                      <button class="btn sm ghost" id="styleSetSave" type="button">Aktualisieren</button>
-                      <button class="btn sm ghost" id="styleSetCreate" type="button">Neu</button>
-                      <button class="btn sm ghost" id="styleSetDelete" type="button">Löschen</button>
-                    </div>
-                  </div>
-                </div>
-                <div class="kv"><label>Palettenname</label><input id="styleSetLabel" class="input" type="text" placeholder="Palette"></div>
-                <div class="help">Paletten speichern Farben, Typografie und Badge-Optionen. „Aktivieren“ übernimmt die Auswahl in die aktuellen Einstellungen.</div>
               </div>
             </div>
 
@@ -623,7 +615,6 @@
         <select id="m_flames" class="input">
           <option value="">—</option>
           <option>1</option><option>2</option><option>3</option>
-          <option>1-2</option><option>2-3</option><option>1-3</option>
         </select>
         <label>Fußnote</label>
         <div>
@@ -660,14 +651,6 @@
     <small class="mut" style="display:block;margin-top:8px">
       Live-Ansicht des ausgewählten Geräts (nur Lesen; kein Pairing, keine Speicherung).
     </small>
-  </div>
-</div>
-
-<div id="slideOrderOverlay" hidden>
-  <div class="panel">
-    <button id="slideOrderClose" class="btn icon" aria-label="Schließen">✕</button>
-    <h2>Slides sortieren</h2>
-    <div id="slideOrderGrid" class="slide-order-grid"></div>
   </div>
 </div>
 

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -732,6 +732,32 @@ function renderSlidesBox(){
       const prevStr = JSON.stringify(Array.isArray(pageState.playlist) ? pageState.playlist : []);
       const nextStr = JSON.stringify(next);
       pageState.playlist = next;
+      if (normalizedKey === 'left') {
+        const layoutSelect = document.getElementById('layoutMode');
+        const layoutModeValue = layoutSelect?.value === 'split' ? 'split' : 'single';
+        if (layoutModeValue !== 'split') {
+          const sortOrder = [];
+          next.forEach(entry => {
+            if (!entry || typeof entry !== 'object') return;
+            if (entry.type === 'sauna' && entry.name) {
+              sortOrder.push({ type: 'sauna', name: entry.name });
+            } else if (entry.type === 'media' && entry.id != null) {
+              sortOrder.push({ type: 'media', id: entry.id });
+            } else if (entry.type === 'story' && entry.id != null) {
+              sortOrder.push({ type: 'story', id: entry.id });
+            }
+          });
+          const prevSortStr = JSON.stringify(Array.isArray(settings.slides?.sortOrder) ? settings.slides.sortOrder : []);
+          settings.slides ||= {};
+          if (sortOrder.length) settings.slides.sortOrder = sortOrder;
+          else delete settings.slides.sortOrder;
+          const nextSortStr = JSON.stringify(sortOrder);
+          if (prevSortStr !== nextSortStr && prevStr === nextStr) {
+            setUnsavedState(true);
+            if (typeof window.dockPushDebounced === 'function') window.dockPushDebounced();
+          }
+        }
+      }
       if (prevStr !== nextStr) {
         setUnsavedState(true);
         if (typeof window.dockPushDebounced === 'function') window.dockPushDebounced();
@@ -917,6 +943,12 @@ function renderSlidesBox(){
     }
 
     renderTiles();
+    if (normalizedKey === 'left') {
+      const layoutSelect = document.getElementById('layoutMode');
+      if ((layoutSelect?.value === 'split' ? 'split' : 'single') !== 'split') {
+        commitPlaylist();
+      }
+    }
   };
 
   // Schrift

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -29,8 +29,6 @@ const DEFAULT_FONTS = {
 const DEFAULT_ENABLED_COMPONENTS = {
   title:true,
   description:true,
-  aromas:true,
-  facts:true,
   badges:true
 };
 

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -22,7 +22,7 @@ import { DEFAULTS } from '../core/defaults.js';
 let ctx = null; // { getSchedule, getSettings, setSchedule, setSettings }
 let wiredStatic = false;
 
-const COMPONENT_KEYS = ['title','description','aromas','facts','badges'];
+const COMPONENT_KEYS = ['title','description','badges'];
 
 const STYLE_THEME_KEYS = [
   'bg','fg','accent','gridBorder','gridTable','gridTableW','cellBg','boxFg','headRowBg','headRowFg',
@@ -2742,26 +2742,6 @@ if (durPer) durPer.onchange = () => {
 
   // Medien-Slides
   renderInterstitialsPanel('interList2');
-
-  const sortBtn = $('#btnSortSlides');
-  const orderOverlay = $('#slideOrderOverlay');
-  const closeOrder = $('#slideOrderClose');
-  if (sortBtn) sortBtn.onclick = () => {
-    if (orderOverlay) {
-      orderOverlay.hidden = false;
-      renderSlideOrderView();
-    }
-  };
-  if (closeOrder) closeOrder.onclick = () => {
-    if (orderOverlay) orderOverlay.hidden = true;
-    renderSlidesMaster();
-  };
-  if (orderOverlay) orderOverlay.addEventListener('click', e => {
-    if (e.target === orderOverlay) {
-      orderOverlay.hidden = true;
-      renderSlidesMaster();
-    }
-  });
 
   // Reset & Add Sauna
   const rs = $('#resetTiming');


### PR DESCRIPTION
## Summary
- move the style palette controls into a dedicated "Style Paletten" card and drop the unused fit mode selector
- streamline slide component toggles to the remaining supported options and remove the old slide-sorting overlay/button
- sync the single-column playlist with the slideshow sort order so that it defines the playback sequence

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d41e46c9c483208eb776933a044f1a