### PR TITLE
Fix installer admin seeding when helper script not executable

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,7 +206,7 @@ seed_admin_user(){
   log "Registering admin account in application store"
 
   local user_script="$SCRIPT_DIR/users.php"
-  if [[ ! -x "$user_script" ]]; then
+  if [[ ! -f "$user_script" ]]; then
     warn "User management helper not found; skipping admin registration"
     return
   fi


### PR DESCRIPTION
## Summary
- allow the installer to find the user management helper even if it is missing the executable bit so the admin account is registered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6d88acaac8320b02a4d07eaf026a5