### PR TITLE
Add container stack, telemetry monitoring, and admin role controls

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2022: true
+  },
+  extends: ['eslint:recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  ignorePatterns: ['node_modules/', 'webroot/assets/', 'webroot/data/', 'vendor/'],
+  rules: {
+    'no-console': 'off',
+    'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.log
 *.tmp
 .DS_Store
+node_modules/
+coverage/
+pnpm-lock.yaml
+yarn.lock
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -32,3 +32,56 @@ and prints the URLs and configuration paths when finished.
 Environment variables such as `SIGNAGE_PUBLIC_PORT`, `SIGNAGE_ADMIN_PORT`,
 `SIGNAGE_ADMIN_USER` and `SIGNAGE_ADMIN_PASS` can still be set to override
 the defaults.
+
+### Preflight checks
+
+Before deploying on a fresh host you can run the non-destructive preflight
+script. It verifies that Docker is installed, checks port availability and
+ensures sufficient disk space and write permissions:
+
+```bash
+scripts/preflight.sh
+```
+
+The installer invokes this script automatically (use `--skip-preflight` to
+skip it when re-running on the same machine).
+
+### Local development with Docker
+
+A lightweight Docker Compose stack is available for local development. It
+provisions PHP-FPM and nginx containers and mounts the repository into the
+containers for hot reloading:
+
+```bash
+docker compose up --build
+```
+
+The admin UI is then reachable at <http://localhost:8080/admin/> while the
+public signage runs on <http://localhost:8080/>.
+
+### Tests and linting
+
+JavaScript tooling is managed through `npm`. Install dependencies once and use
+Vitest for unit tests as well as ESLint for static analysis:
+
+```bash
+npm install
+npm run test
+npm run lint
+```
+
+### User and role management
+
+The admin APIs now support role-based access control. Create and maintain user
+accounts via the CLI helper:
+
+```bash
+php scripts/users.php add alice editor
+php scripts/users.php list
+php scripts/users.php delete bob
+```
+
+Available roles are `viewer`, `editor` and `admin`. When at least one user is
+defined the API requires HTTP Basic authentication. Accounts are stored in
+`data/users.json` and all write operations are logged to `data/audit.log` with
+the acting username and payload metadata.

--- a/config/auth/users.example.json
+++ b/config/auth/users.example.json
@@ -1,0 +1,10 @@
+{
+  "users": [
+    {
+      "username": "admin",
+      "displayName": "Administrator",
+      "password": "$2y$10$examplehashreplacewithscripts",
+      "roles": ["admin"]
+    }
+  ]
+}

--- a/config/php/opcache.ini
+++ b/config/php/opcache.ini
@@ -1,0 +1,6 @@
+opcache.enable=1
+opcache.enable_cli=1
+opcache.validate_timestamps=${PHP_OPCACHE_VALIDATE_TIMESTAMPS}
+opcache.max_accelerated_files=${PHP_OPCACHE_MAX_ACCELERATED_FILES}
+opcache.memory_consumption=${PHP_OPCACHE_MEMORY_CONSUMPTION}
+opcache.interned_strings_buffer=16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  php:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+    volumes:
+      - ./webroot:/var/www/html:rw,cached
+      - ./config/php:/usr/local/etc/php/conf.d:ro
+      - ./webroot/data:/var/www/html/data
+    environment:
+      - PHP_OPCACHE_VALIDATE_TIMESTAMPS=1
+      - PHP_OPCACHE_MAX_ACCELERATED_FILES=20000
+      - PHP_OPCACHE_MEMORY_CONSUMPTION=256
+    healthcheck:
+      test: ["CMD", "php", "-m"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  nginx:
+    image: nginx:1.25-alpine
+    depends_on:
+      - php
+    ports:
+      - "8080:80"
+    volumes:
+      - ./webroot:/var/www/html:ro
+      - ./webroot/data:/var/www/html/data:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost/ >/dev/null 2>&1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /var/www/html;
+    index index.php index.html;
+
+    access_log /var/log/nginx/access.log main;
+    error_log  /var/log/nginx/error.log warn;
+
+    location /admin/api/ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass php:9000;
+    }
+
+    location /admin/ {
+        try_files $uri /admin/index.html;
+    }
+
+    location /api/ {
+        try_files $uri =404;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass php:9000;
+    }
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass php:9000;
+    }
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:8.2-fpm-alpine
+
+RUN set -eux; \
+    apk add --no-cache bash curl git icu-libs icu-data-full; \
+    docker-php-ext-install opcache
+
+WORKDIR /var/www/html
+
+COPY --chown=www-data:www-data webroot/ /var/www/html/
+COPY --chown=www-data:www-data config/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=1 \
+    PHP_OPCACHE_MAX_ACCELERATED_FILES=20000 \
+    PHP_OPCACHE_MEMORY_CONSUMPTION=256
+
+CMD ["php-fpm"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "htmlsignage",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint webroot/admin/js --ext .js"
+  },
+  "devDependencies": {
+    "@eslint/js": "^8.57.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-import": "^2.29.1",
+    "vitest": "^1.6.0"
+  }
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log(){ printf '\033[1;34m[CHECK]\033[0m %s\n' "$*"; }
+warn(){ printf '\033[1;33m[WARN ]\033[0m %s\n' "$*"; }
+fail(){ printf '\033[1;31m[FAIL]\033[0m %s\n' "$*"; }
+ok(){ printf '\033[1;32m[ OK ]\033[0m %s\n' "$*"; }
+
+REQUIRED_CMDS=(docker)
+REQUIRED_PORTS=(80 443)
+MIN_DISK_MB=2048
+
+check_commands(){
+  local missing=0
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      fail "Command '$cmd' missing";
+      missing=1
+    else
+      ok "Found $cmd"
+    fi
+  done
+  if command -v docker >/dev/null 2>&1; then
+    if docker compose version >/dev/null 2>&1; then
+      ok "Docker Compose plugin available"
+    elif command -v docker-compose >/dev/null 2>&1; then
+      ok "docker-compose CLI available"
+    else
+      fail "Docker Compose not installed (plugin or docker-compose)"
+      missing=1
+    fi
+  fi
+  if [[ $missing -eq 1 ]]; then
+    warn "Install missing commands before continuing."
+    return 1
+  fi
+}
+
+check_ports(){
+  local busy=0
+  for port in "${REQUIRED_PORTS[@]}"; do
+    local listeners=""
+    if command -v ss >/dev/null 2>&1; then
+      listeners=$(ss -lnt 2>/dev/null | awk 'NR>1 {print $4}')
+    elif command -v netstat >/dev/null 2>&1; then
+      listeners=$(netstat -lnt 2>/dev/null | awk 'NR>2 {print $4}')
+    else
+      warn "Cannot inspect ports – missing ss/netstat"
+      continue
+    }
+    if printf '%s\n' "$listeners" | grep -qE "[:.]${port}$"; then
+      warn "Port ${port} already in use"
+      busy=1
+    else
+      ok "Port ${port} available"
+    fi
+  done
+  [[ $busy -eq 0 ]]
+}
+
+check_disk(){
+  local avail
+  avail=$(df -Pm . | awk 'NR==2 {print $4}')
+  if [[ -z $avail ]]; then
+    warn "Could not determine free disk space"
+    return 0
+  fi
+  if (( avail < MIN_DISK_MB )); then
+    fail "Only ${avail}MB free, ${MIN_DISK_MB}MB required"
+    return 1
+  fi
+  ok "Disk space OK (${avail}MB free)"
+}
+
+check_permissions(){
+  if [[ ! -w webroot/data ]]; then
+    warn "webroot/data is not writable by current user"
+    return 1
+  fi
+  ok "webroot/data writable"
+}
+
+run_all(){
+  local status=0
+  log "Running deployment preflight checks"
+  check_commands || status=1
+  check_ports || status=1
+  check_disk || status=1
+  check_permissions || status=1
+
+  if [[ $status -ne 0 ]]; then
+    fail "Preflight checks failed"
+    exit 1
+  fi
+  ok "All checks passed"
+}
+
+run_all "$@"

