### PR TITLE
Add extras modules, layout profiles, and offline caching

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -381,6 +381,28 @@ body.devices-pinned #devicesPane{ position:sticky; top:0; z-index:40; }
 .settings-card-body .kv{ margin-bottom:0; }
 .settings-card-body .help{ margin:0; }
 .settings-card-body .fieldset{ margin:6px 0; }
+.settings-card-body .divider{ height:1px; background:color-mix(in srgb, var(--border) 85%, transparent); margin:4px 0; border-radius:1px; }
+.style-auto-list{ display:flex; flex-direction:column; gap:8px; }
+.style-auto-slot{ display:grid; grid-template-columns:minmax(0,120px) minmax(0,150px) minmax(0,1fr) auto; gap:8px; align-items:center; padding:10px 12px; border:1px solid color-mix(in srgb, var(--border) 85%, var(--fg) 5%); border-radius:12px; background:color-mix(in srgb, var(--panel) 92%, var(--fg) 4%); }
+.style-auto-slot label{ font-size:12px; font-weight:600; color:var(--muted); }
+.style-auto-slot .style-auto-field{ display:flex; flex-direction:column; gap:4px; }
+.style-auto-slot button{ align-self:flex-start; }
+.style-auto-actions{ justify-content:flex-start; }
+#styleAutoEventBox{ gap:10px; background:color-mix(in srgb, var(--panel) 96%, var(--fg) 4%); border:1px dashed color-mix(in srgb, var(--border) 70%, var(--fg) 8%); }
+.extras-card-body{ display:flex; flex-direction:column; gap:14px; }
+.extras-group{ display:flex; flex-direction:column; gap:10px; padding:12px; border:1px dashed color-mix(in srgb, var(--border) 70%, var(--fg) 6%); border-radius:14px; background:color-mix(in srgb, var(--panel) 94%, var(--fg) 3%); }
+.extras-group-head{ display:flex; align-items:center; justify-content:space-between; gap:10px; }
+.extras-group-title{ font-weight:700; font-size:13px; letter-spacing:.01em; }
+.extras-group-list{ display:flex; flex-direction:column; gap:10px; }
+.extras-item{ border:1px solid color-mix(in srgb, var(--border) 80%, var(--fg) 6%); border-radius:12px; background:color-mix(in srgb, var(--panel) 96%, var(--fg) 2%); padding:10px 12px; display:flex; flex-direction:column; gap:10px; }
+.extras-item-header{ display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
+.extras-item-header .input{ flex:1 1 160px; min-width:120px; }
+.extras-item-body{ display:flex; flex-direction:column; gap:8px; }
+.extras-item textarea{ min-height:72px; resize:vertical; }
+.extras-item-actions{ display:flex; justify-content:flex-end; }
+.extras-inline{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+.extras-inline .input{ flex:1 1 160px; min-width:120px; }
+.extras-item small.help{ color:var(--muted); font-size:12px; }
 .content > details.ac.sub{ margin-top:12px; }
 .card .content, .content{ padding:12px 14px; }
 summary{
@@ -912,9 +934,16 @@ body.device-mode #devPairedList tr.selected{
   #devPairedList td{ flex:0 1 auto; }
   #devPairedList td:first-child{ flex:1 1 220px; font-weight:700; min-width:180px; }
   #devPairedList td.status{ margin-left:auto; font-weight:700; }
-  #devPairedList td.status.offline,
-  #devPairedList td.status.online{ order:99; flex-basis:100%; margin-left:0; }
-  #devPairedList td.status small{ display:block; }
+#devPairedList td.status.offline,
+#devPairedList td.status.online{ order:99; flex-basis:100%; margin-left:0; }
+#devPairedList td.status small{ display:block; }
+#devPairedList .dev-heartbeat{ display:inline-flex; align-items:center; gap:6px; font-weight:600; }
+#devPairedList .dev-heartbeat .dev-heartbeat-dot{ width:10px; height:10px; border-radius:50%; box-shadow:0 0 0 2px rgba(0,0,0,.08); }
+#devPairedList .dev-heartbeat[data-state="ok"] .dev-heartbeat-dot{ background:#10B981; box-shadow:0 0 0 3px rgba(16,185,129,.22); }
+#devPairedList .dev-heartbeat[data-state="warn"] .dev-heartbeat-dot{ background:#F59E0B; box-shadow:0 0 0 3px rgba(245,158,11,.26); }
+#devPairedList .dev-heartbeat[data-state="crit"] .dev-heartbeat-dot{ background:#EF4444; box-shadow:0 0 0 3px rgba(239,68,68,.26); }
+#devPairedList .dev-heartbeat[data-state="unknown"] .dev-heartbeat-dot{ background:#9CA3AF; box-shadow:0 0 0 3px rgba(156,163,175,.22); }
+#devPairedList .dev-heartbeat time{ font-size:12px; font-weight:500; color:var(--muted); }
   #devPairedList tr.ind{ border-left:none; border-inline-start:4px solid var(--btn-accent); padding-left:8px; }
   body.device-mode #devPairedList tr.ind{ border-inline-start-color:var(--btn-primary); }
   #devPairedList tr.selected{ outline-offset:2px; }

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -141,6 +141,66 @@
             <input id="presetAuto" type="checkbox">
           </div>
           <div class="help">Wenn aktiv, wird beim Öffnen und beim Wechsel des Tabs automatisch das Preset des aktuellen Wochentags geladen (falls vorhanden).</div>
+          <div class="divider"></div>
+          <div class="kv">
+            <label>Style-Automation aktiv</label>
+            <input id="styleAutoEnabled" type="checkbox">
+          </div>
+          <div class="kv">
+            <label>Fallback-Stil</label>
+            <select id="styleAutoFallback" class="input"></select>
+          </div>
+          <div class="style-auto-list" id="styleAutoList"></div>
+          <div class="row style-auto-actions">
+            <button class="btn sm" id="styleAutoAdd">Zeitfenster hinzufügen</button>
+          </div>
+          <div class="fieldset" id="styleAutoEventBox">
+            <div class="legend">Event-Trigger</div>
+            <div class="kv">
+              <label>Aktiv</label>
+              <input id="styleEventEnabled" type="checkbox">
+            </div>
+            <div class="kv">
+              <label>Vorwarnzeit (Minuten)</label>
+              <input id="styleEventLookahead" class="input num3" type="number" min="5" max="360" step="5">
+            </div>
+            <div class="kv">
+              <label>Style für Events</label>
+              <select id="styleEventStyle" class="input"></select>
+            </div>
+            <div class="help">Liegt ein Countdown-Event innerhalb des Vorwarnfensters, wird automatisch dieser Stil aktiviert.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-card" id="extraContentCard">
+        <div class="settings-card-head">
+          <div class="settings-card-title">Zusatzinhalte</div>
+          <p class="settings-card-description">Pflege Wellness-Tipps, Event-Countdowns und Gastronomiehinweise für linke oder rechte Bildschirmhälfte.</p>
+        </div>
+        <div class="settings-card-body extras-card-body">
+          <div class="extras-group" id="extrasWellness">
+            <div class="extras-group-head">
+              <div class="extras-group-title">Wellness-Tipps</div>
+              <button class="btn sm" id="extrasWellnessAdd">Tipp hinzufügen</button>
+            </div>
+            <div class="extras-group-list" id="extrasWellnessList"></div>
+          </div>
+          <div class="extras-group" id="extrasEvents">
+            <div class="extras-group-head">
+              <div class="extras-group-title">Event-Countdowns</div>
+              <button class="btn sm" id="extrasEventAdd">Event hinzufügen</button>
+            </div>
+            <div class="extras-group-list" id="extrasEventList"></div>
+            <div class="help">Datums- und Zeitangabe im lokalen Format, z.&nbsp;B. 2024-12-24T20:00.</div>
+          </div>
+          <div class="extras-group" id="extrasGastro">
+            <div class="extras-group-head">
+              <div class="extras-group-title">Gastronomie-Highlights</div>
+              <button class="btn sm" id="extrasGastroAdd">Highlight hinzufügen</button>
+            </div>
+            <div class="extras-group-list" id="extrasGastroList"></div>
+          </div>
         </div>
       </div>
 
@@ -324,6 +384,16 @@
                   <select id="layoutMode" class="input">
                     <option value="single">Einspaltig</option>
                     <option value="split">Zweispaltig</option>
+                  </select>
+                </div>
+                <div class="kv">
+                  <label>Layout-Profil</label>
+                  <select id="layoutProfile" class="input">
+                    <option value="landscape">Standard (16:9)</option>
+                    <option value="portrait">Portrait – Einzel</option>
+                    <option value="portrait-split">Portrait – geteilte Bereiche</option>
+                    <option value="triple">Triple-Column</option>
+                    <option value="asymmetric">Asymmetrisch</option>
                   </select>
                 </div>
                 <div class="layout-display-columns">

--- a/webroot/admin/js/core/defaults.js
+++ b/webroot/admin/js/core/defaults.js
@@ -105,6 +105,126 @@ const DEFAULT_STYLE_SETS = {
       tileFlameGapScale:1,
       saunaTitleMaxWidthPercent:100
     }
+  },
+  sunset:{
+    label:'Sunset Glow',
+    theme:{
+      bg:'#2B1A3F', fg:'#FFE7D9', accent:'#FF914D',
+      gridBorder:'#3D2556',
+      gridTable:'#3D2556', gridTableW:2,
+      cellBg:'#3F285B', boxFg:'#FFE7D9',
+      headRowBg:'#341F4B', headRowFg:'#FFE7D9',
+      timeColBg:'#2F1C46', timeZebra1:'#3B2555', timeZebra2:'#27163B',
+      zebra1:'#462C63', zebra2:'#2E1A42',
+      cornerBg:'#2F1C46', cornerFg:'#FFE7D9',
+      tileBorder:'#FF914D', tileBorderW:3,
+      chipBorder:'#FF914D', chipBorderW:2,
+      flame:'#FFB347',
+      saunaColor:'#FF914D'
+    },
+    fonts:{
+      family:"'Poppins', 'Montserrat', system-ui, sans-serif",
+      tileTextScale:0.84,
+      tileWeight:600,
+      chipHeight:1.05,
+      tileMetaScale:DEFAULT_FONTS.tileMetaScale,
+      overviewTimeWidthCh:DEFAULT_FONTS.overviewTimeWidthCh,
+      overviewShowFlames:true,
+      chipOverflowMode:'scale',
+      flamePct:58,
+      flameGapScale:0.15
+    },
+    slides:{
+      infobadgeColor:'#FF914D',
+      badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
+      badgeScale:1,
+      badgeDescriptionScale:1,
+      tilePaddingScale:0.78,
+      customBadgeEmojis:[],
+      tileFlameSizeScale:1.05,
+      tileFlameGapScale:1,
+      saunaTitleMaxWidthPercent:100
+    }
+  },
+  midnight:{
+    label:'Midnight Calm',
+    theme:{
+      bg:'#050913', fg:'#E6F1FF', accent:'#4F7BFF',
+      gridBorder:'#0F1A33',
+      gridTable:'#101B37', gridTableW:2,
+      cellBg:'#0E172C', boxFg:'#E6F1FF',
+      headRowBg:'#0B1324', headRowFg:'#E6F1FF',
+      timeColBg:'#0B1324', timeZebra1:'#101A31', timeZebra2:'#09101F',
+      zebra1:'#0F1B33', zebra2:'#091327',
+      cornerBg:'#0B1324', cornerFg:'#E6F1FF',
+      tileBorder:'#4F7BFF', tileBorderW:3,
+      chipBorder:'#4F7BFF', chipBorderW:2,
+      flame:'#7CB8FF',
+      saunaColor:'#4F7BFF'
+    },
+    fonts:{
+      family:"'IBM Plex Sans', system-ui, sans-serif",
+      tileTextScale:0.88,
+      tileWeight:500,
+      chipHeight:1,
+      tileMetaScale:0.95,
+      overviewTimeWidthCh:DEFAULT_FONTS.overviewTimeWidthCh,
+      overviewShowFlames:false,
+      chipOverflowMode:'scale',
+      flamePct:64,
+      flameGapScale:0.18
+    },
+    slides:{
+      infobadgeColor:'#4F7BFF',
+      badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
+      badgeScale:1,
+      badgeDescriptionScale:1,
+      tilePaddingScale:0.72,
+      customBadgeEmojis:[],
+      tileFlameSizeScale:0.92,
+      tileFlameGapScale:1,
+      saunaTitleMaxWidthPercent:90
+    }
+  },
+  celebration:{
+    label:'Event Highlight',
+    theme:{
+      bg:'#1A1A1A', fg:'#FDF6E3', accent:'#FFCD3C',
+      gridBorder:'#2A2A2A',
+      gridTable:'#2A2A2A', gridTableW:3,
+      cellBg:'#222222', boxFg:'#FDF6E3',
+      headRowBg:'#101010', headRowFg:'#FFCD3C',
+      timeColBg:'#101010', timeZebra1:'#1C1C1C', timeZebra2:'#121212',
+      zebra1:'#252525', zebra2:'#1B1B1B',
+      cornerBg:'#101010', cornerFg:'#FFCD3C',
+      tileBorder:'#FFCD3C', tileBorderW:4,
+      chipBorder:'#FFCD3C', chipBorderW:3,
+      flame:'#FF6B3C',
+      saunaColor:'#FFCD3C'
+    },
+    fonts:{
+      family:"'Source Sans Pro', system-ui, sans-serif",
+      tileTextScale:0.9,
+      tileWeight:700,
+      chipHeight:1.12,
+      tileMetaScale:1,
+      overviewTimeWidthCh:11,
+      overviewShowFlames:true,
+      chipOverflowMode:'scroll',
+      flamePct:70,
+      flameGapScale:0.2
+    },
+    slides:{
+      infobadgeColor:'#FFCD3C',
+      badgeLibrary: JSON.parse(JSON.stringify(DEFAULT_BADGE_LIBRARY)),
+      badgeScale:1.05,
+      badgeDescriptionScale:1.05,
+      tilePaddingScale:0.82,
+      customBadgeEmojis:['🎉','✨','🎶'],
+      tileFlameSizeScale:1.1,
+      tileFlameGapScale:1.05,
+      saunaTitleMaxWidthPercent:100
+    }
   }
 };
 
@@ -137,7 +257,21 @@ export const DEFAULTS = {
     heroTimelineMaxEntries:null,
     enabledComponents:{ ...DEFAULT_ENABLED_COMPONENTS },
     styleSets:{ ...DEFAULT_STYLE_SETS },
-    activeStyleSet:'classic'
+    activeStyleSet:'classic',
+    styleAutomation:{
+      enabled:true,
+      fallbackStyle:'classic',
+      timeSlots:[
+        { id:'morning', label:'Vormittag', start:'06:00', style:'classic' },
+        { id:'evening', label:'Abend', start:'18:00', style:'sunset' },
+        { id:'night', label:'Nacht', start:'21:30', style:'midnight' }
+      ],
+      eventStyle:{
+        enabled:true,
+        lookaheadMinutes:90,
+        style:'celebration'
+      }
+    }
   },
   display:{
     fit:'auto',
@@ -147,17 +281,18 @@ export const DEFAULTS = {
     cutTopPercent:28,
     cutBottomPercent:12,
     layoutMode:'single',
+    layoutProfile:'landscape',
     pages:{
       left:{
         source:'master',
         timerSec:null,
-        contentTypes:['overview','sauna','hero-timeline','story','image','video','url'],
+        contentTypes:['overview','sauna','hero-timeline','story','wellness-tip','event-countdown','gastronomy-highlight','image','video','url'],
         playlist:[]
       },
       right:{
         source:'media',
         timerSec:null,
-        contentTypes:['image','video','url'],
+        contentTypes:['wellness-tip','event-countdown','gastronomy-highlight','image','video','url'],
         playlist:[]
       }
     }
@@ -167,7 +302,19 @@ export const DEFAULTS = {
   fonts:{ ...DEFAULT_FONTS },
   h2:{ mode:'text', text:'Aufgusszeiten', showOnOverview:true },
   assets:{ flameImage:'/assets/img/flame_test.svg' },
-  footnotes:[ { id:'star', label:'*', text:'Nur am Fr und Sa' } ]
+  footnotes:[ { id:'star', label:'*', text:'Nur am Fr und Sa' } ],
+  extras:{
+    wellnessTips:[
+      { id:'wellness_hydrate', icon:'💧', title:'Hydration', text:'Vor und nach dem Saunagang ausreichend Wasser trinken.' },
+      { id:'wellness_cooldown', icon:'❄️', title:'Abkühlen', text:'Zwischen den Gängen an die frische Luft gehen und kalt abduschen.' }
+    ],
+    eventCountdowns:[
+      { id:'event_moonlight', title:'Moonlight-Special', subtitle:'Heute Abend', target:'2024-12-24T20:00:00+01:00' }
+    ],
+    gastronomyHighlights:[
+      { id:'bar_vital', title:'Vital-Bar', description:'Hausgemachtes Ingwerwasser und frische Obstspieße im Ruhebereich.' }
+    ]
+  }
 };
 
 // Wochentage + Labels (+ „Opt“ als manueller Tag)

--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -108,6 +108,25 @@ body[data-layout='split'] .stage-area{display:flex}
 body[data-layout='single'] .stage{gap:0;}
 body[data-layout='single'] #stage-right{display:none;}
 
+body[data-layout-profile='portrait'] .stage,
+body[data-layout-profile='portrait-split'] .stage{flex-direction:column; align-items:stretch;}
+body[data-layout-profile='portrait'] .stage-area,
+body[data-layout-profile='portrait-split'] .stage-area{flex:1 1 auto; height:auto; min-height:0;}
+body[data-layout-profile='portrait-split'][data-layout='split'] #stage-left{flex:0 0 58%;}
+body[data-layout-profile='portrait-split'][data-layout='split'] #stage-right{flex:0 0 42%;}
+
+body[data-layout-profile='triple'] .stage,
+body[data-layout-profile='asymmetric'] .stage{display:grid; grid-auto-flow:column; align-items:stretch;}
+body[data-layout-profile='triple'] .stage{grid-template-columns:minmax(0,1.35fr) minmax(0,1fr) minmax(0,1fr);}
+body[data-layout-profile='triple'] #stage-left{grid-column:1 / span 2;}
+body[data-layout-profile='triple'] #stage-right{grid-column:3 / span 1;}
+body[data-layout='single'][data-layout-profile='triple'] #stage-left{grid-column:1 / -1;}
+
+body[data-layout-profile='asymmetric'] .stage{grid-template-columns:minmax(0,1.65fr) minmax(0,1fr);}
+body[data-layout-profile='asymmetric'] #stage-left{grid-column:1;}
+body[data-layout-profile='asymmetric'] #stage-right{grid-column:2;}
+body[data-layout='single'][data-layout-profile='asymmetric'] #stage-left{grid-column:1 / -1;}
+
 .fade{opacity:0;transition:opacity .5s}
 .fade.show{opacity:1}
 
@@ -134,6 +153,23 @@ body[data-layout='single'] #stage-right{display:none;}
 .container{position:relative; height:100%; padding:calc(32px*var(--vwScale)); display:flex; flex-direction:column; align-items:flex-start}
 .container.has-right{padding-right:calc(var(--rightW) + 32px)}
 .container.overview{padding-right:32px}
+.container.extra{background:var(--cell); color:var(--boxfg); border-radius:calc(28px*var(--vwScale)); box-shadow:0 28px 60px rgba(0,0,0,.32); padding:calc(40px*var(--vwScale)); gap:calc(20px*var(--vwScale));}
+.container.extra .brand{margin-top:auto; opacity:.55; font-size:calc(18px*var(--scale));}
+.extra-eyebrow{text-transform:uppercase; font-weight:700; letter-spacing:.24em; font-size:calc(18px*var(--scale)); opacity:.7; margin-bottom:calc(16px*var(--vwScale));}
+.extra-content{display:flex; flex-direction:row; align-items:flex-start; gap:calc(24px*var(--vwScale)); width:100%;}
+.extra-icon{font-size:calc(88px*var(--scale)); line-height:1; filter:drop-shadow(0 12px 24px rgba(0,0,0,.35));}
+.extra-body-wrap{display:flex; flex-direction:column; gap:calc(16px*var(--vwScale)); max-width:min(100%, 960px);}
+.extra-title{margin:0; font-size:calc(54px*var(--scale)); line-height:1.1; font-weight:800; letter-spacing:.01em;}
+.extra-text,.extra-textline{margin:0; font-size:calc(24px*var(--scale)); line-height:1.45; opacity:.9;}
+.extra-list{margin:0; padding-left:1.4em; display:flex; flex-direction:column; gap:calc(8px*var(--vwScale)); font-size:calc(24px*var(--scale));}
+.extra-list li{margin:0;}
+.extra-content.extra-countdown{align-items:flex-start;}
+.extra-countdown-display{display:flex; flex-direction:column; gap:calc(8px*var(--vwScale)); margin-top:calc(12px*var(--vwScale));}
+.extra-countdown-value{font-size:calc(72px*var(--scale)); font-weight:800; letter-spacing:.02em;}
+.extra-countdown-label{font-size:calc(24px*var(--scale)); opacity:.75;}
+.extra-event.is-live .extra-countdown-value{color:var(--accent);}
+.extra-event.is-soon:not(.is-live) .extra-countdown-value{color:color-mix(in srgb, var(--accent) 70%, #fff 30%);}
+
 .headings{width:100%;}
 .container.has-right .headings{
   max-width:min(

--- a/webroot/assets/responsive.css
+++ b/webroot/assets/responsive.css
@@ -12,6 +12,17 @@
     flex-direction:column;
     gap:calc(12px*var(--vwScale));
   }
+  body[data-layout-profile='triple'] .stage,
+  body[data-layout-profile='asymmetric'] .stage{
+    display:flex;
+    flex-direction:column;
+  }
+  body[data-layout-profile='triple'] .stage-area,
+  body[data-layout-profile='asymmetric'] .stage-area{flex:1 1 auto; min-height:0;}
+  .container.extra{padding:calc(32px*var(--vwScale));}
+  .container.extra .extra-content{flex-direction:column; gap:calc(18px*var(--vwScale));}
+  .extra-icon{font-size:calc(68px*var(--scale));}
+  .extra-title{font-size:calc(46px*var(--scale));}
 }
 
 @media (max-width: 600px) {
@@ -25,4 +36,7 @@
   body[data-layout='split'] .stage{
     gap:calc(10px*var(--vwScale));
   }
+  .container.extra{padding:calc(28px*var(--vwScale));}
+  .extra-title{font-size:calc(40px*var(--scale));}
+  .extra-countdown-value{font-size:calc(60px*var(--scale));}
 }

--- a/webroot/data/settings.json
+++ b/webroot/data/settings.json
@@ -15,7 +15,7 @@
   },
   "fonts": {
     "family": "-apple-system, Segoe UI, Roboto, Arial, Noto Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-    "scale": 1.00,
+    "scale": 1.0,
     "flameGapScale": 0.14
   },
   "display": {
@@ -27,14 +27,33 @@
       "left": {
         "source": "master",
         "timerSec": null,
-        "contentTypes": ["overview", "sauna", "hero-timeline", "story", "image", "video", "url"]
+        "contentTypes": [
+          "overview",
+          "sauna",
+          "hero-timeline",
+          "story",
+          "image",
+          "video",
+          "url",
+          "wellness-tip",
+          "event-countdown",
+          "gastronomy-highlight"
+        ]
       },
       "right": {
         "source": "media",
         "timerSec": null,
-        "contentTypes": ["image", "video", "url"]
+        "contentTypes": [
+          "image",
+          "video",
+          "url",
+          "wellness-tip",
+          "event-countdown",
+          "gastronomy-highlight"
+        ]
       }
-    }
+    },
+    "layoutProfile": "landscape"
   },
   "slides": {
     "overviewDurationSec": 10,
@@ -45,13 +64,32 @@
     "tileMaxScale": 0.57,
     "infobadgeColor": "#5C3101",
     "badgeLibrary": [
-      { "id": "bdg_classic", "icon": "🌿", "label": "Klassisch" },
-      { "id": "bdg_event", "icon": "⭐", "label": "Event" },
-      { "id": "bdg_ritual", "icon": "🔥", "label": "Ritual" }
+      {
+        "id": "bdg_classic",
+        "icon": "🌿",
+        "label": "Klassisch"
+      },
+      {
+        "id": "bdg_event",
+        "icon": "⭐",
+        "label": "Event"
+      },
+      {
+        "id": "bdg_ritual",
+        "icon": "🔥",
+        "label": "Ritual"
+      }
     ],
     "loop": true,
     "waitForVideo": false,
-    "order": ["overview","Aufgusssauna","Finnische Sauna","Kelosauna","Dampfbad","Fenster zur Welt"],
+    "order": [
+      "overview",
+      "Aufgusssauna",
+      "Finnische Sauna",
+      "Kelosauna",
+      "Dampfbad",
+      "Fenster zur Welt"
+    ],
     "enabledComponents": {
       "title": true,
       "description": true,
@@ -98,9 +136,21 @@
         "slides": {
           "infobadgeColor": "#5C3101",
           "badgeLibrary": [
-            { "id": "bdg_classic", "icon": "🌿", "label": "Klassisch" },
-            { "id": "bdg_event", "icon": "⭐", "label": "Event" },
-            { "id": "bdg_ritual", "icon": "🔥", "label": "Ritual" }
+            {
+              "id": "bdg_classic",
+              "icon": "🌿",
+              "label": "Klassisch"
+            },
+            {
+              "id": "bdg_event",
+              "icon": "⭐",
+              "label": "Event"
+            },
+            {
+              "id": "bdg_ritual",
+              "icon": "🔥",
+              "label": "Ritual"
+            }
           ]
         }
       },
@@ -143,14 +193,248 @@
         "slides": {
           "infobadgeColor": "#4EA8DE",
           "badgeLibrary": [
-            { "id": "bdg_classic", "icon": "🌿", "label": "Klassisch" },
-            { "id": "bdg_event", "icon": "⭐", "label": "Event" },
-            { "id": "bdg_ritual", "icon": "🔥", "label": "Ritual" }
+            {
+              "id": "bdg_classic",
+              "icon": "🌿",
+              "label": "Klassisch"
+            },
+            {
+              "id": "bdg_event",
+              "icon": "⭐",
+              "label": "Event"
+            },
+            {
+              "id": "bdg_ritual",
+              "icon": "🔥",
+              "label": "Ritual"
+            }
           ]
+        }
+      },
+      "sunset": {
+        "label": "Sunset Glow",
+        "theme": {
+          "bg": "#2B1A3F",
+          "fg": "#FFE7D9",
+          "accent": "#FF914D",
+          "gridBorder": "#3D2556",
+          "gridTable": "#3D2556",
+          "gridTableW": 2,
+          "cellBg": "#3F285B",
+          "boxFg": "#FFE7D9",
+          "headRowBg": "#341F4B",
+          "headRowFg": "#FFE7D9",
+          "timeColBg": "#2F1C46",
+          "timeZebra1": "#3B2555",
+          "timeZebra2": "#27163B",
+          "zebra1": "#462C63",
+          "zebra2": "#2E1A42",
+          "cornerBg": "#2F1C46",
+          "cornerFg": "#FFE7D9",
+          "tileBorder": "#FF914D",
+          "tileBorderW": 3,
+          "chipBorder": "#FF914D",
+          "chipBorderW": 2,
+          "flame": "#FFB347",
+          "saunaColor": "#FF914D"
+        },
+        "fonts": {
+          "family": "'Poppins', 'Montserrat', system-ui, sans-serif",
+          "tileTextScale": 0.84,
+          "tileWeight": 600,
+          "chipHeight": 1.05,
+          "overviewTimeWidthCh": 10,
+          "overviewShowFlames": true,
+          "chipOverflowMode": "scale",
+          "flamePct": 58,
+          "flameGapScale": 0.15
+        },
+        "slides": {
+          "infobadgeColor": "#FF914D",
+          "badgeLibrary": [
+            {
+              "id": "bdg_classic",
+              "icon": "🌿",
+              "label": "Klassisch"
+            },
+            {
+              "id": "bdg_event",
+              "icon": "⭐",
+              "label": "Event"
+            },
+            {
+              "id": "bdg_ritual",
+              "icon": "🔥",
+              "label": "Ritual"
+            }
+          ],
+          "badgeScale": 1,
+          "badgeDescriptionScale": 1,
+          "tileFlameSizeScale": 1.05,
+          "tileFlameGapScale": 1,
+          "saunaTitleMaxWidthPercent": 100
+        }
+      },
+      "midnight": {
+        "label": "Midnight Calm",
+        "theme": {
+          "bg": "#050913",
+          "fg": "#E6F1FF",
+          "accent": "#4F7BFF",
+          "gridBorder": "#0F1A33",
+          "gridTable": "#101B37",
+          "gridTableW": 2,
+          "cellBg": "#0E172C",
+          "boxFg": "#E6F1FF",
+          "headRowBg": "#0B1324",
+          "headRowFg": "#E6F1FF",
+          "timeColBg": "#0B1324",
+          "timeZebra1": "#101A31",
+          "timeZebra2": "#09101F",
+          "zebra1": "#0F1B33",
+          "zebra2": "#091327",
+          "cornerBg": "#0B1324",
+          "cornerFg": "#E6F1FF",
+          "tileBorder": "#4F7BFF",
+          "tileBorderW": 3,
+          "chipBorder": "#4F7BFF",
+          "chipBorderW": 2,
+          "flame": "#7CB8FF",
+          "saunaColor": "#4F7BFF"
+        },
+        "fonts": {
+          "family": "'IBM Plex Sans', system-ui, sans-serif",
+          "tileTextScale": 0.88,
+          "tileWeight": 500,
+          "chipHeight": 1,
+          "tileMetaScale": 0.95,
+          "overviewTimeWidthCh": 10,
+          "overviewShowFlames": false,
+          "chipOverflowMode": "scale",
+          "flamePct": 64,
+          "flameGapScale": 0.18
+        },
+        "slides": {
+          "infobadgeColor": "#4F7BFF",
+          "badgeLibrary": [
+            {
+              "id": "bdg_classic",
+              "icon": "🌿",
+              "label": "Klassisch"
+            },
+            {
+              "id": "bdg_event",
+              "icon": "⭐",
+              "label": "Event"
+            },
+            {
+              "id": "bdg_ritual",
+              "icon": "🔥",
+              "label": "Ritual"
+            }
+          ],
+          "badgeScale": 1,
+          "badgeDescriptionScale": 1,
+          "tileFlameSizeScale": 0.92,
+          "tileFlameGapScale": 1,
+          "saunaTitleMaxWidthPercent": 90,
+          "overviewShowFlames": false
+        }
+      },
+      "celebration": {
+        "label": "Event Highlight",
+        "theme": {
+          "bg": "#1A1A1A",
+          "fg": "#FDF6E3",
+          "accent": "#FFCD3C",
+          "gridBorder": "#2A2A2A",
+          "gridTable": "#2A2A2A",
+          "gridTableW": 3,
+          "cellBg": "#222222",
+          "boxFg": "#FDF6E3",
+          "headRowBg": "#101010",
+          "headRowFg": "#FFCD3C",
+          "timeColBg": "#101010",
+          "timeZebra1": "#1C1C1C",
+          "timeZebra2": "#121212",
+          "zebra1": "#252525",
+          "zebra2": "#1B1B1B",
+          "cornerBg": "#101010",
+          "cornerFg": "#FFCD3C",
+          "tileBorder": "#FFCD3C",
+          "tileBorderW": 4,
+          "chipBorder": "#FFCD3C",
+          "chipBorderW": 3,
+          "flame": "#FFB347",
+          "saunaColor": "#FFCD3C"
+        },
+        "fonts": {
+          "family": "'Montserrat', 'Segoe UI', sans-serif",
+          "tileTextScale": 0.86,
+          "tileWeight": 700,
+          "chipHeight": 1.05,
+          "overviewShowFlames": true,
+          "chipOverflowMode": "scale",
+          "flamePct": 62,
+          "flameGapScale": 0.16
+        },
+        "slides": {
+          "infobadgeColor": "#FFCD3C",
+          "badgeLibrary": [
+            {
+              "id": "bdg_classic",
+              "icon": "🌿",
+              "label": "Klassisch"
+            },
+            {
+              "id": "bdg_event",
+              "icon": "⭐",
+              "label": "Event"
+            },
+            {
+              "id": "bdg_ritual",
+              "icon": "🔥",
+              "label": "Ritual"
+            }
+          ],
+          "badgeScale": 1.05,
+          "badgeDescriptionScale": 1,
+          "tileFlameSizeScale": 1.1,
+          "tileFlameGapScale": 1,
+          "saunaTitleMaxWidthPercent": 96
         }
       }
     },
-    "activeStyleSet": "classic"
+    "activeStyleSet": "classic",
+    "styleAutomation": {
+      "enabled": true,
+      "fallbackStyle": "classic",
+      "timeSlots": [
+        {
+          "id": "sty_morning",
+          "label": "Morgen",
+          "start": "06:00",
+          "style": "classic"
+        },
+        {
+          "id": "sty_day",
+          "label": "Tag",
+          "start": "11:00",
+          "style": "fresh"
+        },
+        {
+          "id": "sty_evening",
+          "label": "Abend",
+          "start": "18:00",
+          "style": "sunset"
+        }
+      ],
+      "eventStyle": {
+        "enabled": true,
+        "lookaheadMinutes": 180,
+        "style": "celebration"
+      }
+    }
   },
   "assets": {
     "rightImages": {
@@ -163,5 +447,43 @@
     "flameImage": "/assets/img/flame_test.svg"
   },
   "popupSelectors": [],
-  "footnote": "* Nur am Fr und Sa"
+  "footnote": "* Nur am Fr und Sa",
+  "extras": {
+    "wellnessTips": [
+      {
+        "id": "well_hydrate",
+        "icon": "💧",
+        "title": "Hydration",
+        "text": "Vor und nach dem Saunagang ausreichend trinken."
+      },
+      {
+        "id": "well_cool",
+        "icon": "❄️",
+        "title": "Abkühlen",
+        "text": "Zwischen den Gängen frische Luft und kaltes Wasser genießen."
+      }
+    ],
+    "eventCountdowns": [
+      {
+        "id": "event_moon",
+        "title": "Moonlight-Special",
+        "subtitle": "Heute 20:00",
+        "target": "2024-12-24T20:00:00+01:00",
+        "style": "celebration"
+      }
+    ],
+    "gastronomyHighlights": [
+      {
+        "id": "gastro_vital",
+        "title": "Vital-Bar",
+        "description": "Hausgemachtes Ingwerwasser und frische Obstspieße.",
+        "icon": "🥗",
+        "items": [
+          "Ingwerwasser",
+          "Frische Snacks"
+        ],
+        "textLines": []
+      }
+    ]
+  }
 }

