### PR TITLE
Refine stage controller playback flow

### DIFF
--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -3550,19 +3550,36 @@ function renderStorySlide(story = {}, region = 'left') {
       updateActiveState();
     }
 
-    function step(){
+    function showFallback(){
+      show(renderStageFallback(id));
+      updateActiveState();
+    }
+
+    function guardPlayback(onEmpty = showFallback){
       clearTimers();
       if (!config.enabled) {
         clear();
-        return;
+        return false;
       }
       if (!queue.length) {
-        show(renderStageFallback(id));
-        updateActiveState();
-        return;
+        if (typeof onEmpty === 'function') onEmpty();
+        return false;
       }
+      return true;
+    }
+
+    function normalizeIndex(){
+      if (!queue.length) return;
       if (index < 0 || index >= queue.length) {
         index = ((index % queue.length) + queue.length) % queue.length;
+      }
+    }
+
+    function displayCurrent(){
+      normalizeIndex();
+      if (!queue.length) {
+        showFallback();
+        return;
       }
       let item = queue[index];
       let key = slideKey(item);
@@ -3590,34 +3607,16 @@ function renderStorySlide(story = {}, region = 'left') {
     }
 
     function advance(){
-      clearTimers();
-      if (!config.enabled) {
-        clear();
-        return;
-      }
-      if (!queue.length) {
-        show(renderStageFallback(id));
-        updateActiveState();
-        return;
-      }
+      if (!guardPlayback()) return;
       hide(() => {
         index = (index + 1) % queue.length;
-        step();
+        displayCurrent();
       });
     }
 
     function play(){
-      clearTimers();
-      if (!config.enabled) {
-        clear();
-        return;
-      }
-      if (!queue.length) {
-        show(renderStageFallback(id));
-        updateActiveState();
-        return;
-      }
-      step();
+      if (!guardPlayback()) return;
+      displayCurrent();
     }
 
     function clear(){


### PR DESCRIPTION
## Summary
- introduce reusable playback guards in the stage controller to centralize queue checks and fallback handling
- normalize slide index management and reuse the rendering logic for play and advance flows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d57e4955e483208868337474657c6f