### PR TITLE
Align overview flames to chip edge

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -433,10 +433,18 @@ body[data-layout='single'][data-layout-profile='asymmetric'] #stage-left{grid-co
 }
 
 /* Flammen rechts, kompakt und nie über dem Text */
-.chip-flames{ 
-  flex:0 0 auto; display:inline-flex; margin-left:.6em;
+.chip-flames{
+  flex:0 0 auto;
+  display:inline-flex;
+  margin-left:auto;
+  padding-left:.6em;
+  justify-content:flex-end;
 }
-.chip-flames .flames{ display:inline-flex; gap:var(--chipFlameGap); }
+.chip-flames .flames{
+  display:inline-flex;
+  gap:var(--chipFlameGap);
+  justify-content:flex-end;
+}
 .chip-flames .flame{
   height:calc(var(--chipH) * var(--chipFlamePct));
   width:auto;


### PR DESCRIPTION
## Summary
- push overview chip flames to the right edge by letting the flame container consume remaining space
- ensure nested flame wrappers justify their icons to the end for consistent alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d63bc7e1548320a193ae52cc157e86