### PR TITLE
Streamline admin cockpit navigation

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -160,6 +160,251 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .btn.icon-label{ gap:4px; }
 .devices-section{ margin-top:12px; }
 
+/* ---------- Workspace Overview ---------- */
+.workspace-overview{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+  margin:16px 16px 18px;
+  padding:18px 20px 20px;
+  border-radius:18px;
+  background:color-mix(in oklab, var(--panel) 92%, var(--btn-accent) 8%);
+  box-shadow:0 16px 40px -30px rgba(15,23,42,.45);
+  border:1px solid color-mix(in oklab, var(--btn-accent) 35%, var(--inbr));
+  grid-column:1 / -1;
+  transition:box-shadow .2s ease, border-color .2s ease, transform .2s ease;
+}
+.workspace-overview[data-pinned="true"]{
+  position:sticky;
+  top:calc(64px + 12px);
+  z-index:40;
+  box-shadow:0 22px 52px -28px rgba(15,23,42,.5);
+  border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
+}
+.workspace-overview[data-collapsed="true"]{
+  padding-bottom:14px;
+}
+.workspace-toolbar{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.workspace-title{
+  margin:0;
+  font-size:18px;
+  letter-spacing:.02em;
+}
+.workspace-toolbar-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+.workspace-tool-btn{
+  appearance:none;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  border-radius:999px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--inbr));
+  background:color-mix(in oklab, var(--panel) 95%, transparent);
+  color:inherit;
+  font-size:13px;
+  font-weight:600;
+  padding:6px 12px;
+  cursor:pointer;
+  transition:transform .16s ease, border-color .16s ease, background-color .16s ease, box-shadow .16s ease;
+}
+.workspace-tool-btn:hover,
+.workspace-tool-btn:focus-visible{
+  border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
+  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
+  box-shadow:0 12px 30px -22px rgba(124,58,237,.55);
+  transform:translateY(-1px);
+}
+.workspace-tool-btn:focus-visible{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+.workspace-tool-btn.is-active{
+  border-color:color-mix(in oklab, var(--btn-accent) 65%, var(--border));
+  background:color-mix(in oklab, var(--btn-accent) 24%, var(--panel));
+}
+.workspace-tool-icon{
+  font-size:14px;
+  line-height:1;
+}
+.workspace-tool-label{
+  display:inline-flex;
+  align-items:center;
+}
+.workspace-body{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+.workspace-overview[data-collapsed="true"] .workspace-body{
+  display:none;
+}
+.workspace-grid{
+  display:grid;
+  gap:14px;
+  grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));
+}
+.workspace-card{
+  background:color-mix(in oklab, var(--panel) 96%, transparent);
+  border-radius:16px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 14%, var(--inbr));
+  padding:18px 18px 20px;
+  box-shadow:0 16px 40px -32px rgba(15,23,42,.5);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.workspace-card-head{
+  display:flex;
+  gap:12px;
+  align-items:flex-start;
+}
+.workspace-card-icon{
+  font-size:28px;
+  line-height:1;
+}
+.workspace-card-head h3{
+  margin:0 0 4px;
+  font-size:16px;
+}
+.workspace-card-head p{
+  margin:0;
+  color:var(--muted);
+}
+.workspace-card-list{
+  margin:0;
+  padding-left:20px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  color:color-mix(in oklab, var(--fg) 82%, var(--muted));
+  font-size:13px;
+}
+.workspace-card-actions{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  margin-top:auto;
+}
+.workspace-card-actions-main{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+.workspace-card-branches{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+}
+.workspace-card-btn{
+  border-radius:999px;
+  padding:8px 16px;
+  font-weight:600;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--inbr));
+  background:color-mix(in oklab, var(--panel) 96%, transparent);
+  color:inherit;
+  cursor:pointer;
+  transition:transform .16s ease, box-shadow .16s ease, border-color .16s ease, background-color .16s ease;
+}
+.workspace-card-btn:not(.primary):hover,
+.workspace-card-btn:not(.primary):focus-visible{
+  transform:translateY(-1px);
+  border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
+  background:color-mix(in oklab, var(--btn-accent) 16%, var(--panel));
+  box-shadow:0 16px 32px -26px rgba(124,58,237,.55);
+}
+.workspace-card-btn:focus-visible{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+.workspace-card-btn.primary{
+  background:linear-gradient(135deg, var(--btn-primary), var(--btn-primary-2));
+  color:var(--btn-primary-fg);
+  border-color:color-mix(in oklab, var(--btn-primary) 45%, var(--btn-primary-2));
+  box-shadow:0 14px 32px -20px color-mix(in oklab, var(--btn-primary) 55%, transparent);
+}
+.workspace-card-btn.primary:hover,
+.workspace-card-btn.primary:focus-visible{
+  transform:translateY(-1px);
+  background:linear-gradient(135deg, var(--btn-primary-2), var(--btn-primary));
+  border-color:color-mix(in oklab, var(--btn-primary) 65%, var(--btn-primary-2));
+  box-shadow:0 18px 36px -24px color-mix(in oklab, var(--btn-primary) 55%, transparent);
+}
+.workspace-card-btn.ghost{
+  background:color-mix(in oklab, var(--panel) 92%, transparent);
+}
+.workspace-branch-btn{
+  appearance:none;
+  border-radius:999px;
+  padding:6px 12px;
+  font-size:12px;
+  font-weight:600;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 20%, var(--border));
+  background:color-mix(in oklab, var(--panel) 94%, transparent);
+  color:color-mix(in oklab, var(--fg) 90%, var(--muted));
+  cursor:pointer;
+  transition:transform .16s ease, border-color .16s ease, background-color .16s ease, box-shadow .16s ease;
+}
+.workspace-branch-btn:hover,
+.workspace-branch-btn:focus-visible{
+  transform:translateY(-1px);
+  border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
+  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
+  box-shadow:0 12px 28px -22px rgba(124,58,237,.45);
+}
+.workspace-branch-btn:focus-visible{
+  outline:2px solid var(--btn-accent);
+  outline-offset:2px;
+}
+@media (max-width: 720px){
+  .workspace-overview{
+    padding:16px 18px 18px;
+  }
+  .workspace-toolbar-actions{
+    justify-content:flex-start;
+  }
+}
+[data-jump-target]{
+  scroll-margin-block-start:132px;
+}
+details[data-jump-target] > summary{
+  scroll-margin-block-start:132px;
+}
+.jump-flash{
+  outline:2px solid color-mix(in oklab, var(--btn-accent) 55%, transparent);
+  outline-offset:2px;
+  box-shadow:0 0 0 6px color-mix(in oklab, var(--btn-accent) 25%, transparent);
+  animation:jumpFlash 1.4s ease-out;
+}
+details > summary.jump-flash{
+  border-radius:12px;
+}
+[data-jump-target].jump-flash{
+  border-radius:18px;
+}
+@keyframes jumpFlash{
+  0%{
+    box-shadow:0 0 0 8px color-mix(in oklab, var(--btn-accent) 45%, transparent);
+    outline-color:color-mix(in oklab, var(--btn-accent) 80%, transparent);
+  }
+  55%{
+    box-shadow:0 0 0 3px color-mix(in oklab, var(--btn-accent) 25%, transparent);
+    outline-color:color-mix(in oklab, var(--btn-accent) 45%, transparent);
+  }
+  100%{
+    box-shadow:0 0 0 0 color-mix(in oklab, var(--btn-accent) 0%, transparent);
+    outline-color:color-mix(in oklab, var(--btn-accent) 0%, transparent);
+  }
+}
+
 /* ---------- Header ---------- */
 header{
   position:sticky; top:0; z-index:60;

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -52,8 +52,148 @@
   </header>
 
   <main class="layout">
+    <section class="workspace-overview" aria-labelledby="adminCockpitTitle" data-collapsed="false" data-pinned="false">
+      <header class="workspace-toolbar">
+        <h2 id="adminCockpitTitle" class="workspace-title">Admin-Cockpit</h2>
+        <div class="workspace-toolbar-actions" role="group" aria-label="Cockpit-Optionen">
+          <button type="button" class="workspace-tool-btn" data-action="pin" aria-pressed="false" title="Cockpit anheften">
+            <span class="workspace-tool-icon" data-role="icon" data-icon-pinned="📍" data-icon-unpinned="📌" aria-hidden="true">📌</span>
+            <span class="workspace-tool-label" data-role="label" data-label-pinned="Lösen" data-label-unpinned="Anheften">Anheften</span>
+          </button>
+          <button type="button" class="workspace-tool-btn" data-action="toggle" aria-controls="adminCockpitBody" aria-expanded="true" title="Cockpit minimieren">
+            <span class="workspace-tool-icon" data-role="icon" data-icon-expanded="▾" data-icon-collapsed="▸" aria-hidden="true">▾</span>
+            <span class="workspace-tool-label" data-role="label" data-label-expanded="Einklappen" data-label-collapsed="Aufklappen">Einklappen</span>
+          </button>
+        </div>
+      </header>
+
+      <div class="workspace-body" id="adminCockpitBody">
+        <div class="workspace-grid" role="list">
+          <article class="workspace-card" role="listitem">
+            <div class="workspace-card-head">
+              <span class="workspace-card-icon" aria-hidden="true">🗓️</span>
+              <div>
+                <h3>Tagesplan &amp; Wochenablauf</h3>
+                <p>Zeiten strukturieren, Reihenfolge anpassen und Wochenvorlagen sichern.</p>
+              </div>
+            </div>
+            <ul class="workspace-card-list">
+              <li>Zeiten verschieben, duplizieren oder löschen</li>
+              <li>Wochentage vergleichen und speichern</li>
+              <li>Schnell zu freien Slots navigieren</li>
+            </ul>
+            <div class="workspace-card-actions">
+              <div class="workspace-card-actions-main">
+                <button type="button" class="workspace-card-btn primary" data-jump="gridPane" aria-controls="gridPane">Plan bearbeiten</button>
+              </div>
+            </div>
+          </article>
+
+          <article class="workspace-card" role="listitem">
+            <div class="workspace-card-head">
+              <span class="workspace-card-icon" aria-hidden="true">🔥</span>
+              <div>
+                <h3>Saunen &amp; Hinweise</h3>
+                <p>Saunen, Fußnoten und Badge-Bibliothek pflegen – inklusive Vorschau und Reihenfolge.</p>
+              </div>
+            </div>
+            <ul class="workspace-card-list">
+              <li>Saunen aktivieren/deaktivieren</li>
+              <li>Badges und Hinweise verwalten</li>
+              <li>Übersicht für den Aufgussplan anpassen</li>
+            </ul>
+            <div class="workspace-card-actions">
+              <div class="workspace-card-actions-main">
+                <button type="button" class="workspace-card-btn primary" data-jump="boxSaunas" aria-controls="boxSaunas">Saunen öffnen</button>
+              </div>
+              <div class="workspace-card-branches" role="group" aria-label="Weitere Bereiche">
+                <button type="button" class="workspace-branch-btn" data-jump="boxFootnotes" aria-controls="boxFootnotes">Fußnoten &amp; Badges</button>
+                <button type="button" class="workspace-branch-btn" data-jump="badgeLibrarySection" aria-controls="badgeLibrarySection">Badge-Bibliothek</button>
+              </div>
+            </div>
+          </article>
+
+          <article class="workspace-card" role="listitem">
+            <div class="workspace-card-head">
+              <span class="workspace-card-icon" aria-hidden="true">🎬</span>
+              <div>
+                <h3>Slides &amp; Automationen</h3>
+                <p>Dauer, Übergänge und Reihenfolgen einstellen, damit der Ablauf passt.</p>
+              </div>
+            </div>
+            <ul class="workspace-card-list">
+              <li>Globale oder individuelle Slide-Dauer wählen</li>
+              <li>Automatisierungen aktivieren</li>
+              <li>Übersichten &amp; Vorschauen prüfen</li>
+            </ul>
+            <div class="workspace-card-actions">
+              <div class="workspace-card-actions-main">
+                <button type="button" class="workspace-card-btn primary" data-jump="slidesMaster" aria-controls="slidesMaster">Ablauf steuern</button>
+              </div>
+              <div class="workspace-card-branches" role="group" aria-label="Weitere Einstellungen">
+                <button type="button" class="workspace-branch-btn" data-jump="slidesFlowCard" aria-controls="slidesFlowCard">Zeitsteuerung</button>
+                <button type="button" class="workspace-branch-btn" data-jump="slidesAutomationCard" aria-controls="slidesAutomationCard">Automatisierung</button>
+              </div>
+            </div>
+          </article>
+
+          <article class="workspace-card" role="listitem">
+            <div class="workspace-card-head">
+              <span class="workspace-card-icon" aria-hidden="true">🖼️</span>
+              <div>
+                <h3>Infos &amp; Story-Slides</h3>
+                <p>Zusatzinhalte, Countdowns, Wellness-Tipps und Story-Baukasten betreuen.</p>
+              </div>
+            </div>
+            <ul class="workspace-card-list">
+              <li>Wellness-, Gastro- und Eventinfos pflegen</li>
+              <li>Hero-Timeline aktivieren und timen</li>
+              <li>Story-Slides mit Spalten-Baukasten gestalten</li>
+            </ul>
+            <div class="workspace-card-actions">
+              <div class="workspace-card-actions-main">
+                <button type="button" class="workspace-card-btn primary" data-jump="boxStories" aria-controls="boxStories">Zusatzinfos</button>
+              </div>
+              <div class="workspace-card-branches" role="group" aria-label="Direkte Abschnitte">
+                <button type="button" class="workspace-branch-btn" data-jump="infoWellness" aria-controls="infoWellness">Wellness-Tipps</button>
+                <button type="button" class="workspace-branch-btn" data-jump="infoEvents" aria-controls="infoEvents">Event-Countdowns</button>
+                <button type="button" class="workspace-branch-btn" data-jump="infoGastro" aria-controls="infoGastro">Gastro-Infos</button>
+                <button type="button" class="workspace-branch-btn" data-jump="infoHero" aria-controls="infoHero">Hero-Timeline</button>
+                <button type="button" class="workspace-branch-btn" data-jump="infoStories" aria-controls="infoStories">Story-Slides</button>
+              </div>
+            </div>
+          </article>
+
+          <article class="workspace-card" role="listitem">
+            <div class="workspace-card-head">
+              <span class="workspace-card-icon" aria-hidden="true">🎨</span>
+              <div>
+                <h3>Medien &amp; Layout</h3>
+                <p>Slides mit Bildern, Texten, Farben und Layouts gestalten – inklusive Presets.</p>
+              </div>
+            </div>
+            <ul class="workspace-card-list">
+              <li>Medien-Slides verwalten und sortieren</li>
+              <li>Layouts für Splitscreens und Anzeigearten festlegen</li>
+              <li>Style-Presets pflegen und anwenden</li>
+            </ul>
+            <div class="workspace-card-actions">
+              <div class="workspace-card-actions-main">
+                <button type="button" class="workspace-card-btn primary" data-jump="boxImages" aria-controls="boxImages">Medienbereich</button>
+              </div>
+              <div class="workspace-card-branches" role="group" aria-label="Layout &amp; Styles">
+                <button type="button" class="workspace-branch-btn" data-jump="boxSlidesText" aria-controls="boxSlidesText">Slideshow &amp; Text</button>
+                <button type="button" class="workspace-branch-btn" data-jump="displayLayoutFold" aria-controls="displayLayoutFold">Darstellung &amp; Seiten</button>
+                <button type="button" class="workspace-branch-btn" data-jump="styleSetControls" aria-controls="styleSetControls">Style-Paletten</button>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <section class="leftcol">
-<div class="card" id="gridPane">
+<div class="card" id="gridPane" data-jump-target>
         <div class="content" style="padding-bottom:0">
 <div class="row" id="planHead" style="justify-content:space-between;align-items:center;margin-bottom:8px;gap:8px;flex-wrap:wrap">
   <div style="font-weight:700">Aufgussplan <span class="mut">(<span id="activeDayLabel">—</span>)</span></div>
@@ -82,7 +222,7 @@
       <div class="layout-resizer" id="layoutResizer" role="separator" aria-orientation="vertical" aria-label="Sidebar-Größe anpassen" tabindex="0" aria-hidden="false"></div>
       <div class="rightbar-columns">
 <!-- Slides – Masterbox -->
-<details class="ac full" open id="slidesMaster">
+<details class="ac full" open id="slidesMaster" data-jump-target>
   <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Slides – Reihenfolge, Sichtbarkeit & Zeiten</div>
     <div class="actions">
@@ -91,7 +231,7 @@
   </summary>
   <div class="content">
     <div class="settings-stack">
-      <div class="settings-card" id="slidesFlowCard">
+      <div class="settings-card" id="slidesFlowCard" data-jump-target>
         <div class="settings-card-head">
           <div class="settings-card-title">Ablauf &amp; Zeitsteuerung</div>
           <p class="settings-card-description">Bestimme Dauer, Übergänge und Verhalten beim Abspielen.</p>
@@ -130,7 +270,7 @@
         </div>
       </div>
 
-      <div class="settings-card" id="slidesAutomationCard">
+      <div class="settings-card" id="slidesAutomationCard" data-jump-target>
         <div class="settings-card-head">
           <div class="settings-card-title">Automatisierung</div>
           <p class="settings-card-description">Lädt zu Start oder Tab-Wechsel automatisch passende Voreinstellungen.</p>
@@ -166,7 +306,7 @@
     </div>
 
     <!-- Unterbox 1: Saunen & Übersicht -->
-    <details class="ac sub" open id="boxSaunas">
+    <details class="ac sub" open id="boxSaunas" data-jump-target>
       <summary><div class="ttl">▶<span class="chev">⮞</span> Saunen & Übersicht</div>
  <div class="actions"><button class="btn sm" id="btnAddSauna">Sauna hinzufügen</button></div>
 </summary>      
@@ -205,13 +345,13 @@
     </details>
 
     <!-- Unterbox 2: Fußnoten & Badges -->
-    <details class="ac sub" id="boxFootnotes">
+    <details class="ac sub" id="boxFootnotes" data-jump-target>
   <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Fußnoten &amp; Badges</div>
     <div class="actions"><button class="btn sm" id="fnAdd">Fußnote hinzufügen</button></div>
   </summary>
   <div class="content">
-    <div class="footnote-section" id="footnoteSection">
+    <div class="footnote-section" id="footnoteSection" data-jump-target>
       <div class="footnote-header">
         <button class="footnote-toggle" type="button" id="footnoteToggle" aria-expanded="false" aria-controls="footnoteBody">Fußnoten verwalten</button>
       </div>
@@ -230,7 +370,7 @@
         <option value="stacked">Untereinander (jede Zeile)</option>
       </select>
     </div>
-    <div class="badge-lib-section" id="badgeLibrarySection">
+    <div class="badge-lib-section" id="badgeLibrarySection" data-jump-target>
       <div class="badge-lib-header">
         <button class="badge-lib-toggle" type="button" id="badgeLibraryToggle" aria-expanded="false" aria-controls="badgeLibraryBody">Badge-Bibliothek</button>
         <button class="btn sm" id="badgeAdd" type="button">Badge hinzufügen</button>
@@ -259,13 +399,13 @@
 </details>
 
     <!-- Unterbox 4: Globale Zusatzinhalte & Informationen -->
-    <details class="ac sub" id="boxStories">
+    <details class="ac sub" id="boxStories" data-jump-target>
       <summary>
         <div class="ttl">▶<span class="chev">⮞</span> Global Zusatzinhalte &amp; Informationen</div>
       </summary>
       <div class="content global-info-pane">
         <div class="global-info-sections">
-          <details class="info-fold" id="infoWellness" open>
+          <details class="info-fold" id="infoWellness" open data-jump-target>
             <summary>Wellness-Tipps</summary>
             <div class="info-fold-body">
               <div class="extras-group" id="extrasWellness">
@@ -277,7 +417,7 @@
               </div>
             </div>
           </details>
-          <details class="info-fold" id="infoEvents" open>
+          <details class="info-fold" id="infoEvents" open data-jump-target>
             <summary>Event-Countdowns</summary>
             <div class="info-fold-body">
               <div class="extras-group" id="extrasEvents">
@@ -290,7 +430,7 @@
               </div>
             </div>
           </details>
-          <details class="info-fold" id="infoGastro" open>
+          <details class="info-fold" id="infoGastro" open data-jump-target>
             <summary>Gastro-Infos</summary>
             <div class="info-fold-body">
               <div class="extras-group" id="extrasGastro">
@@ -302,7 +442,7 @@
               </div>
             </div>
           </details>
-          <details class="info-fold" id="infoHero">
+          <details class="info-fold" id="infoHero" data-jump-target>
             <summary>Hero-Timeline</summary>
             <div class="info-fold-body hero-fold-body">
               <div class="kv">
@@ -324,7 +464,7 @@
               </div>
             </div>
           </details>
-          <details class="info-fold" id="infoStories">
+          <details class="info-fold" id="infoStories" data-jump-target>
             <summary>Story-Slides</summary>
             <div class="info-fold-body story-fold-body">
               <div class="info-fold-actions"><button class="btn sm" id="btnStoryAdd">Information hinzufügen</button></div>
@@ -342,7 +482,7 @@
     </details>
 
     <!-- Unterbox 4: Medien-Slides -->
-    <details class="ac sub" id="boxImages">
+    <details class="ac sub" id="boxImages" data-jump-target>
 <summary>
     <div class="ttl">▶<span class="chev">⮞</span> Medien-Slides</div>
     <div class="actions"><button class="btn sm" id="btnMediaAdd">Medien hinzufügen</button></div>
@@ -365,14 +505,14 @@
   </div>
 </details>
 
- <details class="ac full" id="boxSlidesText">
+ <details class="ac full" id="boxSlidesText" data-jump-target>
         <summary>
           <div class="ttl">▶<span class="chev">⮞</span> Slideshow & Text</div>
           <div class="actions"><button class="btn sm ghost" id="resetSlides">Standardwerte</button></div>
         </summary>
         <div class="content">
           <div class="layout-display-block">
-            <details class="layout-display-fold" id="displayLayoutFold" open>
+            <details class="layout-display-fold" id="displayLayoutFold" open data-jump-target>
               <summary class="layout-display-summary">
                 <span class="layout-display-summary-text">
                   <span class="layout-display-summary-title">Darstellung &amp; Seiten</span>
@@ -436,7 +576,7 @@
               <div class="settings-card-body">
                 <div class="kv">
                   <label>Stil-Paletten</label>
-                  <div class="style-set-controls">
+                  <div class="style-set-controls" id="styleSetControls" data-jump-target>
                     <select id="styleSetSelect" class="input"></select>
                     <div class="row" style="gap:6px;flex-wrap:wrap">
                       <button class="btn sm" id="styleSetApply" type="button">Aktivieren</button>
@@ -738,6 +878,164 @@
   </div>
 </div>
 
+<script>
+  (function(){
+    const cockpit = document.querySelector('.workspace-overview');
+    if (!cockpit) return;
+    const body = cockpit.querySelector('.workspace-body');
+    if (!body) return;
+
+    const pinBtn = cockpit.querySelector('[data-action="pin"]');
+    const toggleBtn = cockpit.querySelector('[data-action="toggle"]');
+
+    let storageAvailable = true;
+    try{
+      const testKey = '__cockpit__';
+      localStorage.setItem(testKey, '1');
+      localStorage.removeItem(testKey);
+    }catch(err){
+      storageAvailable = false;
+    }
+
+    const load = (key) => storageAvailable ? localStorage.getItem(key) : null;
+    const save = (key, value) => {
+      if (!storageAvailable) return;
+      if (value === null){
+        localStorage.removeItem(key);
+      }else{
+        localStorage.setItem(key, value);
+      }
+    };
+
+    const PIN_KEY = 'adminCockpitPinned';
+    const COLLAPSE_KEY = 'adminCockpitCollapsed';
+
+    const setPinState = (pinned) => {
+      cockpit.dataset.pinned = pinned ? 'true' : 'false';
+      if (pinBtn){
+        pinBtn.setAttribute('aria-pressed', String(pinned));
+        pinBtn.classList.toggle('is-active', pinned);
+        const label = pinBtn.querySelector('[data-role="label"]');
+        const icon = pinBtn.querySelector('[data-role="icon"]');
+        if (label){
+          const onText = label.dataset.labelPinned || label.textContent;
+          const offText = label.dataset.labelUnpinned || label.textContent;
+          label.textContent = pinned ? onText : offText;
+        }
+        if (icon){
+          const onIcon = icon.dataset.iconPinned || icon.textContent;
+          const offIcon = icon.dataset.iconUnpinned || icon.textContent;
+          icon.textContent = pinned ? onIcon : offIcon;
+        }
+        pinBtn.setAttribute('title', pinned ? 'Cockpit lösen' : 'Cockpit anheften');
+      }
+      save(PIN_KEY, pinned ? '1' : null);
+    };
+
+    const setCollapseState = (collapsed) => {
+      cockpit.dataset.collapsed = collapsed ? 'true' : 'false';
+      body.hidden = collapsed;
+      if (toggleBtn){
+        toggleBtn.setAttribute('aria-expanded', String(!collapsed));
+        toggleBtn.classList.toggle('is-active', !collapsed);
+        const label = toggleBtn.querySelector('[data-role="label"]');
+        const icon = toggleBtn.querySelector('[data-role="icon"]');
+        if (label){
+          const expandedText = label.dataset.labelExpanded || label.textContent;
+          const collapsedText = label.dataset.labelCollapsed || label.textContent;
+          label.textContent = collapsed ? collapsedText : expandedText;
+        }
+        if (icon){
+          const expandedIcon = icon.dataset.iconExpanded || icon.textContent;
+          const collapsedIcon = icon.dataset.iconCollapsed || icon.textContent;
+          icon.textContent = collapsed ? collapsedIcon : expandedIcon;
+        }
+        toggleBtn.setAttribute('title', collapsed ? 'Cockpit öffnen' : 'Cockpit minimieren');
+      }
+      save(COLLAPSE_KEY, collapsed ? '1' : null);
+    };
+
+    let pinned = load(PIN_KEY) === '1';
+    let collapsed = load(COLLAPSE_KEY) === '1';
+
+    setPinState(pinned);
+    setCollapseState(collapsed);
+
+    pinBtn?.addEventListener('click', () => {
+      pinned = !pinned;
+      setPinState(pinned);
+    });
+
+    toggleBtn?.addEventListener('click', () => {
+      collapsed = !collapsed;
+      setCollapseState(collapsed);
+    });
+  })();
+</script>
+<script>
+  (function(){
+    const jumpButtons = document.querySelectorAll('[data-jump]');
+    if (!jumpButtons.length) return;
+
+    const ensureDetailsOpen = (element) => {
+      if (!element) return;
+      if (element.matches('details')) {
+        element.open = true;
+      }
+      let parent = element.closest('details');
+      while (parent) {
+        parent.open = true;
+        parent = parent.parentElement?.closest('details');
+      }
+    };
+
+    const getScrollTarget = (element) => {
+      if (!element) return null;
+      if (element.hasAttribute('data-jump-target')) {
+        return element;
+      }
+      return element.closest('[data-jump-target]') || element;
+    };
+
+    const highlight = (element) => {
+      if (!element) return;
+      element.classList.remove('jump-flash');
+      void element.offsetWidth;
+      element.classList.add('jump-flash');
+      window.setTimeout(() => element.classList.remove('jump-flash'), 1600);
+    };
+
+    const canFocus = (element) => {
+      if (!(element instanceof HTMLElement)) return false;
+      if (element.tabIndex >= 0) return true;
+      return /^(A|BUTTON|SUMMARY|INPUT|SELECT|TEXTAREA)$/i.test(element.tagName);
+    };
+
+    jumpButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const targetId = button.dataset.jump;
+        if (!targetId) return;
+        const target = document.getElementById(targetId);
+        if (!target) return;
+
+        ensureDetailsOpen(target);
+
+        const scrollTarget = getScrollTarget(target);
+        window.requestAnimationFrame(() => {
+          scrollTarget?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          const highlightEl = target.matches('details')
+            ? target.querySelector(':scope > summary') || scrollTarget
+            : scrollTarget;
+          highlight(highlightEl);
+          if (highlightEl && typeof highlightEl.focus === 'function' && canFocus(highlightEl)) {
+            highlightEl.focus({ preventScroll: true });
+          }
+        });
+      });
+    });
+  })();
+</script>
 <script>
 
   (function(){


### PR DESCRIPTION
## Summary
- replace the admin cockpit intro with a compact toolbar and comprehensive quick access cards
- add branch buttons and jump targets so footnotes, info folds, layout tools, and style palettes are reachable directly
- implement pin and collapse behaviour with stored preferences and refresh workspace styling for the new layout

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d67a8a89008320acdfe6e65b94cd46