### PR TITLE
Fix single flame alignment in overview chips

### DIFF
--- a/webroot/assets/design.css
+++ b/webroot/assets/design.css
@@ -433,10 +433,18 @@ body[data-layout='single'][data-layout-profile='asymmetric'] #stage-left{grid-co
 }
 
 /* Flammen rechts, kompakt und nie über dem Text */
-.chip-flames{ 
-  flex:0 0 auto; display:inline-flex; margin-left:.6em;
+.chip-flames{
+  flex:0 0 auto;
+  display:inline-flex;
+  margin-left:auto;
+  padding-left:.6em;
+  justify-content:flex-end;
 }
-.chip-flames .flames{ display:inline-flex; gap:var(--chipFlameGap); }
+.chip-flames .flames{
+  display:inline-flex;
+  gap:var(--chipFlameGap);
+  justify-content:flex-end;
+}
 .chip-flames .flame{
   height:calc(var(--chipH) * var(--chipFlamePct));
   width:auto;

--- a/webroot/assets/slideshow.js
+++ b/webroot/assets/slideshow.js
@@ -1541,9 +1541,9 @@ async function loadDeviceResolved(id){
   function flamesWrap(spec) {
     const { count, approx } = parseFlameSpec(spec);
     const wrap = h('div', { class: 'flames' + (approx ? ' approx' : '') });
-    wrap.appendChild(count >= 1 ? flameNode() : h('span'));
-    wrap.appendChild(count >= 2 ? flameNode() : h('span'));
-    wrap.appendChild(count >= 3 ? flameNode() : h('span'));
+    for (let i = 0; i < count; i += 1) {
+      wrap.appendChild(flameNode());
+    }
     return wrap;
   }
 


### PR DESCRIPTION
## Summary
- stop inserting placeholder flame spans so only real flames render
- rely on flex alignment so single flames sit flush with the chip edge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63bc7e1548320a193ae52cc157e86