--- a/scripts/users.php
+++ b/scripts/users.php
@@ -1,0 +1,105 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../webroot/admin/api/auth/users_store.php';
+
+function usage(): void
+{
+    echo "Usage:\n";
+    echo "  php scripts/users.php list\n";
+    echo "  php scripts/users.php add <username> [roles]\n";
+    echo "  php scripts/users.php delete <username>\n";
+    echo "\nRoles: viewer, editor, admin (default: viewer)\n";
+    exit(1);
+}
+
+function prompt_hidden(string $prompt): string
+{
+    if (!function_exists('posix_isatty') || !posix_isatty(STDIN)) {
+        echo $prompt;
+        return trim((string) fgets(STDIN));
+    }
+    echo $prompt;
+    $stty = shell_exec('stty -g');
+    system('stty -echo');
+    $value = trim((string) fgets(STDIN));
+    if ($stty) {
+        system('stty ' . $stty);
+    } else {
+        system('stty echo');
+    }
+    echo PHP_EOL;
+    return $value;
+}
+
+$argv = $_SERVER['argv'] ?? [];
+$command = $argv[1] ?? 'help';
+
+switch ($command) {
+    case 'list':
+        $state = auth_users_load();
+        if (empty($state['users'])) {
+            echo "No users configured.\n";
+            exit(0);
+        }
+        foreach ($state['users'] as $user) {
+            $roles = implode(',', auth_user_roles($user));
+            $display = $user['displayName'] ?? '';
+            echo $user['username'];
+            if ($display !== '') {
+                echo " ({$display})";
+            }
+            echo " – roles: {$roles}\n";
+        }
+        exit(0);
+
+    case 'add':
+    case 'update':
+        $username = $argv[2] ?? '';
+        if ($username === '') {
+            usage();
+        }
+        $rolesArg = $argv[3] ?? 'viewer';
+        $roles = array_values(array_filter(array_map('trim', preg_split('/[,\s]+/', $rolesArg) ?: [])));
+        if (!$roles) {
+            $roles = ['viewer'];
+        }
+        $password = getenv('SIGNAGE_USER_PASSWORD') ?: prompt_hidden('Password: ');
+        if ($password === '') {
+            fwrite(STDERR, "Password required\n");
+            exit(1);
+        }
+        $confirm = getenv('SIGNAGE_USER_PASSWORD_CONFIRM') ?: prompt_hidden('Repeat password: ');
+        if ($password !== $confirm) {
+            fwrite(STDERR, "Passwords do not match\n");
+            exit(1);
+        }
+        $displayName = getenv('SIGNAGE_USER_DISPLAY') ?: '';
+        $user = [
+            'username' => $username,
+            'roles' => $roles,
+            'password' => auth_hash_password($password),
+        ];
+        if ($displayName !== '') {
+            $user['displayName'] = $displayName;
+        }
+        auth_users_set($user);
+        echo "User '{$username}' saved.\n";
+        exit(0);
+
+    case 'delete':
+        $username = $argv[2] ?? '';
+        if ($username === '') {
+            usage();
+        }
+        if (auth_users_remove($username)) {
+            echo "User '{$username}' removed.\n";
+            exit(0);
+        }
+        fwrite(STDERR, "User not found.\n");
+        exit(1);
+
+    default:
+        usage();
+}

