### PR TITLE
Fix admin overlay issues and badge library persistence

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -2110,9 +2110,9 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
 
 /* Ansicht-Menü (Header) */
 #btnDevices, #viewMenuWrap{ flex-shrink:0; }
-.menuwrap{ position:relative; }
+.menuwrap{ position:relative; z-index:120; }
 .dropdown{
-  position:absolute; top:calc(100% + 6px); left:0; z-index:80;
+  position:absolute; top:calc(100% + 6px); left:0; z-index:200;
   min-width: 220px; padding:6px;
   background:var(--panel); border:1px solid var(--border); border-radius:12px;
   box-shadow:0 12px 24px rgba(0,0,0,.12);

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -921,28 +921,47 @@
       return cockpit.offsetHeight;
     };
 
+    let devicesObserver = null;
+    let observedPane = null;
+
     const updateOffsets = () => {
       const headerHeight = header?.offsetHeight || 0;
       const pinned = cockpit.dataset.pinned === 'true';
       const cockpitHeight = pinned ? resolveCockpitHeight() : 0;
-      const workspaceOffset = Math.max(132, headerHeight + cockpitHeight + (pinned ? 28 : 24));
+      const cockpitStyle = pinned ? window.getComputedStyle(cockpit) : null;
+      const cockpitMarginBottom = pinned ? Number.parseFloat(cockpitStyle?.marginBottom || '0') || 0 : 0;
+      const workspaceGap = pinned ? Math.max(20, cockpitMarginBottom + 12) : 24;
+      const workspaceOffset = Math.max(132, headerHeight + cockpitHeight + workspaceGap);
       const stickTop = headerHeight + 12;
-      const devicesOffset = headerHeight + cockpitHeight + 12;
+      const baseDevicesOffset = headerHeight + 12;
+      const devicesOffset = Math.max(baseDevicesOffset, headerHeight + cockpitHeight + cockpitMarginBottom + 12);
 
       root?.style.setProperty('--workspace-offset', `${workspaceOffset}px`);
       root?.style.setProperty('--cockpit-stick-top', `${stickTop}px`);
       root?.style.setProperty('--devices-offset', `${devicesOffset}px`);
       root?.style.setProperty('scroll-padding-top', `${workspaceOffset}px`);
       document.body?.style.setProperty('scroll-padding-top', `${workspaceOffset}px`);
+
+      const pane = document.getElementById('devicesPane');
+      if (pane !== observedPane) {
+        devicesObserver?.disconnect();
+        devicesObserver = null;
+        observedPane = null;
+        if (pane && 'ResizeObserver' in window) {
+          devicesObserver = new ResizeObserver(() => scheduleUpdate());
+          devicesObserver.observe(pane);
+          observedPane = pane;
+        }
+      }
     };
 
-    const scheduleUpdate = () => {
+    function scheduleUpdate(){
       if ('requestAnimationFrame' in window) {
         window.requestAnimationFrame(updateOffsets);
       } else {
         updateOffsets();
       }
-    };
+    }
 
     if ('ResizeObserver' in window){
       const resizeObserver = new ResizeObserver(() => scheduleUpdate());
@@ -958,6 +977,11 @@
     }
 
     window.addEventListener('resize', scheduleUpdate, { passive:true });
+    window.addEventListener('beforeunload', () => {
+      devicesObserver?.disconnect();
+      devicesObserver = null;
+      observedPane = null;
+    }, { once:true });
 
     const pinBtn = cockpit.querySelector('[data-action="pin"]');
     const toggleBtn = cockpit.querySelector('[data-action="toggle"]');

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -2310,6 +2310,17 @@ export function renderSlidesMaster(){
     };
     if (!badgeListHost) return;
 
+    const finalizeOpenEditors = () => {
+      if (!badgeListHost) return;
+      badgeListHost.querySelectorAll('.badge-lib-label').forEach((input) => {
+        if (input instanceof HTMLInputElement) {
+          input.dispatchEvent(new Event('blur'));
+        }
+      });
+    };
+
+    finalizeOpenEditors();
+
     const emojiInput = $('#badgeEmojiInput');
     const emojiAddBtn = $('#badgeEmojiAdd');
     const emojiCustomList = $('#badgeEmojiCustom');
@@ -2569,6 +2580,7 @@ export function renderSlidesMaster(){
       });
 
       removeBtn.addEventListener('click', () => {
+        finalizeOpenEditors();
         const listRef = ensureBadgeLibrary(settings);
         listRef.splice(index, 1);
         renderBadgeLibraryRows();
@@ -2585,6 +2597,7 @@ export function renderSlidesMaster(){
 
   if (badgeAddBtn){
     badgeAddBtn.onclick = () => {
+      finalizeOpenEditors();
       const list = ensureBadgeLibrary(settings);
       list.push({ id: genId('bdg_'), icon:'', label:'' });
       setBadgeSectionExpanded(true);


### PR DESCRIPTION
## Summary
- raise the view menu dropdown above the cockpit so it is no longer covered
- refine the dynamic cockpit/device offset handling and observe the device pane size to keep sticky panes from overlapping the grid and preview
- commit pending badge label edits before re-rendering so changes stay intact when adding or removing badges

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a184fdf08320be5058cbde3d651b