### PR TITLE
Enhance admin index overview

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -160,6 +160,88 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .btn.icon-label{ gap:4px; }
 .devices-section{ margin-top:12px; }
 
+/* ---------- Dashboard Intro & Quick Navigation ---------- */
+.dashboard-intro{
+  display:flex;
+  flex-direction:column;
+  gap:22px;
+  margin:18px 16px 22px;
+  padding:20px;
+  border-radius:16px;
+  background:color-mix(in oklab, var(--panel) 88%, var(--btn-accent) 12%);
+  box-shadow:0 18px 40px -22px rgba(15,23,42,.35);
+  border:1px solid color-mix(in oklab, var(--btn-accent) 45%, var(--inbr));
+  grid-column:1 / -1;
+}
+.dashboard-intro h2{ margin:0 0 6px; font-size:20px; letter-spacing:.2px; }
+.intro-text{ margin:0; max-width:56ch; color:color-mix(in oklab, var(--fg) 82%, var(--muted)); }
+.intro-head{ display:flex; flex-wrap:wrap; justify-content:space-between; gap:18px; align-items:center; }
+.intro-status{ display:flex; flex-direction:column; gap:6px; min-width:200px; padding:12px 14px; border-radius:12px; background:color-mix(in oklab, var(--panel) 92%, transparent); border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--border)); }
+.status-indicator{ display:flex; align-items:center; gap:10px; font-weight:600; font-size:13px; }
+.status-dot{ width:10px; height:10px; border-radius:50%; background:linear-gradient(135deg, var(--btn-accent), var(--btn-accent-hover)); box-shadow:0 0 0 3px rgba(124,58,237,.18); }
+.status-help{ font-size:12px; color:var(--muted); }
+
+.quick-nav{ display:grid; gap:10px; grid-template-columns:repeat(auto-fit, minmax(160px, 1fr)); }
+.quick-nav-item{
+  display:flex;
+  gap:12px;
+  align-items:flex-start;
+  padding:12px 14px;
+  border-radius:14px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 10%, var(--inbr));
+  background:color-mix(in oklab, var(--panel) 96%, transparent);
+  color:inherit;
+  text-decoration:none;
+  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+}
+.quick-nav-item:hover,
+.quick-nav-item:focus-visible{
+  transform:translateY(-2px);
+  border-color:color-mix(in oklab, var(--btn-accent) 40%, var(--border));
+  box-shadow:0 14px 28px -20px rgba(124,58,237,.55);
+}
+.quick-nav-item:focus-visible{ outline:2px solid var(--btn-accent); outline-offset:3px; }
+.quick-nav-icon{ font-size:20px; line-height:1; }
+.quick-nav-title{ display:block; font-weight:700; font-size:14px; margin-bottom:2px; }
+.quick-nav-sub{ display:block; font-size:12px; color:var(--muted); }
+
+.overview-cards{ display:grid; gap:14px; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); }
+.overview-card{
+  background:color-mix(in oklab, var(--panel) 95%, transparent);
+  border-radius:16px;
+  padding:18px 20px 20px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 12%, var(--inbr));
+  box-shadow:0 12px 34px -26px rgba(15,23,42,.48);
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.overview-card h3{ margin:0; font-size:16px; }
+.overview-card p{ margin:0; color:var(--muted); }
+.overview-link{
+  align-self:flex-start;
+  margin-top:auto;
+  font-weight:600;
+  color:color-mix(in oklab, var(--btn-accent) 60%, var(--fg));
+  text-decoration:none;
+  padding:6px 0;
+  position:relative;
+}
+.overview-link::after{
+  content:"";
+  position:absolute;
+  inset:auto 0 -2px;
+  height:2px;
+  background:linear-gradient(90deg, var(--btn-accent), var(--btn-accent-hover));
+  opacity:.65;
+  transform:scaleX(.4);
+  transform-origin:left;
+  transition:transform .18s ease, opacity .18s ease;
+}
+.overview-link:hover::after,
+.overview-link:focus-visible::after{ opacity:1; transform:scaleX(1); }
+.overview-link:focus-visible{ outline:2px solid var(--btn-accent); outline-offset:4px; border-radius:6px; }
+
 /* ---------- Header ---------- */
 header{
   position:sticky; top:0; z-index:60;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -52,6 +52,80 @@
   </header>
 
   <main class="layout">
+    <section class="dashboard-intro" aria-labelledby="adminIntroTitle">
+      <div class="intro-head">
+        <div>
+          <h2 id="adminIntroTitle">Willkommen im Adminbereich</h2>
+          <p class="intro-text">
+            Hier steuerst du Tagespläne, Slideshows und Zusatzinformationen für die Anzeigen. Wähle einen Bereich über die Schnellnavigation oder starte direkt mit den wichtigsten Aufgaben.
+          </p>
+        </div>
+        <div class="intro-status" aria-live="polite">
+          <div class="status-indicator">
+            <span class="status-dot" aria-hidden="true"></span>
+            <span id="introStatusText">Bereit zum Bearbeiten</span>
+          </div>
+          <div class="status-help">Nutze „Speichern“, sobald deine Änderungen fertig sind.</div>
+        </div>
+      </div>
+
+      <nav class="quick-nav" aria-label="Schnellnavigation">
+        <a class="quick-nav-item" href="#gridPane">
+          <span class="quick-nav-icon" aria-hidden="true">🗓️</span>
+          <span>
+            <span class="quick-nav-title">Tagesplan</span>
+            <span class="quick-nav-sub">Zeiten &amp; Wochenpläne</span>
+          </span>
+        </a>
+        <a class="quick-nav-item" href="#slidesMaster">
+          <span class="quick-nav-icon" aria-hidden="true">🎬</span>
+          <span>
+            <span class="quick-nav-title">Slides &amp; Steuerung</span>
+            <span class="quick-nav-sub">Ablauf &amp; Automationen</span>
+          </span>
+        </a>
+        <a class="quick-nav-item" href="#boxSaunas">
+          <span class="quick-nav-icon" aria-hidden="true">🔥</span>
+          <span>
+            <span class="quick-nav-title">Saunen &amp; Übersicht</span>
+            <span class="quick-nav-sub">Inhalte &amp; Presets</span>
+          </span>
+        </a>
+        <a class="quick-nav-item" href="#boxImages">
+          <span class="quick-nav-icon" aria-hidden="true">🖼️</span>
+          <span>
+            <span class="quick-nav-title">Medien-Slides</span>
+            <span class="quick-nav-sub">Fotos &amp; Videos verwalten</span>
+          </span>
+        </a>
+        <a class="quick-nav-item" href="#boxSlidesText">
+          <span class="quick-nav-icon" aria-hidden="true">🧩</span>
+          <span>
+            <span class="quick-nav-title">Slideshow &amp; Layout</span>
+            <span class="quick-nav-sub">Layouts &amp; Farben anpassen</span>
+          </span>
+        </a>
+      </nav>
+
+      <div class="overview-cards" aria-label="Kurzübersicht">
+        <article class="overview-card">
+          <h3>Tagesplanung</h3>
+          <p>Verwalte Aufgusszeiten, Wochentage und voreingestellte Presets direkt im Kalender.</p>
+          <a class="overview-link" href="#gridPane">Zum Plan</a>
+        </article>
+        <article class="overview-card">
+          <h3>Inhalte &amp; Medien</h3>
+          <p>Pflege Saunen, Zusatzinfos und Medien-Slides inklusive Vorschau und Sichtbarkeit.</p>
+          <a class="overview-link" href="#boxSaunas">Zu den Inhalten</a>
+        </article>
+        <article class="overview-card">
+          <h3>Design &amp; Automation</h3>
+          <p>Steuere Dauer, Layouts, Farben und Automatisierungen für einen konsistenten Auftritt.</p>
+          <a class="overview-link" href="#slidesMaster">Zu den Einstellungen</a>
+        </article>
+      </div>
+    </section>
+
     <section class="leftcol">
 <div class="card" id="gridPane">
         <div class="content" style="padding-bottom:0">


### PR DESCRIPTION
## Summary
- add an introductory dashboard section to the admin index with quick navigation links for major tasks
- provide overview cards that explain the primary content, media, and design management areas
- style the new section with polished visuals to improve clarity and usability for new operators

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d67a8a89008320acdfe6e65b94cd46