--- a/tests/device_service.test.js
+++ b/tests/device_service.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSeconds,
+  resolveNowSeconds,
+  __TEST__
+} from '../webroot/admin/js/core/device_service.js';
+
+const { sanitizeStatus, sanitizeMetrics, sanitizeHistory } = __TEST__;
+
+describe('device service helpers', () => {
+  it('normalizes various timestamp units', () => {
+    expect(normalizeSeconds(1700000000000)).toBe(1700000000);
+    expect(normalizeSeconds('170')).toBe(170);
+    expect(normalizeSeconds(null)).toBe(0);
+    expect(normalizeSeconds('foo')).toBe(0);
+  });
+
+  it('resolves current time when missing', () => {
+    const result = resolveNowSeconds();
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('sanitizes status details', () => {
+    const status = sanitizeStatus({
+      firmware: ' 1.2.3 ',
+      appVersion: ' Player 4 ',
+      ip: '192.168.0.10 ',
+      notes: 'Needs maintenance',
+      network: { type: 'wifi', quality: 87.4, rssi: -44.1, ssid: 'Guest' },
+      errors: [
+        { code: 'E1', message: 'Overheat ', ts: 1700000000 },
+        'Loose cable'
+      ]
+    });
+    expect(status.firmware).toBe('1.2.3');
+    expect(status.network.quality).toBe(87);
+    expect(status.errors).toHaveLength(2);
+    expect(status.errors[0]).toMatchObject({ code: 'E1', message: 'Overheat', ts: 1700000000 });
+  });
+
+  it('sanitizes metrics', () => {
+    const metrics = sanitizeMetrics({
+      cpuLoad: '34.2',
+      memoryUsage: 61,
+      temperature: '41'
+    });
+    expect(metrics).toMatchObject({ cpuLoad: 34.2, memoryUsage: 61, temperature: 41 });
+  });
+
+  it('sanitizes heartbeat history', () => {
+    const history = sanitizeHistory([
+      { ts: 1700000000, status: { firmware: '1.0.0' }, metrics: { cpuLoad: 20 } },
+      { ts: 'bad' }
+    ], 1700000300);
+    expect(history).toHaveLength(1);
+    expect(history[0].ago).toBe(300);
+    expect(history[0].status.firmware).toBe('1.0.0');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.js'],
+    coverage: {
+      reporter: ['text', 'lcov'],
+      enabled: false
+    }
+  }
+});

--- a/webroot/admin/api/auth/guard.php
+++ b/webroot/admin/api/auth/guard.php
@@ -1,0 +1,118 @@
+<?php
+// Authentifizierungs- und Autorisierungshelfer
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/users_store.php';
+
+const SIGNAGE_AUTH_REALM = 'HTMLSignage Admin';
+
+function auth_is_enabled(): bool
+{
+    static $cached = null;
+    if ($cached === null) {
+        $state = auth_users_load();
+        $cached = !empty($state['users']);
+    }
+    return $cached;
+}
+
+function auth_resolve_basic_credentials(): ?array
+{
+    $user = $_SERVER['PHP_AUTH_USER'] ?? null;
+    $pass = $_SERVER['PHP_AUTH_PW'] ?? null;
+    if ($user !== null) {
+        return ['username' => (string) $user, 'password' => (string) $pass];
+    }
+    $header = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? null;
+    if (!$header || stripos($header, 'Basic ') !== 0) {
+        return null;
+    }
+    $decoded = base64_decode(substr($header, 6), true);
+    if (!$decoded) {
+        return null;
+    }
+    if (!str_contains($decoded, ':')) {
+        return null;
+    }
+    [$username, $password] = explode(':', $decoded, 2);
+    return ['username' => $username, 'password' => $password];
+}
+
+function auth_get_request_user(): ?array
+{
+    static $resolved = null;
+    if ($resolved !== null) {
+        return $resolved;
+    }
+    if (!auth_is_enabled()) {
+        $resolved = null;
+        return null;
+    }
+    $credentials = auth_resolve_basic_credentials();
+    if (!$credentials || $credentials['username'] === '') {
+        $resolved = null;
+        return null;
+    }
+    $user = auth_users_find($credentials['username']);
+    if (!$user || empty($user['password'])) {
+        $resolved = null;
+        return null;
+    }
+    if (!auth_verify_password($credentials['password'] ?? '', (string) $user['password'])) {
+        $resolved = null;
+        return null;
+    }
+    $resolved = $user;
+    return $resolved;
+}
+
+function auth_send_unauthorized(): void
+{
+    header('WWW-Authenticate: Basic realm="' . SIGNAGE_AUTH_REALM . '", charset="UTF-8"');
+    http_response_code(401);
+    echo json_encode(['ok' => false, 'error' => 'auth-required']);
+    exit;
+}
+
+function auth_send_forbidden(): void
+{
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'error' => 'forbidden']);
+    exit;
+}
+
+function auth_require_role(string $role): array
+{
+    if (!auth_is_enabled()) {
+        return ['username' => 'system', 'roles' => ['admin']];
+    }
+    $user = auth_get_request_user();
+    if ($user === null) {
+        auth_send_unauthorized();
+    }
+    if (!auth_user_has_role($user, $role)) {
+        auth_send_forbidden();
+    }
+    auth_register_last_user($user);
+    return $user;
+}
+
+function auth_register_last_user(array $user): void
+{
+    $GLOBALS['__signage_auth_last_user'] = $user;
+}
+
+function auth_current_user(): ?array
+{
+    return $GLOBALS['__signage_auth_last_user'] ?? auth_get_request_user();
+}
+
+function auth_audit(string $event, array $context = []): void
+{
+    $user = auth_current_user();
+    if ($user) {
+        $context['user'] = $user['username'];
+    }
+    auth_append_audit($event, $context);
+}

--- a/webroot/admin/api/devices_claim.php
+++ b/webroot/admin/api/devices_claim.php
@@ -1,7 +1,10 @@
 <?php
 // Hängt am ADMIN-VHost (BasicAuth schützt), nicht im öffentlichen /pair/*
 header('Content-Type: application/json; charset=UTF-8');
-require_once __DIR__.'/devices_store.php';
+require_once __DIR__ . '/auth/guard.php';
+require_once __DIR__ . '/devices_store.php';
+
+auth_require_role('editor');
 
 $raw = file_get_contents('php://input');
 $in  = json_decode($raw, true);
@@ -21,5 +24,10 @@ $db['devices'][$id] = [
 ];
 $db['pairings'][$code]['deviceId'] = $id;
 devices_save($db);
+auth_audit('device.claim', [
+  'code' => $code,
+  'deviceId' => $id,
+  'name' => $name !== '' ? $name : null
+]);
 
 echo json_encode(['ok'=>true,'deviceId'=>$id]);

--- a/webroot/admin/api/devices_gc.php
+++ b/webroot/admin/api/devices_gc.php
@@ -1,6 +1,8 @@
 <?php
 // /admin/api/devices_gc.php – aufräumen & reparieren (vollständig)
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('editor');
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
@@ -37,4 +39,8 @@ foreach (($db['pairings'] ?? []) as $code => $row) {
 }
 
 if (!devices_save($db)) { echo json_encode(['ok'=>false,'error'=>'save-failed']); exit; }
+auth_audit('device.gc', [
+  'deletedDevices' => $deletedDevices,
+  'deletedPairings' => $deletedPairings
+]);
 echo json_encode(['ok'=>true,'deletedDevices'=>$deletedDevices,'deletedPairings'=>$deletedPairings]);

--- a/webroot/admin/api/devices_list.php
+++ b/webroot/admin/api/devices_list.php
@@ -3,7 +3,9 @@
 // Warum: Die Admin-UI erwartet dieses Format; gemischte Ausgabe verursachte
 // "undefined"-Einträge & fehlschlagendes Löschen.
 
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('viewer');
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
@@ -48,7 +50,12 @@ foreach (($db['devices'] ?? []) as $id => $d) {
     'overrides' => [
       'settings' => $overrides['settings'] ?? (object)[],
       'schedule' => $overrides['schedule'] ?? (object)[]
-    ]
+    ],
+    'status' => isset($d['status']) && is_array($d['status']) ? $d['status'] : (object)[],
+    'metrics' => isset($d['metrics']) && is_array($d['metrics']) ? $d['metrics'] : (object)[],
+    'heartbeatHistory' => isset($d['heartbeatHistory']) && is_array($d['heartbeatHistory'])
+      ? array_slice(array_values($d['heartbeatHistory']), -10)
+      : []
   ];
 }
 