--- a/webroot/offline.html
+++ b/webroot/offline.html
@@ -4,11 +4,113 @@
 <meta charset="utf-8">
 <title>Offline</title>
 <style>
-body{font-family:sans-serif;text-align:center;padding:2rem;background:#f0f0f0;color:#333;}
+  body{margin:0;font-family:"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:#10131a;color:#f5f7fb;display:flex;align-items:center;justify-content:center;min-height:100vh;}
+  .offline-wrap{max-width:720px;padding:48px 56px;background:rgba(15,19,28,.92);border-radius:24px;box-shadow:0 28px 60px rgba(0,0,0,.35);text-align:left;}
+  h1{margin:0 0 12px;font-size:2.4rem;font-weight:800;letter-spacing:.01em;}
+  p{margin:.5rem 0 1.6rem;font-size:1.05rem;opacity:.85;}
+  section{margin-top:2.2rem;}
+  section h2{margin:0 0 .6rem;font-size:1.35rem;font-weight:700;}
+  ul{margin:0;padding-left:1.2rem;display:flex;flex-direction:column;gap:.35rem;}
+  li{line-height:1.35;}
+  .meta{display:flex;flex-wrap:wrap;gap:1rem;font-size:.95rem;opacity:.8;}
+  .meta span{display:flex;flex-direction:column;}
+  .meta span strong{font-size:1.1rem;color:#fefefe;}
+  .meta span small{font-size:.85rem;opacity:.7;}
+  .offline-note{margin-top:2rem;font-size:.9rem;opacity:.65;}
 </style>
 </head>
 <body>
-<h1>Offline</h1>
-<p>Keine Verbindung zum Server.</p>
+<div class="offline-wrap">
+  <h1>Offline-Modus</h1>
+  <p>Die zuletzt verfügbaren Plan- und Einstellungsdaten werden angezeigt, bis die Verbindung wiederhergestellt ist.</p>
+  <section id="scheduleSection" hidden>
+    <h2>Letzter Aufgussplan</h2>
+    <ul id="scheduleList"></ul>
+  </section>
+  <section id="settingsSection" hidden>
+    <h2>Geräteeinstellungen</h2>
+    <div class="meta" id="settingsMeta"></div>
+  </section>
+  <p class="offline-note">Tipp: Stelle sicher, dass der Server erreichbar ist oder prüfe das Netzwerk, um Live-Daten zu erhalten.</p>
+</div>
+<script>
+(async () => {
+  if (!('caches' in window)) return;
+  let cache = null;
+  try {
+    cache = await caches.open('signage-data-v1');
+  } catch (error) {
+    return;
+  }
+  if (!cache) return;
+
+  async function loadJson(path){
+    const response = await cache.match(path);
+    if (!response) return null;
+    try {
+      return await response.json();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  const schedule = await loadJson('/data/schedule.json');
+  const settings = await loadJson('/data/settings.json');
+
+  if (schedule) {
+    const section = document.getElementById('scheduleSection');
+    const list = document.getElementById('scheduleList');
+    const saunas = Array.isArray(schedule.saunas) ? schedule.saunas : [];
+    const rows = Array.isArray(schedule.rows) ? schedule.rows : [];
+    const entries = [];
+    rows.forEach((row) => {
+      if (!row || typeof row !== 'object') return;
+      const time = typeof row.time === 'string' ? row.time.trim() : '';
+      const items = Array.isArray(row.entries) ? row.entries : [];
+      const labels = [];
+      items.forEach((cell, idx) => {
+        if (!cell || typeof cell !== 'object') return;
+        const name = saunas[idx] || '';
+        const title = typeof cell.title === 'string' ? cell.title.trim() : '';
+        if (!title) return;
+        labels.push(name ? `${name}: ${title}` : title);
+      });
+      if (time && labels.length) entries.push({ time, labels });
+    });
+    entries.slice(0, 6).forEach(({ time, labels }) => {
+      const item = document.createElement('li');
+      item.textContent = `${time} – ${labels.join(' • ')}`;
+      list.appendChild(item);
+    });
+    if (entries.length) section.hidden = false;
+  }
+
+  if (settings) {
+    const meta = document.getElementById('settingsMeta');
+    const section = document.getElementById('settingsSection');
+    const layoutMode = settings.display?.layoutMode === 'split' ? 'Zweispaltig' : 'Einspaltig';
+    const layoutProfile = settings.display?.layoutProfile || 'landscape';
+    const activeStyle = settings.slides?.activeStyleSet || 'classic';
+    const extras = settings.extras || {};
+    const wellnessCount = Array.isArray(extras.wellnessTips) ? extras.wellnessTips.length : 0;
+    const eventCount = Array.isArray(extras.eventCountdowns) ? extras.eventCountdowns.length : 0;
+    const gastroCount = Array.isArray(extras.gastronomyHighlights) ? extras.gastronomyHighlights.length : 0;
+
+    const metaItems = [
+      ['Layout', `${layoutMode} · Profil: ${layoutProfile}`],
+      ['Style-Set', activeStyle],
+      ['Wellness-Tipps', String(wellnessCount)],
+      ['Events', String(eventCount)],
+      ['Gastronomie', String(gastroCount)]
+    ];
+    metaItems.forEach(([label, value]) => {
+      const span = document.createElement('span');
+      span.innerHTML = `<strong>${value}</strong><small>${label}</small>`;
+      meta.appendChild(span);
+    });
+    section.hidden = false;
+  }
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend slideshow logic with wellness, event, and gastronomy modules, automated style switching, and layout profile handling
- add styling for new layout profiles and extra content components, including responsive tweaks
- improve offline support by caching schedule/settings data and showing last-known content in the offline page, updating sample settings accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d58028d6448320bbff15d2145cc4c2