### PR TITLE
Fix resize handler illegal invocation

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -519,12 +519,12 @@ async function loadDeviceResolved(id){
     };
     updateVwScale();
 
-    const requestFrame = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame
+    const requestFrame = typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
       : (cb) => setTimeout(cb, 16);
-    const cancelFrame = typeof cancelAnimationFrame === 'function'
-      ? cancelAnimationFrame
-      : clearTimeout;
+    const cancelFrame = typeof window.cancelAnimationFrame === 'function'
+      ? window.cancelAnimationFrame.bind(window)
+      : (id) => clearTimeout(id);
     displayListeners.cancelFrame = cancelFrame;
 
     const onResize = () => {


### PR DESCRIPTION
## Summary
- bind the stored requestAnimationFrame/cancelAnimationFrame helpers to window to preserve their context
- fall back to a timeout wrapper to ensure cancelFrame remains a function when animations are unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4dd9d08dc8320bbfee5a3b818637e