### PR TITLE
Rework admin index workspace navigation

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -160,6 +160,233 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .btn.icon-label{ gap:4px; }
 .devices-section{ margin-top:12px; }
 
+/* ---------- Workspace Overview ---------- */
+.workspace-overview{
+  display:flex;
+  flex-direction:column;
+  gap:26px;
+  margin:18px 16px 22px;
+  padding:26px;
+  border-radius:20px;
+  background:color-mix(in oklab, var(--panel) 88%, var(--btn-accent) 12%);
+  box-shadow:0 22px 48px -24px rgba(15,23,42,.38);
+  border:1px solid color-mix(in oklab, var(--btn-accent) 45%, var(--inbr));
+  grid-column:1 / -1;
+}
+.workspace-head{
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:24px;
+}
+.workspace-copy{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  max-width:min(640px, 100%);
+}
+.workspace-kicker{
+  margin:0;
+  text-transform:uppercase;
+  letter-spacing:0.18em;
+  font-size:12px;
+  color:color-mix(in oklab, var(--fg) 65%, var(--muted));
+  font-weight:700;
+}
+.workspace-text{
+  margin:0;
+  max-width:60ch;
+  color:color-mix(in oklab, var(--fg) 85%, var(--muted));
+}
+.workspace-quick{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:6px;
+}
+.workspace-quick-btn{
+  appearance:none;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--inbr));
+  background:color-mix(in oklab, var(--panel) 92%, transparent);
+  color:inherit;
+  padding:8px 14px;
+  border-radius:999px;
+  font-weight:600;
+  font-size:13px;
+  cursor:pointer;
+  transition:transform .16s ease, border-color .16s ease, box-shadow .16s ease, background-color .16s ease;
+}
+.workspace-quick-btn:hover,
+.workspace-quick-btn:focus-visible{
+  border-color:color-mix(in oklab, var(--btn-accent) 65%, var(--border));
+  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
+  box-shadow:0 10px 24px -18px rgba(124,58,237,.6);
+  transform:translateY(-1px);
+}
+.workspace-quick-btn:focus-visible{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+.workspace-status{
+  min-width:220px;
+  padding:16px 18px;
+  border-radius:16px;
+  background:color-mix(in oklab, var(--panel) 94%, transparent);
+  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--border));
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.workspace-status-label{
+  font-size:12px;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  color:color-mix(in oklab, var(--fg) 60%, var(--muted));
+  font-weight:700;
+}
+.workspace-status-value{
+  font-size:18px;
+  font-weight:700;
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+}
+.workspace-status-value::before{
+  content:"";
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  background:linear-gradient(135deg, var(--btn-accent), var(--btn-accent-hover));
+  box-shadow:0 0 0 4px color-mix(in oklab, var(--btn-accent) 25%, transparent);
+}
+.workspace-status-help{
+  margin:0;
+  font-size:12px;
+  color:var(--muted);
+}
+.workspace-grid{
+  display:grid;
+  gap:16px;
+  grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));
+}
+.workspace-card{
+  background:color-mix(in oklab, var(--panel) 95%, transparent);
+  border-radius:18px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 16%, var(--inbr));
+  padding:20px 20px 22px;
+  box-shadow:0 18px 44px -30px rgba(15,23,42,.55);
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+.workspace-card-head{
+  display:flex;
+  gap:12px;
+  align-items:flex-start;
+}
+.workspace-card-icon{
+  font-size:28px;
+  line-height:1;
+}
+.workspace-card-head h3{
+  margin:0 0 4px;
+  font-size:16px;
+}
+.workspace-card-head p{
+  margin:0;
+  color:var(--muted);
+}
+.workspace-card-list{
+  margin:0;
+  padding-left:20px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  color:color-mix(in oklab, var(--fg) 82%, var(--muted));
+  font-size:13px;
+}
+.workspace-card-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:auto;
+}
+.workspace-card-btn{
+  border-radius:999px;
+  padding:8px 16px;
+  font-weight:600;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--inbr));
+  background:color-mix(in oklab, var(--panel) 96%, transparent);
+  color:inherit;
+  cursor:pointer;
+  transition:transform .16s ease, box-shadow .16s ease, border-color .16s ease, background-color .16s ease;
+}
+.workspace-card-btn:not(.primary):hover,
+.workspace-card-btn:not(.primary):focus-visible{
+  transform:translateY(-1px);
+  border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
+  background:color-mix(in oklab, var(--btn-accent) 16%, var(--panel));
+  box-shadow:0 16px 32px -26px rgba(124,58,237,.55);
+}
+.workspace-card-btn:focus-visible{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+.workspace-card-btn.primary{
+  background:linear-gradient(135deg, var(--btn-primary), var(--btn-primary-2));
+  color:var(--btn-primary-fg);
+  border-color:color-mix(in oklab, var(--btn-primary) 45%, var(--btn-primary-2));
+  box-shadow:0 14px 32px -20px color-mix(in oklab, var(--btn-primary) 55%, transparent);
+}
+.workspace-card-btn.primary:hover,
+.workspace-card-btn.primary:focus-visible{
+  transform:translateY(-1px);
+  background:linear-gradient(135deg, var(--btn-primary-2), var(--btn-primary));
+  border-color:color-mix(in oklab, var(--btn-primary) 65%, var(--btn-primary-2));
+  box-shadow:0 18px 36px -24px color-mix(in oklab, var(--btn-primary) 55%, transparent);
+}
+.workspace-card-btn.ghost{
+  background:color-mix(in oklab, var(--panel) 92%, transparent);
+}
+@media (max-width: 720px){
+  .workspace-status{ width:100%; }
+  .workspace-overview{ padding:22px; }
+}
+
+[data-jump-target]{
+  scroll-margin-block-start:96px;
+}
+details[data-jump-target] > summary{
+  scroll-margin-block-start:96px;
+}
+.jump-flash{
+  outline:2px solid color-mix(in oklab, var(--btn-accent) 55%, transparent);
+  outline-offset:2px;
+  box-shadow:0 0 0 6px color-mix(in oklab, var(--btn-accent) 25%, transparent);
+  animation:jumpFlash 1.4s ease-out;
+}
+details > summary.jump-flash{
+  border-radius:12px;
+}
+[data-jump-target].jump-flash{
+  border-radius:18px;
+}
+@keyframes jumpFlash{
+  0%{
+    box-shadow:0 0 0 8px color-mix(in oklab, var(--btn-accent) 45%, transparent);
+    outline-color:color-mix(in oklab, var(--btn-accent) 80%, transparent);
+  }
+  55%{
+    box-shadow:0 0 0 3px color-mix(in oklab, var(--btn-accent) 25%, transparent);
+    outline-color:color-mix(in oklab, var(--btn-accent) 45%, transparent);
+  }
+  100%{
+    box-shadow:0 0 0 0 color-mix(in oklab, var(--btn-accent) 0%, transparent);
+    outline-color:color-mix(in oklab, var(--btn-accent) 0%, transparent);
+  }
+}
+
 /* ---------- Header ---------- */
 header{
   position:sticky; top:0; z-index:60;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -52,8 +52,107 @@
   </header>
 
   <main class="layout">
+    <section class="workspace-overview" aria-labelledby="adminIntroTitle">
+      <header class="workspace-head">
+        <div class="workspace-copy">
+          <p class="workspace-kicker">Admin-Cockpit</p>
+          <h2 id="adminIntroTitle">Willkommen im Adminbereich</h2>
+          <p class="workspace-text">
+            Hier steuerst du Tagespläne, Slides, Zusatzinfos und das Design deiner Anzeigen. Wähle den passenden Arbeitsbereich oder springe direkt zu den wichtigsten Aufgaben.
+          </p>
+          <div class="workspace-quick" role="group" aria-label="Schnellzugriff">
+            <button type="button" class="workspace-quick-btn" data-jump="gridPane" aria-controls="gridPane">Aufgussplan</button>
+            <button type="button" class="workspace-quick-btn" data-jump="boxSaunas" aria-controls="boxSaunas">Inhalte &amp; Saunen</button>
+            <button type="button" class="workspace-quick-btn" data-jump="slidesMaster" aria-controls="slidesMaster">Ablauf &amp; Zeiten</button>
+            <button type="button" class="workspace-quick-btn" data-jump="boxImages" aria-controls="boxImages">Medien verwalten</button>
+            <button type="button" class="workspace-quick-btn" data-jump="boxSlidesText" aria-controls="boxSlidesText">Layout &amp; Farben</button>
+          </div>
+        </div>
+        <div class="workspace-status" aria-live="polite">
+          <div class="workspace-status-label">Status</div>
+          <div class="workspace-status-value" id="introStatusText">Bereit zum Bearbeiten</div>
+          <p class="workspace-status-help">Speichere regelmäßig, sobald Änderungen fertig sind.</p>
+        </div>
+      </header>
+
+      <div class="workspace-grid" role="list">
+        <article class="workspace-card" role="listitem">
+          <div class="workspace-card-head">
+            <span class="workspace-card-icon" aria-hidden="true">🗓️</span>
+            <div>
+              <h3>Tagesplan &amp; Wochenablauf</h3>
+              <p>Zeiten strukturieren, Reihenfolge anpassen und Wochenvorlagen sichern.</p>
+            </div>
+          </div>
+          <ul class="workspace-card-list">
+            <li>Zeiten verschieben, duplizieren oder löschen</li>
+            <li>Wochentage vergleichen und speichern</li>
+            <li>Schnell zu freien Slots navigieren</li>
+          </ul>
+          <div class="workspace-card-actions">
+            <button type="button" class="workspace-card-btn primary" data-jump="gridPane" aria-controls="gridPane">Plan bearbeiten</button>
+          </div>
+        </article>
+
+        <article class="workspace-card" role="listitem">
+          <div class="workspace-card-head">
+            <span class="workspace-card-icon" aria-hidden="true">🔥</span>
+            <div>
+              <h3>Saunen &amp; Zusatzinformationen</h3>
+              <p>Saunen, Badges und Zusatztexte pflegen – inklusive Vorschau und Reihenfolge.</p>
+            </div>
+          </div>
+          <ul class="workspace-card-list">
+            <li>Saunen aktivieren/deaktivieren</li>
+            <li>Badges &amp; Hinweise zuweisen</li>
+            <li>Story-Slides komfortabel bearbeiten</li>
+          </ul>
+          <div class="workspace-card-actions">
+            <button type="button" class="workspace-card-btn" data-jump="boxSaunas" aria-controls="boxSaunas">Inhalte öffnen</button>
+          </div>
+        </article>
+
+        <article class="workspace-card" role="listitem">
+          <div class="workspace-card-head">
+            <span class="workspace-card-icon" aria-hidden="true">🎬</span>
+            <div>
+              <h3>Slides &amp; Automationen</h3>
+              <p>Dauer, Übergänge und Reihenfolgen einstellen, damit der Ablauf passt.</p>
+            </div>
+          </div>
+          <ul class="workspace-card-list">
+            <li>Globale oder individuelle Slide-Dauer wählen</li>
+            <li>Automatisierungen aktivieren</li>
+            <li>Übersichten &amp; Vorschauen prüfen</li>
+          </ul>
+          <div class="workspace-card-actions">
+            <button type="button" class="workspace-card-btn" data-jump="slidesMaster" aria-controls="slidesMaster">Ablauf steuern</button>
+          </div>
+        </article>
+
+        <article class="workspace-card" role="listitem">
+          <div class="workspace-card-head">
+            <span class="workspace-card-icon" aria-hidden="true">🖼️</span>
+            <div>
+              <h3>Medien &amp; Layout</h3>
+              <p>Slides mit Bildern, Texten und Farben gestalten – inklusive Style-Presets.</p>
+            </div>
+          </div>
+          <ul class="workspace-card-list">
+            <li>Medien-Slides verwalten und sortieren</li>
+            <li>Layouts für Split-Screens definieren</li>
+            <li>Farbpaletten und Typografie justieren</li>
+          </ul>
+          <div class="workspace-card-actions">
+            <button type="button" class="workspace-card-btn" data-jump="boxImages" aria-controls="boxImages">Medienbereich</button>
+            <button type="button" class="workspace-card-btn ghost" data-jump="boxSlidesText" aria-controls="boxSlidesText">Layout &amp; Text</button>
+          </div>
+        </article>
+      </div>
+    </section>
+
     <section class="leftcol">
-<div class="card" id="gridPane">
+<div class="card" id="gridPane" data-jump-target>
         <div class="content" style="padding-bottom:0">
 <div class="row" id="planHead" style="justify-content:space-between;align-items:center;margin-bottom:8px;gap:8px;flex-wrap:wrap">
   <div style="font-weight:700">Aufgussplan <span class="mut">(<span id="activeDayLabel">—</span>)</span></div>
@@ -82,7 +181,7 @@
       <div class="layout-resizer" id="layoutResizer" role="separator" aria-orientation="vertical" aria-label="Sidebar-Größe anpassen" tabindex="0" aria-hidden="false"></div>
       <div class="rightbar-columns">
 <!-- Slides – Masterbox -->
-<details class="ac full" open id="slidesMaster">
+<details class="ac full" open id="slidesMaster" data-jump-target>
   <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Slides – Reihenfolge, Sichtbarkeit & Zeiten</div>
     <div class="actions">
@@ -166,7 +265,7 @@
     </div>
 
     <!-- Unterbox 1: Saunen & Übersicht -->
-    <details class="ac sub" open id="boxSaunas">
+    <details class="ac sub" open id="boxSaunas" data-jump-target>
       <summary><div class="ttl">▶<span class="chev">⮞</span> Saunen & Übersicht</div>
  <div class="actions"><button class="btn sm" id="btnAddSauna">Sauna hinzufügen</button></div>
 </summary>      
@@ -342,7 +441,7 @@
     </details>
 
     <!-- Unterbox 4: Medien-Slides -->
-    <details class="ac sub" id="boxImages">
+    <details class="ac sub" id="boxImages" data-jump-target>
 <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>
     <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button></div>
@@ -365,7 +464,7 @@
   </div>
 </details>
 
- <details class="ac full" id="boxSlidesText">
+ <details class="ac full" id="boxSlidesText" data-jump-target>
         <summary>
           <div class="ttl">▶<span class="chev">⮞</span> Slideshow & Text</div>
           <div class="actions"><button class="btn sm ghost" id="resetSlides">Standardwerte</button></div>
@@ -738,6 +837,70 @@
   </div>
 </div>
 
+<script>
+  (function(){
+    const jumpButtons = document.querySelectorAll('[data-jump]');
+    if (!jumpButtons.length) return;
+
+    const ensureDetailsOpen = (element) => {
+      if (!element) return;
+      if (element.matches('details')) {
+        element.open = true;
+      }
+      let parent = element.closest('details');
+      while (parent) {
+        parent.open = true;
+        parent = parent.parentElement?.closest('details');
+      }
+    };
+
+    const getScrollTarget = (element) => {
+      if (!element) return null;
+      if (element.hasAttribute('data-jump-target')) {
+        return element;
+      }
+      return element.closest('[data-jump-target]') || element;
+    };
+
+    const highlight = (element) => {
+      if (!element) return;
+      element.classList.remove('jump-flash');
+      void element.offsetWidth;
+      element.classList.add('jump-flash');
+      window.setTimeout(() => element.classList.remove('jump-flash'), 1600);
+    };
+
+    const canFocus = (element) => {
+      if (!(element instanceof HTMLElement)) return false;
+      if (element.tabIndex >= 0) return true;
+      return /^(A|BUTTON|SUMMARY|INPUT|SELECT|TEXTAREA)$/i.test(element.tagName);
+    };
+
+    jumpButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const targetId = button.dataset.jump;
+        if (!targetId) return;
+        const target = document.getElementById(targetId);
+        if (!target) return;
+
+        ensureDetailsOpen(target);
+
+        const scrollTarget = getScrollTarget(target);
+        window.requestAnimationFrame(() => {
+          scrollTarget?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          const highlightEl = target.matches('details')
+            ? target.querySelector(':scope > summary') || scrollTarget
+            : scrollTarget;
+          highlight(highlightEl);
+          if (highlightEl && typeof highlightEl.focus === 'function' && canFocus(highlightEl)) {
+            highlightEl.focus({ preventScroll: true });
+          }
+        });
+      });
+    });
+  })();
+</script>
 <script>
 
   (function(){


### PR DESCRIPTION
## Summary
- rebuild the admin landing section into a workspace overview with descriptive cards and quick actions
- add scripted jump navigation that opens target panels even when the sidebar is collapsed
- refresh styling to support the new overview cards, quick buttons, and jump-target highlights

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d67a8a89008320acdfe6e65b94cd46