### PR TITLE
Normalize device storage schema and tighten API validation

### DIFF
--- a/webroot/admin/api/device_resolve.php
+++ b/webroot/admin/api/device_resolve.php
@@ -33,14 +33,15 @@ function day_key() {
 
 // --- Input ------------------------------------------------------------------
 
-$devId = isset($_GET['device']) ? trim($_GET['device']) : '';
-if ($devId === '') {
+$rawDevice = $_GET['device'] ?? '';
+$rawDevice = is_string($rawDevice) ? trim($rawDevice) : '';
+$devId = devices_normalize_device_id($rawDevice);
+if ($rawDevice === '') {
   http_response_code(400);
   echo json_encode(['ok'=>false, 'error'=>'missing-device'], JSON_UNESCAPED_SLASHES);
   exit;
 }
-if (!preg_match('/^dev_[a-f0-9]{12}$/i', $devId)) {
-  // Schützt vor Karteileichen/Fehlformaten
+if ($devId === '') {
   http_response_code(400);
   echo json_encode(['ok'=>false, 'error'=>'invalid-device-format'], JSON_UNESCAPED_SLASHES);
   exit;

--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -25,28 +25,31 @@ foreach (($db['pairings'] ?? []) as $code => $row) {
 usort($pairings, fn($a,$b)=>($b['createdAt']??0)-($a['createdAt']??0));
 
 $devices = [];
-foreach (($db['devices'] ?? []) as $key => $d) {
-
-  $id = $key;
-  if (is_int($key) || (is_string($key) && ctype_digit($key))) {
-    $id = $d['id'] ?? (string)$key;
+foreach (($db['devices'] ?? []) as $id => $d) {
+  if (!is_array($d)) {
+    continue;
+  }
+  $deviceId = is_string($id) ? $id : ($d['id'] ?? '');
+  if (!devices_is_valid_id($deviceId)) {
+    continue;
   }
 
   $last = isset($d['lastSeenAt']) ? (int)$d['lastSeenAt'] : (int)($d['lastSeen'] ?? 0);
   $offline = !$last || ($now - $last) > OFFLINE_AFTER_MIN * 60;
 
+  $overrides = isset($d['overrides']) && is_array($d['overrides']) ? $d['overrides'] : [];
+
   $devices[] = [
-    'id' => $id,
-    'name' => $d['name'] ?? $id,
+    'id' => $deviceId,
+    'name' => isset($d['name']) && is_string($d['name']) ? $d['name'] : $deviceId,
     'lastSeenAt' => $last ?: null,
     'offline' => $offline,
     'useOverrides' => !empty($d['useOverrides']),
     'overrides' => [
-      'settings' => $d['overrides']['settings'] ?? (object)[],
-      'schedule' => $d['overrides']['schedule'] ?? (object)[]
+      'settings' => $overrides['settings'] ?? (object)[],
+      'schedule' => $overrides['schedule'] ?? (object)[]
     ]
   ];
-
 }
 
 echo json_encode([

--- a/webroot/admin/api/devices_rename.php
+++ b/webroot/admin/api/devices_rename.php
@@ -4,11 +4,16 @@ header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
 $body = json_decode(file_get_contents('php://input'), true) ?: [];
-$devIn = trim((string)($body['device'] ?? ''));
+$devIn = devices_normalize_device_id($body['device'] ?? '');
 $name  = trim((string)($body['name'] ?? ''));
 
-if ($devIn === '') {
+if (($body['device'] ?? '') === '') {
   echo json_encode(['ok'=>false, 'error'=>'missing-device']);
+  exit;
+}
+
+if ($devIn === '') {
+  echo json_encode(['ok'=>false, 'error'=>'invalid-device']);
   exit;
 }
 
@@ -18,22 +23,12 @@ if (!$db) {
   exit;
 }
 
-// exakte Übereinstimmung (neues Format) …
-$foundKey = isset($db['devices'][$devIn]) ? $devIn : null;
-// … oder Legacy: numerische Schlüssel als String ("0","1",…)
-if ($foundKey === null) {
-  $legacyKey = (string)intval($devIn);
-  if (isset($db['devices'][$legacyKey])) {
-    $foundKey = $legacyKey;
-  }
-}
-
-if ($foundKey === null) {
+if (!isset($db['devices'][$devIn])) {
   echo json_encode(['ok'=>false, 'error'=>'unknown-device']);
   exit;
 }
 
-$db['devices'][$foundKey]['name'] = $name;
+$db['devices'][$devIn]['name'] = $name;
 
 try {
   devices_save($db);
@@ -42,4 +37,4 @@ try {
   exit;
 }
 
-echo json_encode(['ok'=>true, 'device'=>$foundKey, 'name'=>$name]);
+echo json_encode(['ok'=>true, 'device'=>$devIn, 'name'=>$name]);

--- a/webroot/admin/api/devices_save_override.php
+++ b/webroot/admin/api/devices_save_override.php
@@ -8,7 +8,10 @@ $in  = json_decode($raw, true);
 if (!$in || !isset($in['device']) || !is_array($in['settings'])) {
   echo json_encode(['ok'=>false, 'error'=>'missing']); exit;
 }
-$devId = $in['device'];
+$devId = devices_normalize_device_id($in['device']);
+if ($devId === '') {
+  echo json_encode(['ok'=>false, 'error'=>'invalid-device']); exit;
+}
 $set   = $in['settings'];
 $sch   = isset($in['schedule']) && is_array($in['schedule']) ? $in['schedule'] : null;
 

--- a/webroot/admin/api/devices_set_mode.php
+++ b/webroot/admin/api/devices_set_mode.php
@@ -5,10 +5,16 @@ header('Cache-Control: no-store');
 
 $raw = file_get_contents('php://input');
 $in  = json_decode($raw, true);
-$devId = isset($in['device']) ? trim($in['device']) : '';
+$rawDevice = isset($in['device']) ? trim((string)$in['device']) : '';
+$devId = devices_normalize_device_id($rawDevice);
 $mode  = isset($in['mode']) ? trim($in['mode']) : '';
-if ($devId === '' || !in_array($mode, ['global','device'], true)) {
+if ($rawDevice === '' || !in_array($mode, ['global','device'], true)) {
   echo json_encode(['ok'=>false, 'error'=>'invalid']);
+  exit;
+}
+
+if ($devId === '') {
+  echo json_encode(['ok'=>false, 'error'=>'invalid-device']);
   exit;
 }
 

--- a/webroot/admin/api/devices_store.php
+++ b/webroot/admin/api/devices_store.php
@@ -3,64 +3,211 @@
 // Wird von Heartbeat- und Admin-APIs genutzt. Pfade werden zentral über
 // devices_path() bestimmt, um harte Pfadangaben zu vermeiden.
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/storage.php';
 
-function devices_path() {
-  $custom = getenv('DEVICES_PATH');
-  if (is_string($custom) && $custom !== '') return $custom;
-  if (!empty($_ENV['DEVICES_PATH'])) return $_ENV['DEVICES_PATH'];
-  return signage_data_path('devices.json');
+const DEVICES_ID_PATTERN = '/^dev_[a-f0-9]{12}$/';
+const DEVICES_CODE_PATTERN = '/^[A-Z]{6}$/';
+
+function devices_path(): string
+{
+    $custom = getenv('DEVICES_PATH');
+    if (is_string($custom) && $custom !== '') {
+        return $custom;
+    }
+    if (!empty($_ENV['DEVICES_PATH'])) {
+        return $_ENV['DEVICES_PATH'];
+    }
+    return signage_data_path('devices.json');
 }
 
-function devices_load(){
-  $p = devices_path();
-  if (!is_file($p)) return ['version'=>1,'pairings'=>[],'devices'=>[]];
-  $j = json_decode(@file_get_contents($p), true);
-  return is_array($j) ? $j : ['version'=>1,'pairings'=>[],'devices'=>[]];
+function devices_default_state(): array
+{
+    return [
+        'version' => 1,
+        'pairings' => [],
+        'devices' => [],
+    ];
 }
 
-function devices_save($db){
-  $p = devices_path();
-  @mkdir(dirname($p), 02775, true);
-  $json = json_encode($db, SIGNAGE_JSON_FLAGS);
-  $bytes = @file_put_contents($p, $json, LOCK_EX);
-  if ($bytes === false) {
-    throw new RuntimeException('Unable to write device database');
-  }
-  @chmod($p, 0644);
-  @chown($p,'www-data'); @chgrp($p,'www-data');
-  return true;
+function devices_normalize_device_id($value): string
+{
+    if (!is_string($value)) {
+        return '';
+    }
+    $id = strtolower(trim($value));
+    return preg_match(DEVICES_ID_PATTERN, $id) ? $id : '';
+}
+
+function devices_is_valid_id(string $id): bool
+{
+    return preg_match(DEVICES_ID_PATTERN, $id) === 1;
+}
+
+function devices_normalize_code($value): string
+{
+    if (!is_string($value)) {
+        return '';
+    }
+    $code = strtoupper(trim($value));
+    return preg_match(DEVICES_CODE_PATTERN, $code) ? $code : '';
+}
+
+function devices_normalize_state($state): array
+{
+    $normalized = devices_default_state();
+    if (!is_array($state)) {
+        return $normalized;
+    }
+
+    if (isset($state['version'])) {
+        $normalized['version'] = (int) $state['version'];
+    }
+
+    foreach ($state as $key => $value) {
+        if ($key === 'devices' || $key === 'pairings') {
+            continue;
+        }
+        $normalized[$key] = $value;
+    }
+
+    if (isset($state['pairings']) && is_array($state['pairings'])) {
+        foreach ($state['pairings'] as $code => $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $normalizedCode = devices_normalize_code($row['code'] ?? $code);
+            if ($normalizedCode === '') {
+                continue;
+            }
+            $entry = $row;
+            $entry['code'] = $normalizedCode;
+            $entry['created'] = isset($entry['created']) ? (int) $entry['created'] : time();
+            if (isset($entry['deviceId'])) {
+                $deviceId = devices_normalize_device_id($entry['deviceId']);
+                $entry['deviceId'] = $deviceId !== '' ? $deviceId : null;
+            }
+            $normalized['pairings'][$normalizedCode] = $entry;
+        }
+    }
+
+    if (isset($state['devices']) && is_array($state['devices'])) {
+        foreach ($state['devices'] as $key => $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $id = devices_normalize_device_id($row['id'] ?? $key);
+            if ($id === '') {
+                continue;
+            }
+            $device = $row;
+            $device['id'] = $id;
+            if (!isset($device['name']) || !is_string($device['name'])) {
+                $device['name'] = $id;
+            }
+            if (isset($device['created'])) {
+                $device['created'] = (int) $device['created'];
+            }
+            if (isset($device['lastSeen'])) {
+                $device['lastSeen'] = (int) $device['lastSeen'];
+            }
+            if (isset($device['lastSeenAt'])) {
+                $device['lastSeenAt'] = (int) $device['lastSeenAt'];
+            }
+            if (!isset($device['overrides']) || !is_array($device['overrides'])) {
+                $device['overrides'] = [];
+            }
+            $normalized['devices'][$id] = $device;
+        }
+    }
+
+    return $normalized;
+}
+
+function devices_load(): array
+{
+    $path = devices_path();
+    if (!is_file($path)) {
+        return devices_default_state();
+    }
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') {
+        return devices_default_state();
+    }
+    $decoded = json_decode($raw, true);
+    return devices_normalize_state($decoded);
+}
+
+function devices_save(array &$db): bool
+{
+    $db = devices_normalize_state($db);
+    $path = devices_path();
+    @mkdir(dirname($path), 02775, true);
+    $json = json_encode($db, SIGNAGE_JSON_FLAGS);
+    $bytes = @file_put_contents($path, $json, LOCK_EX);
+    if ($bytes === false) {
+        throw new RuntimeException('Unable to write device database');
+    }
+    @chmod($path, 0644);
+    @chown($path, 'www-data');
+    @chgrp($path, 'www-data');
+    return true;
+}
+
+function devices_touch_entry(array &$db, $id, ?int $timestamp = null): bool
+{
+    $normalizedId = devices_normalize_device_id($id);
+    if ($normalizedId === '' || !isset($db['devices'][$normalizedId]) || !is_array($db['devices'][$normalizedId])) {
+        return false;
+    }
+    $ts = $timestamp ?? time();
+    $db['devices'][$normalizedId]['lastSeen'] = $ts;
+    $db['devices'][$normalizedId]['lastSeenAt'] = $ts;
+    return true;
 }
 
 // Koppel-Code (AAAAAA) aus A–Z (ohne I/O) generieren; keine Speicherung hier
-function dev_gen_code($db){
-  $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
-  for ($i=0; $i<500; $i++) {
-    $code = '';
-    for ($j=0; $j<6; $j++) $code .= $alphabet[random_int(0, strlen($alphabet)-1)];
-    if (empty($db['pairings'][$code])) return $code;
-  }
-  return null;
+function dev_gen_code($db)
+{
+    $alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
+    for ($i = 0; $i < 500; $i++) {
+        $code = '';
+        for ($j = 0; $j < 6; $j++) {
+            $code .= $alphabet[random_int(0, strlen($alphabet) - 1)];
+        }
+        if (empty($db['pairings'][$code])) {
+            return $code;
+        }
+    }
+    return null;
 }
 
 // Geräte-ID im Format dev_ + 12 hex (Regex im Player erwartet exakt das)
-function dev_gen_id($db){
-  for ($i=0; $i<1000; $i++) {
-    $id = 'dev_'.bin2hex(random_bytes(6));
-    if (empty($db['devices'][$id])) return $id;
-  }
-  return null;
+function dev_gen_id($db)
+{
+    for ($i = 0; $i < 1000; $i++) {
+        $id = 'dev_' . bin2hex(random_bytes(6));
+        if (empty($db['devices'][$id])) {
+            return $id;
+        }
+    }
+    return null;
 }
 
 // Aufräumen: offene Pairings >15min löschen; verwaiste Links bereinigen
-function dev_gc(&$db){
-  $now = time();
-  foreach (($db['pairings'] ?? []) as $code => $p) {
-    $age = $now - (int)($p['created'] ?? $now);
-    if ($age > 900 && empty($p['deviceId'])) unset($db['pairings'][$code]);
-    // Referenz auf nicht-existentes Device? -> lösen
-    if (!empty($p['deviceId']) && empty($db['devices'][$p['deviceId']])) {
-      $db['pairings'][$code]['deviceId'] = null;
+function dev_gc(&$db)
+{
+    $db = devices_normalize_state($db);
+    $now = time();
+    foreach (($db['pairings'] ?? []) as $code => $p) {
+        $age = $now - (int) ($p['created'] ?? $now);
+        if ($age > 900 && empty($p['deviceId'])) {
+            unset($db['pairings'][$code]);
+        }
+        // Referenz auf nicht-existentes Device? -> lösen
+        if (!empty($p['deviceId']) && empty($db['devices'][$p['deviceId']])) {
+            $db['pairings'][$code]['deviceId'] = null;
+        }
     }
-  }
 }

--- a/webroot/admin/api/devices_touch.php
+++ b/webroot/admin/api/devices_touch.php
@@ -1,55 +1,37 @@
 <?php
 header('Content-Type: application/json; charset=UTF-8');
-require_once __DIR__.'/devices_store.php';
+require_once __DIR__ . '/devices_store.php';
 
 $raw = file_get_contents('php://input');
 $payload = json_decode($raw, true);
-if (!is_array($payload)) {
-  $payload = [];
-}
+$payload = is_array($payload) ? $payload : [];
 
-$id = $payload['device'] ?? ($_POST['device'] ?? ($_GET['device'] ?? ''));
-$id = is_string($id) ? trim($id) : '';
+$rawDevice = $payload['device'] ?? ($_POST['device'] ?? ($_GET['device'] ?? ''));
+$rawDevice = is_string($rawDevice) ? trim($rawDevice) : '';
+$deviceId = devices_normalize_device_id($rawDevice);
 
-if ($id === '') {
-  echo json_encode(['ok'=>false,'error'=>'no-device']);
+if ($rawDevice === '') {
+  echo json_encode(['ok' => false, 'error' => 'no-device']);
   exit;
 }
 
-if (!preg_match('/^dev_[a-f0-9]{12}$/i', $id)) {
-  echo json_encode(['ok'=>false,'error'=>'invalid-device']);
+if ($deviceId === '') {
+  echo json_encode(['ok' => false, 'error' => 'invalid-device']);
   exit;
 }
 
 $db = devices_load();
-$dev = null;
-if (isset($db['devices'][$id])) {
-  $dev =& $db['devices'][$id];
-} elseif (is_array($db['devices'] ?? null)) {
-  foreach ($db['devices'] as &$row) {
-    if (is_array($row) && ($row['id'] ?? null) === $id) {
-      $dev =& $row;
-      break;
-    }
-  }
-  unset($row);
-}
-
-if (!isset($dev)){
-  echo json_encode(['ok'=>false,'error'=>'unknown-device']);
+if (!devices_touch_entry($db, $deviceId)) {
+  echo json_encode(['ok' => false, 'error' => 'unknown-device']);
   exit;
 }
-
-$timestamp = time();
-$dev['lastSeen'] = $timestamp;
-$dev['lastSeenAt'] = $timestamp;
 
 try {
   devices_save($db);
 } catch (RuntimeException $e) {
   http_response_code(500);
   error_log('Failed to persist device touch: ' . $e->getMessage());
-  echo json_encode(['ok'=>false,'error'=>'storage-failed']);
+  echo json_encode(['ok' => false, 'error' => 'storage-failed']);
   exit;
 }
-echo json_encode(['ok'=>true]);
+echo json_encode(['ok' => true]);

--- a/webroot/admin/api/devices_unpair.php
+++ b/webroot/admin/api/devices_unpair.php
@@ -4,38 +4,33 @@ header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
 $body  = json_decode(file_get_contents('php://input'), true) ?: [];
-$didIn = trim((string)($body['device'] ?? ''));
+$rawId = $body['device'] ?? '';
+$rawId = is_string($rawId) ? trim($rawId) : '';
+$didIn = devices_normalize_device_id($rawId);
 $purge = !empty($body['purge']);
 
 $db = devices_load();
 if (!$db) { echo json_encode(['ok'=>false,'error'=>'load-failed']); exit; }
 
-$validNew = function($id){ return is_string($id) && preg_match('/^dev_[a-f0-9]{12}$/i', $id); };
-
-// exakte Übereinstimmung (neues Format) …
-$foundKey = isset($db['devices'][$didIn]) ? $didIn : null;
-
-// … oder Legacy: numerische Schlüssel als String ("0","1",…)
-if ($foundKey === null) {
-  $legacyKey = (string)intval($didIn);
-  if (isset($db['devices'][$legacyKey])) $foundKey = $legacyKey;
-}
-
-if ($foundKey === null) { echo json_encode(['ok'=>false,'error'=>'unknown-device']); exit; }
+if ($rawId === '') { echo json_encode(['ok'=>false,'error'=>'missing-device']); exit; }
+if ($didIn === '') { echo json_encode(['ok'=>false,'error'=>'invalid-device']); exit; }
+if (!isset($db['devices'][$didIn])) { echo json_encode(['ok'=>false,'error'=>'unknown-device']); exit; }
 
 // Pairings entkoppeln
 if (!empty($db['pairings'])) {
   foreach ($db['pairings'] as $code => &$row) {
-    if (($row['deviceId'] ?? null) === $foundKey) unset($row['deviceId']);
+    if (isset($row['deviceId']) && devices_normalize_device_id($row['deviceId']) === $didIn) {
+      unset($row['deviceId']);
+    }
   }
   unset($row);
 }
 
 // Purge: Gerätseintrag ganz weg, sonst nur Overrides löschen
-if ($purge) { unset($db['devices'][$foundKey]); }
+if ($purge) { unset($db['devices'][$didIn]); }
 else {
-  if (isset($db['devices'][$foundKey]['overrides'])) unset($db['devices'][$foundKey]['overrides']);
+  if (isset($db['devices'][$didIn]['overrides'])) unset($db['devices'][$didIn]['overrides']);
 }
 
 if (!devices_save($db)) { echo json_encode(['ok'=>false,'error'=>'save-failed']); exit; }
-echo json_encode(['ok'=>true,'device'=>$foundKey,'removed'=>$purge?1:0]);
+echo json_encode(['ok'=>true,'device'=>$didIn,'removed'=>$purge?1:0]);

--- a/webroot/api/heartbeat.php
+++ b/webroot/api/heartbeat.php
@@ -5,47 +5,28 @@ require_once __DIR__ . '/../admin/api/devices_store.php';
 
 $raw = file_get_contents('php://input');
 $payload = json_decode($raw, true);
-if (!is_array($payload)) {
-  $payload = [];
-}
-$id = $payload['device'] ?? ($_POST['device'] ?? ($_GET['device'] ?? ''));
-$id = is_string($id) ? trim($id) : '';
+$payload = is_array($payload) ? $payload : [];
+$deviceId = $payload['device'] ?? ($_POST['device'] ?? ($_GET['device'] ?? ''));
+$deviceId = devices_normalize_device_id($deviceId);
 
-if (!preg_match('/^dev_[a-f0-9]{12}$/i', $id)) {
-  echo json_encode(['ok'=>false, 'error'=>'invalid-device']);
+if ($deviceId === '') {
+  echo json_encode(['ok' => false, 'error' => 'invalid-device']);
   exit;
 }
 
 $db = devices_load();
-$dev = null;
-if (isset($db['devices'][$id])) {
-  $dev =& $db['devices'][$id];
-} elseif (is_array($db['devices'] ?? null)) {
-  foreach ($db['devices'] as &$row) {
-    if (is_array($row) && ($row['id'] ?? null) === $id) {
-      $dev =& $row;
-      break;
-    }
-  }
-  unset($row);
-}
-
-if (!isset($dev)) {
-  echo json_encode(['ok'=>false, 'error'=>'unknown-device']);
+if (!devices_touch_entry($db, $deviceId)) {
+  echo json_encode(['ok' => false, 'error' => 'unknown-device']);
   exit;
 }
-
-$timestamp = time();
-$dev['lastSeen'] = $timestamp;
-$dev['lastSeenAt'] = $timestamp;
 
 try {
   devices_save($db);
 } catch (RuntimeException $e) {
   http_response_code(500);
   error_log('Failed to persist device heartbeat: ' . $e->getMessage());
-  echo json_encode(['ok'=>false, 'error'=>'storage-failed']);
+  echo json_encode(['ok' => false, 'error' => 'storage-failed']);
   exit;
 }
 
-echo json_encode(['ok'=>true]);
+echo json_encode(['ok' => true]);


### PR DESCRIPTION
## Summary
- normalize the device database schema with shared sanitizers and helpers in `devices_store.php`
- update device management endpoints to rely on the normalized data and provide stricter validation
- simplify device listing and status endpoints by removing legacy fallbacks and using the shared helpers

## Testing
- `php -l webroot/admin/api/device_resolve.php webroot/admin/api/devices_list.php webroot/admin/api/devices_rename.php webroot/admin/api/devices_save_override.php webroot/admin/api/devices_set_mode.php webroot/admin/api/devices_store.php webroot/admin/api/devices_touch.php webroot/admin/api/devices_unpair.php webroot/api/heartbeat.php`


------
https://chatgpt.com/codex/tasks/task_e_68d42c5c86348320a781cd541dbbcda6