--- a/webroot/admin/api/devices_pending.php
+++ b/webroot/admin/api/devices_pending.php
@@ -1,5 +1,7 @@
 <?php
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('viewer');
 header('Content-Type: application/json; charset=UTF-8');
 
 $state = devices_load(); // liest /var/www/signage/data/devices.json

--- a/webroot/admin/api/devices_rename.php
+++ b/webroot/admin/api/devices_rename.php
@@ -1,5 +1,7 @@
 <?php
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('editor');
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
@@ -36,5 +38,10 @@ try {
   echo json_encode(['ok'=>false, 'error'=>'save-failed']);
   exit;
 }
+
+auth_audit('device.rename', [
+  'deviceId' => $devIn,
+  'name' => $name
+]);
 
 echo json_encode(['ok'=>true, 'device'=>$devIn, 'name'=>$name]);

--- a/webroot/admin/api/devices_save_override.php
+++ b/webroot/admin/api/devices_save_override.php
@@ -1,5 +1,7 @@
 <?php
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('editor');
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
@@ -38,6 +40,11 @@ $dev['devices'][$devId]['overrides']['settings'] = $set;
 if (!devices_save($dev)) {
   echo json_encode(['ok'=>false, 'error'=>'write-failed']); exit;
 }
+auth_audit('device.override', [
+  'deviceId' => $devId,
+  'settingsVersion' => $set['version'],
+  'scheduleVersion' => $sch['version'] ?? null
+]);
 echo json_encode([
   'ok'=>true,
   'version'=>$set['version'],

--- a/webroot/admin/api/devices_set_mode.php
+++ b/webroot/admin/api/devices_set_mode.php
@@ -1,5 +1,7 @@
 <?php
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('editor');
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
@@ -30,5 +32,10 @@ if (!devices_save($db)) {
   echo json_encode(['ok'=>false, 'error'=>'write-failed']);
   exit;
 }
+
+auth_audit('device.mode', [
+  'deviceId' => $devId,
+  'mode' => $mode
+]);
 
 echo json_encode(['ok'=>true]);

--- a/webroot/admin/api/devices_status.php
+++ b/webroot/admin/api/devices_status.php
@@ -1,6 +1,8 @@
 <?php
 // /var/www/signage/admin/api/devices_status.php
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('viewer');
 header('Content-Type: application/json; charset=UTF-8');
 
 $state = devices_load();

--- a/webroot/admin/api/devices_store.php
+++ b/webroot/admin/api/devices_store.php
@@ -9,6 +9,342 @@ require_once __DIR__ . '/storage.php';
 
 const DEVICES_ID_PATTERN = '/^dev_[a-f0-9]{12}$/';
 const DEVICES_CODE_PATTERN = '/^[A-Z]{6}$/';
+const DEVICES_HISTORY_LIMIT = 20;
+const DEVICES_MAX_ERRORS = 10;
+
+function devices_truncate_string(string $value, int $length): string
+{
+    if ($length <= 0) {
+        return '';
+    }
+    if (function_exists('mb_strlen') && function_exists('mb_substr')) {
+        if (mb_strlen($value, 'UTF-8') > $length) {
+            return mb_substr($value, 0, $length, 'UTF-8');
+        }
+        return $value;
+    }
+    return strlen($value) > $length ? substr($value, 0, $length) : $value;
+}
+
+function devices_optional_string($value, int $maxLength = 120): ?string
+{
+    if (!is_scalar($value)) {
+        return null;
+    }
+    $string = trim((string) $value);
+    if ($string === '') {
+        return null;
+    }
+    return devices_truncate_string($string, $maxLength);
+}
+
+function devices_sanitize_network($value): array
+{
+    if (!is_array($value)) {
+        return [];
+    }
+
+    $network = [];
+    $type = devices_optional_string($value['type'] ?? $value['interface'] ?? null, 40);
+    if ($type !== null) {
+        $network['type'] = $type;
+    }
+    $ssid = devices_optional_string($value['ssid'] ?? $value['networkName'] ?? null, 64);
+    if ($ssid !== null) {
+        $network['ssid'] = $ssid;
+    }
+    if (isset($value['quality']) && is_numeric($value['quality'])) {
+        $quality = max(0, min(100, (int) round((float) $value['quality'])));
+        $network['quality'] = $quality;
+    }
+    if (isset($value['signal']) && is_numeric($value['signal'])) {
+        $network['signal'] = (float) $value['signal'];
+    }
+    if (isset($value['rssi']) && is_numeric($value['rssi'])) {
+        $network['rssi'] = (int) round((float) $value['rssi']);
+    }
+
+    return $network;
+}
+
+function devices_sanitize_errors($value): array
+{
+    if (!is_array($value)) {
+        return [];
+    }
+
+    $errors = [];
+    foreach ($value as $entry) {
+        if (is_array($entry)) {
+            $code = devices_optional_string($entry['code'] ?? null, 64);
+            $message = devices_optional_string($entry['message'] ?? $entry['detail'] ?? null, 160);
+            $ts = isset($entry['ts']) ? (int) $entry['ts'] : null;
+            if ($code === null && $message === null) {
+                continue;
+            }
+            $item = [];
+            if ($code !== null) {
+                $item['code'] = $code;
+            }
+            if ($message !== null) {
+                $item['message'] = $message;
+            }
+            if ($ts) {
+                $item['ts'] = $ts;
+            }
+            $errors[] = $item;
+        } elseif (is_scalar($entry)) {
+            $message = devices_optional_string($entry, 160);
+            if ($message !== null) {
+                $errors[] = ['message' => $message];
+            }
+        }
+        if (count($errors) >= DEVICES_MAX_ERRORS) {
+            break;
+        }
+    }
+
+    return $errors;
+}
+
+function devices_sanitize_metrics($value): array
+{
+    if (!is_array($value)) {
+        return [];
+    }
+    $metrics = [];
+    $map = [
+        'cpuLoad' => ['cpuLoad', 'cpu', 'cpu_usage'],
+        'memoryUsage' => ['memoryUsage', 'memory', 'ram'],
+        'storageFree' => ['storageFree', 'storage_free', 'storageFreeMb'],
+        'storageUsed' => ['storageUsed', 'storage_used', 'storageUsedMb'],
+        'temperature' => ['temperature', 'temp'],
+        'uptime' => ['uptime', 'upTimeSeconds'],
+        'batteryLevel' => ['battery', 'batteryLevel']
+    ];
+
+    foreach ($map as $target => $candidates) {
+        foreach ($candidates as $candidate) {
+            if (!array_key_exists($candidate, $value)) {
+                continue;
+            }
+            $raw = $value[$candidate];
+            if (!is_numeric($raw)) {
+                continue;
+            }
+            $metrics[$target] = (float) $raw;
+            break;
+        }
+    }
+
+    return $metrics;
+}
+
+function devices_sanitize_status($value): array
+{
+    if (!is_array($value)) {
+        return [];
+    }
+
+    $status = [];
+
+    $firmware = devices_optional_string($value['firmware'] ?? $value['version'] ?? null, 100);
+    if ($firmware !== null) {
+        $status['firmware'] = $firmware;
+    }
+
+    $appVersion = devices_optional_string($value['appVersion'] ?? $value['player'] ?? null, 100);
+    if ($appVersion !== null) {
+        $status['appVersion'] = $appVersion;
+    }
+
+    $ip = devices_optional_string($value['ip'] ?? $value['address'] ?? null, 64);
+    if ($ip !== null) {
+        $status['ip'] = $ip;
+    }
+
+    $notes = devices_optional_string($value['notes'] ?? null, 180);
+    if ($notes !== null) {
+        $status['notes'] = $notes;
+    }
+
+    $networkSource = [];
+    if (isset($value['network']) && is_array($value['network'])) {
+        $networkSource = $value['network'];
+    }
+    if (isset($value['networkType']) && !isset($networkSource['type'])) {
+        $networkSource['type'] = $value['networkType'];
+    }
+    if (isset($value['signal']) && !isset($networkSource['signal'])) {
+        $networkSource['signal'] = $value['signal'];
+    }
+    if (isset($value['quality']) && !isset($networkSource['quality'])) {
+        $networkSource['quality'] = $value['quality'];
+    }
+    if (isset($value['ssid']) && !isset($networkSource['ssid'])) {
+        $networkSource['ssid'] = $value['ssid'];
+    }
+    $network = devices_sanitize_network($networkSource);
+    if (!empty($network)) {
+        $status['network'] = $network;
+    }
+
+    $errors = [];
+    if (isset($value['errors'])) {
+        $errors = devices_sanitize_errors($value['errors']);
+    } elseif (isset($value['lastError'])) {
+        $errors = devices_sanitize_errors([$value['lastError']]);
+    }
+    if (!empty($errors)) {
+        $status['errors'] = $errors;
+    }
+
+    return $status;
+}
+
+function devices_sanitize_history($history): array
+{
+    if (!is_array($history)) {
+        return [];
+    }
+    $normalized = [];
+    foreach ($history as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $ts = isset($entry['ts']) ? (int) $entry['ts'] : null;
+        if (!$ts) {
+            continue;
+        }
+        $row = ['ts' => $ts];
+        if (isset($entry['offline'])) {
+            $row['offline'] = (bool) $entry['offline'];
+        }
+        if (isset($entry['status'])) {
+            $status = devices_sanitize_status($entry['status']);
+            if (!empty($status)) {
+                $row['status'] = $status;
+            }
+        }
+        if (isset($entry['metrics'])) {
+            $metrics = devices_sanitize_metrics($entry['metrics']);
+            if (!empty($metrics)) {
+                $row['metrics'] = $metrics;
+            }
+        }
+        $normalized[] = $row;
+    }
+
+    usort($normalized, static function ($a, $b) {
+        return ($a['ts'] <=> $b['ts']);
+    });
+
+    $count = count($normalized);
+    if ($count > DEVICES_HISTORY_LIMIT) {
+        $normalized = array_slice($normalized, -DEVICES_HISTORY_LIMIT);
+    }
+
+    return array_values($normalized);
+}
+
+function devices_record_telemetry(array &$device, array $telemetry, int $timestamp): void
+{
+    if (!isset($device['heartbeatHistory']) || !is_array($device['heartbeatHistory'])) {
+        $device['heartbeatHistory'] = [];
+    }
+
+    $statusInput = [];
+    if (isset($telemetry['status']) && is_array($telemetry['status'])) {
+        $statusInput = $telemetry['status'];
+    }
+    foreach (['firmware', 'ip', 'network', 'errors', 'notes', 'appVersion'] as $key) {
+        if (isset($telemetry[$key]) && !isset($statusInput[$key])) {
+            $statusInput[$key] = $telemetry[$key];
+        }
+    }
+
+    $metricsInput = [];
+    if (isset($telemetry['metrics']) && is_array($telemetry['metrics'])) {
+        $metricsInput = $telemetry['metrics'];
+    }
+    foreach (['cpuLoad', 'memoryUsage', 'storageFree', 'storageUsed', 'temperature', 'uptime', 'batteryLevel'] as $key) {
+        if (isset($telemetry[$key]) && !isset($metricsInput[$key])) {
+            $metricsInput[$key] = $telemetry[$key];
+        }
+    }
+
+    $status = devices_sanitize_status($statusInput);
+    $metrics = devices_sanitize_metrics($metricsInput);
+
+    if (!empty($status)) {
+        $device['status'] = $status;
+    }
+    if (!empty($metrics)) {
+        $device['metrics'] = $metrics;
+    }
+
+    $history = devices_sanitize_history($device['heartbeatHistory']);
+    $history[] = array_filter([
+        'ts' => $timestamp,
+        'offline' => false,
+        'status' => !empty($status) ? $status : null,
+        'metrics' => !empty($metrics) ? $metrics : null,
+    ], static function ($value) {
+        return $value !== null;
+    });
+
+    if (count($history) > DEVICES_HISTORY_LIMIT) {
+        $history = array_slice($history, -DEVICES_HISTORY_LIMIT);
+    }
+
+    $device['heartbeatHistory'] = $history;
+}
+
+function devices_extract_telemetry_payload(array $payload): array
+{
+    $telemetry = [];
+
+    $status = [];
+    foreach (['firmware', 'appVersion', 'ip', 'notes'] as $key) {
+        if (isset($payload[$key])) {
+            $status[$key] = $payload[$key];
+        }
+    }
+    if (isset($payload['status']) && is_array($payload['status'])) {
+        $status = array_merge($payload['status'], $status);
+    }
+    if (isset($payload['network'])) {
+        if (!isset($status['network'])) {
+            $status['network'] = $payload['network'];
+        } elseif (is_array($status['network']) && is_array($payload['network'])) {
+            $status['network'] = array_merge($payload['network'], $status['network']);
+        }
+    }
+    if (!empty($status)) {
+        $telemetry['status'] = $status;
+    }
+
+    $metrics = [];
+    if (isset($payload['metrics']) && is_array($payload['metrics'])) {
+        $metrics = $payload['metrics'];
+    }
+    foreach (['cpuLoad', 'memoryUsage', 'storageFree', 'storageUsed', 'temperature', 'uptime', 'batteryLevel'] as $key) {
+        if (isset($payload[$key]) && !isset($metrics[$key])) {
+            $metrics[$key] = $payload[$key];
+        }
+    }
+    if (!empty($metrics)) {
+        $telemetry['metrics'] = $metrics;
+    }
+
+    if (isset($payload['errors']) && is_array($payload['errors'])) {
+        $telemetry['errors'] = $payload['errors'];
+    } elseif (isset($payload['status']['errors']) && is_array($payload['status']['errors'])) {
+        $telemetry['errors'] = $payload['status']['errors'];
+    }
+
+    return $telemetry;
+}
 
 function devices_path(): string
 {
@@ -118,6 +454,24 @@ function devices_normalize_state($state): array
             if (!isset($device['overrides']) || !is_array($device['overrides'])) {
                 $device['overrides'] = [];
             }
+            $status = devices_sanitize_status($device['status'] ?? []);
+            if (!empty($status)) {
+                $device['status'] = $status;
+            } else {
+                unset($device['status']);
+            }
+            $metrics = devices_sanitize_metrics($device['metrics'] ?? []);
+            if (!empty($metrics)) {
+                $device['metrics'] = $metrics;
+            } else {
+                unset($device['metrics']);
+            }
+            $history = devices_sanitize_history($device['heartbeatHistory'] ?? []);
+            if (!empty($history)) {
+                $device['heartbeatHistory'] = $history;
+            } else {
+                unset($device['heartbeatHistory']);
+            }
             $normalized['devices'][$id] = $device;
         }
     }
@@ -155,7 +509,7 @@ function devices_save(array &$db): bool
     return true;
 }
 
