### PR TITLE
Refactor admin API storage helpers

### DIFF
--- a/webroot/admin/api/device_resolve.php
+++ b/webroot/admin/api/device_resolve.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/storage.php';
+
 /**
  * File: /var/www/signage/admin/api/device_resolve.php
  * Zweck: Liefert aufgelöste Einstellungen (global + Geräte-Overrides) und Zeitplan.
@@ -22,14 +24,6 @@ function merge_r($a, $b) {
       : $v;
   }
   return $a;
-}
-
-/** JSON sicher lesen; bei defekten/fehlenden Dateien leere Defaults liefern. */
-function read_json_file($absPath) {
-  if (!is_file($absPath)) return [];
-  $raw = @file_get_contents($absPath);
-  $j = json_decode($raw, true);
-  return is_array($j) ? $j : [];
 }
 
 /** Aktueller Tag als Kurzschlüssel (Sun,Mon,...). */
@@ -64,14 +58,8 @@ if (!$dev) {
 
 // --- Pfade & Basiskonfiguration --------------------------------------------
 
-$docRoot = rtrim($_SERVER['DOCUMENT_ROOT'] ?? '', '/');
-if ($docRoot === '' || !is_dir($docRoot)) {
-  // Fallback, falls PHP-FPM nicht mit korrektem DOCUMENT_ROOT läuft
-  $docRoot = rtrim(realpath(__DIR__ . '/../../'), '/');
-}
-
-$baseSettings = read_json_file($docRoot . '/data/settings.json');
-$baseSchedule = read_json_file($docRoot . '/data/schedule.json');
+$baseSettings = signage_read_json('settings.json');
+$baseSchedule = signage_read_json('schedule.json');
 $baseScheduleVersion = intval($baseSchedule['version'] ?? 0);
 
 $overSettings = $dev['overrides']['settings'] ?? [];
@@ -140,4 +128,4 @@ $out = [
   'now'      => time(),
 ];
 
-echo json_encode($out, JSON_UNESCAPED_SLASHES);
+echo json_encode($out, SIGNAGE_JSON_FLAGS);

--- a/webroot/admin/api/devices_store.php
+++ b/webroot/admin/api/devices_store.php
@@ -3,10 +3,13 @@
 // Wird von Heartbeat- und Admin-APIs genutzt. Pfade werden zentral über
 // devices_path() bestimmt, um harte Pfadangaben zu vermeiden.
 
+require_once __DIR__ . '/storage.php';
+
 function devices_path() {
+  $custom = getenv('DEVICES_PATH');
+  if (is_string($custom) && $custom !== '') return $custom;
   if (!empty($_ENV['DEVICES_PATH'])) return $_ENV['DEVICES_PATH'];
-  $root = $_SERVER['DOCUMENT_ROOT'] ?? dirname(__DIR__, 2);
-  return rtrim($root, '/') . '/data/devices.json';
+  return signage_data_path('devices.json');
 }
 
 function devices_load(){
@@ -19,7 +22,7 @@ function devices_load(){
 function devices_save($db){
   $p = devices_path();
   @mkdir(dirname($p), 02775, true);
-  $json = json_encode($db, JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT);
+  $json = json_encode($db, SIGNAGE_JSON_FLAGS);
   $bytes = @file_put_contents($p, $json, LOCK_EX);
   if ($bytes === false) {
     throw new RuntimeException('Unable to write device database');

--- a/webroot/admin/api/load.php
+++ b/webroot/admin/api/load.php
@@ -1,5 +1,9 @@
 <?php
+require_once __DIR__ . '/storage.php';
+
 header('Content-Type: application/json; charset=UTF-8');
-$fn = '/var/www/signage/data/schedule.json';
+$fn = signage_data_path('schedule.json');
 if(!is_file($fn)){ http_response_code(404); echo json_encode(['error'=>'no-schedule']); exit; }
-echo file_get_contents($fn);
+$raw = file_get_contents($fn);
+if ($raw === false) { http_response_code(500); echo json_encode(['error'=>'read-failed']); exit; }
+echo $raw;

--- a/webroot/admin/api/load_settings.php
+++ b/webroot/admin/api/load_settings.php
@@ -1,6 +1,8 @@
 <?php
+require_once __DIR__ . '/storage.php';
+
 header('Content-Type: application/json; charset=UTF-8');
-$fn = '/var/www/signage/data/settings.json';
+$fn = signage_data_path('settings.json');
 if(!is_file($fn)){
 echo json_encode([
   'version'=>1,
@@ -37,7 +39,13 @@ echo json_encode([
   'interstitials'=>[],
   'presets'=>[],
   'presetAuto'=>false
-]);
+], SIGNAGE_JSON_FLAGS);
 exit;
 }
-echo file_get_contents($fn);
+$raw = file_get_contents($fn);
+if ($raw === false) {
+  http_response_code(500);
+  echo json_encode(['error'=>'read-failed']);
+  exit;
+}
+echo $raw;

--- a/webroot/admin/api/storage.php
+++ b/webroot/admin/api/storage.php
@@ -1,0 +1,103 @@
+<?php
+// Gemeinsame Helfer für Dateipfade und JSON-Zugriff
+// Stellt zentrale Funktionen bereit, damit Pfade nicht hart codiert werden
+// und Deployments mit abweichenden Wurzelverzeichnissen funktionieren.
+
+declare(strict_types=1);
+
+const SIGNAGE_JSON_FLAGS = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT;
+
+function signage_base_path(): string
+{
+    static $base = null;
+    if ($base !== null) {
+        return $base;
+    }
+
+    $candidates = [
+        getenv('SIGNAGE_BASE_PATH') ?: null,
+        $_ENV['SIGNAGE_BASE_PATH'] ?? null,
+        $_SERVER['SIGNAGE_BASE_PATH'] ?? null,
+        $_SERVER['DOCUMENT_ROOT'] ?? null,
+        realpath(__DIR__ . '/../../') ?: (__DIR__ . '/../../'),
+    ];
+
+    foreach ($candidates as $candidate) {
+        if (!is_string($candidate) || $candidate === '') {
+            continue;
+        }
+        $resolved = realpath($candidate);
+        if ($resolved !== false) {
+            $candidate = $resolved;
+        }
+        if (is_dir($candidate)) {
+            return $base = rtrim($candidate, '/');
+        }
+    }
+
+    return $base = rtrim(__DIR__ . '/../../', '/');
+}
+
+function signage_data_path(string $file = ''): string
+{
+    $dir = signage_base_path() . '/data';
+    if ($file === '') {
+        return $dir;
+    }
+    return $dir . '/' . ltrim($file, '/');
+}
+
+function signage_assets_path(string $path = ''): string
+{
+    $dir = signage_base_path() . '/assets';
+    if ($path === '') {
+        return $dir;
+    }
+    return $dir . '/' . ltrim($path, '/');
+}
+
+function signage_read_json(string $file, array $default = []): array
+{
+    $path = signage_data_path($file);
+    if (!is_file($path)) {
+        return $default;
+    }
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return $default;
+    }
+    $decoded = json_decode($raw, true);
+    return is_array($decoded) ? $decoded : $default;
+}
+
+function signage_write_json(string $file, $data, ?string &$error = null): bool
+{
+    $path = signage_data_path($file);
+    $dir = dirname($path);
+    if (!is_dir($dir) && !@mkdir($dir, 02775, true) && !is_dir($dir)) {
+        $error = 'unable to create directory: ' . $dir;
+        return false;
+    }
+    $json = json_encode($data, SIGNAGE_JSON_FLAGS);
+    if ($json === false) {
+        $error = 'json_encode failed: ' . json_last_error_msg();
+        return false;
+    }
+    $bytes = @file_put_contents($path, $json, LOCK_EX);
+    if ($bytes === false) {
+        $err = error_get_last();
+        $error = $err['message'] ?? 'file_put_contents failed';
+        return false;
+    }
+    @chmod($path, 0644);
+    return true;
+}
+
+function signage_absolute_path(string $relative): string
+{
+    if ($relative === '' || $relative[0] !== '/') {
+        $relative = '/' . ltrim($relative, '/');
+    }
+    return signage_base_path() . $relative;
+}
+

--- a/webroot/admin/api/upload.php
+++ b/webroot/admin/api/upload.php
@@ -1,6 +1,6 @@
-
 <?php
-// file: /var/www/signage/admin/api/upload.php
+require_once __DIR__ . '/storage.php';
+
 // Zweck: Sicheren Upload von Medien nach /assets/media/ (Bilder, Videos)
 // Hinweise: Nginx client_max_body_size & PHP upload_max_filesize/post_max_size müssen groß genug sein.
 
@@ -46,7 +46,7 @@ $orig = preg_replace('/[^A-Za-z0-9._-]/','_', $u['name']);
 if (!$orig) $orig = 'upload.' . $ext;
 if (!preg_match('/\\.' . preg_quote($ext,'/') . '$/i', $orig)) $orig .= '.' . $ext;
 
-$baseDir = '/var/www/signage/assets/media/'.$subDir.'/';
+$baseDir = rtrim(signage_assets_path('media/'.$subDir), '/') . '/';
 if (!is_dir($baseDir)) { @mkdir($baseDir, 02775, true); @chown($baseDir,'www-data'); @chgrp($baseDir,'www-data'); }
 
 $dest = $baseDir . $orig;
@@ -83,7 +83,7 @@ if ($subDir === 'img'){
   $torig = preg_replace('/[^A-Za-z0-9._-]/','_', $tu['name']);
   if (!$torig) $torig = 'thumb.'.$text;
   if (!preg_match('/\\.' . preg_quote($text,'/') . '$/i', $torig)) $torig .= '.' . $text;
-  $tbase = '/var/www/signage/assets/media/img/';
+  $tbase = rtrim(signage_assets_path('media/img'), '/') . '/';
   if (!is_dir($tbase)) { @mkdir($tbase, 02775, true); @chown($tbase,'www-data'); @chgrp($tbase,'www-data'); }
   $tdest = $tbase . $torig;
   $tpi = pathinfo($tdest);


### PR DESCRIPTION
## Summary
- add a shared storage helper for resolving base paths and JSON read/write helpers
- update admin API endpoints to use the shared helpers instead of hard coded /var/www/signage paths and improve error handling
- streamline export/import/cleanup logic around assets by centralizing absolute/relative path handling

## Testing
- php -l webroot/admin/api/storage.php webroot/admin/api/devices_store.php webroot/admin/api/load.php webroot/admin/api/load_settings.php webroot/admin/api/save.php webroot/admin/api/export.php webroot/admin/api/import.php webroot/admin/api/cleanup_assets.php webroot/admin/api/upload.php webroot/admin/api/device_resolve.php

------
https://chatgpt.com/codex/tasks/task_e_68d425a553ac8320916736a1a9958540