-function devices_touch_entry(array &$db, $id, ?int $timestamp = null): bool
+function devices_touch_entry(array &$db, $id, ?int $timestamp = null, array $telemetry = []): bool
 {
     $normalizedId = devices_normalize_device_id($id);
     if ($normalizedId === '' || !isset($db['devices'][$normalizedId]) || !is_array($db['devices'][$normalizedId])) {
@@ -164,6 +518,9 @@ function devices_touch_entry(array &$db, $id, ?int $timestamp = null): bool
     $ts = $timestamp ?? time();
     $db['devices'][$normalizedId]['lastSeen'] = $ts;
     $db['devices'][$normalizedId]['lastSeenAt'] = $ts;
+    if (!empty($telemetry)) {
+        devices_record_telemetry($db['devices'][$normalizedId], $telemetry, $ts);
+    }
     return true;
 }
 

--- a/webroot/admin/api/devices_touch.php
+++ b/webroot/admin/api/devices_touch.php
@@ -1,6 +1,9 @@
 <?php
 header('Content-Type: application/json; charset=UTF-8');
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+
+auth_require_role('viewer');
 
 $raw = file_get_contents('php://input');
 $payload = json_decode($raw, true);
@@ -21,7 +24,8 @@ if ($deviceId === '') {
 }
 
 $db = devices_load();
-if (!devices_touch_entry($db, $deviceId)) {
+$telemetry = devices_extract_telemetry_payload($payload);
+if (!devices_touch_entry($db, $deviceId, null, $telemetry)) {
   echo json_encode(['ok' => false, 'error' => 'unknown-device']);
   exit;
 }

--- a/webroot/admin/api/devices_unpair.php
+++ b/webroot/admin/api/devices_unpair.php
@@ -1,5 +1,7 @@
 <?php
+require_once __DIR__ . '/auth/guard.php';
 require_once __DIR__ . '/devices_store.php';
+auth_require_role('editor');
 header('Content-Type: application/json; charset=UTF-8');
 header('Cache-Control: no-store');
 
@@ -33,4 +35,8 @@ else {
 }
 
 if (!devices_save($db)) { echo json_encode(['ok'=>false,'error'=>'save-failed']); exit; }
+auth_audit('device.unpair', [
+  'deviceId' => $didIn,
+  'purge' => $purge
+]);
 echo json_encode(['ok'=>true,'device'=>$didIn,'removed'=>$purge?1:0]);

--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -1220,6 +1220,18 @@ body.device-mode #devPairedList tr.selected{
 #devPairedList .dev-heartbeat[data-state="crit"] .dev-heartbeat-dot{ background:#EF4444; box-shadow:0 0 0 3px rgba(239,68,68,.26); }
 #devPairedList .dev-heartbeat[data-state="unknown"] .dev-heartbeat-dot{ background:#9CA3AF; box-shadow:0 0 0 3px rgba(156,163,175,.22); }
 #devPairedList .dev-heartbeat time{ font-size:12px; font-weight:500; color:var(--muted); }
+#devPairedList td.dev-telemetry{ font-size:12px; line-height:1.4; min-width:220px; }
+.dev-telemetry-list{ display:grid; grid-template-columns:auto 1fr; gap:6px 12px; margin:0; }
+.dev-telemetry-list dt{ font-weight:600; color:var(--muted-strong); }
+.dev-telemetry-list dd{ margin:0; }
+.dev-telemetry-list dd .mut{ color:var(--muted); }
+.dev-error-list{ margin:0; padding-left:18px; }
+.dev-error-list li{ margin:0; }
+.dev-history{ display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
+.dev-history-chip{ display:inline-flex; align-items:center; gap:4px; padding:2px 6px; border-radius:999px; font-weight:600; font-size:11px; background:var(--surface-muted); color:var(--muted-strong); }
+.dev-history-chip time{ color:inherit; font-weight:inherit; font-size:inherit; }
+.dev-history-chip[data-state="offline"]{ background:#fee2e2; color:#b91c1c; }
+.dev-history-chip[data-state="online"]{ background:#dcfce7; color:#166534; }
   #devPairedList tr.ind{ border-left:none; border-inline-start:4px solid var(--btn-accent); padding-left:8px; }
   body.device-mode #devPairedList tr.ind{ border-inline-start-color:var(--btn-primary); }
   #devPairedList tr.selected{ outline-offset:2px; }

--- a/webroot/api/heartbeat.php
+++ b/webroot/api/heartbeat.php
@@ -15,7 +15,8 @@ if ($deviceId === '') {
 }
 
 $db = devices_load();
-if (!devices_touch_entry($db, $deviceId)) {
+$telemetry = devices_extract_telemetry_payload($payload);
+if (!devices_touch_entry($db, $deviceId, null, $telemetry)) {
   echo json_encode(['ok' => false, 'error' => 'unknown-device']);
   exit;
 }


### PR DESCRIPTION
## Summary
- introduce a Docker Compose development stack and PHP opcache defaults
- add deployment preflight checks, installer integration, and CLI tooling for admin users
- capture and surface device telemetry data, history, and audit logging in the admin UI
- add role-based access control to device APIs plus Vitest/ESLint tooling for the frontend

## Testing
- php -l webroot/admin/api/auth/users_store.php
- php -l webroot/admin/api/auth/guard.php
- php -l webroot/admin/api/devices_store.php
- npm install *(fails: npm error 403 Forbidden accessing registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bc5af90c8320b56d952d1cf0321d