### PR TITLE
Synchronize nginx basic auth with application user store

### DIFF
--- a/config/nginx/signage-admin.conf
+++ b/config/nginx/signage-admin.conf
@@ -2,7 +2,7 @@ server {
   listen __ADMIN_PORT__;
   listen [::]:__ADMIN_PORT__;
   server_name _;
-  root /var/www/signage;
+  root __APP_DIR__;
   index index.html;
 
   # große Uploads zulassen (muss zu PHP post_max_size passen)
@@ -14,7 +14,7 @@ server {
   add_header X-Served-By signage-admin always;
 
   auth_basic "Restricted";
-  auth_basic_user_file /etc/nginx/.signage_admin;
+  auth_basic_user_file __AUTH_FILE__;
 
   location = / { return 302 /admin/; }
   location = /admin { return 302 /admin/; }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,7 +170,9 @@ deploy_nginx(){
 
   replace_placeholders /etc/nginx/sites-available/signage-admin.conf \
     "__ADMIN_PORT__" "$SIGNAGE_ADMIN_PORT" \
-    "__PHP_SOCK__" "$PHP_SOCK"
+    "__PHP_SOCK__" "$PHP_SOCK" \
+    "__APP_DIR__" "$APP_DIR" \
+    "__AUTH_FILE__" "$APP_DIR/data/.htpasswd"
 
   replace_placeholders /etc/nginx/snippets/signage-pairing.conf \
     "__PHP_SOCK__" "$PHP_SOCK"
@@ -195,18 +197,20 @@ EOPHP
 
 configure_basic_auth(){
   log "Configuring basic auth"
-  if [[ ! -f /etc/nginx/.signage_admin ]]; then
-    printf "%s:%s\n" "$SIGNAGE_ADMIN_USER" "$(openssl passwd -apr1 "$SIGNAGE_ADMIN_PASS")" > /etc/nginx/.signage_admin
+  local auth_file="$APP_DIR/data/.htpasswd"
+  install -d -m 2775 "$(dirname "$auth_file")"
+  if [[ ! -f "$auth_file" ]]; then
+    install -m 0640 /dev/null "$auth_file"
   fi
-  chown root:www-data /etc/nginx/.signage_admin
-  chmod 640 /etc/nginx/.signage_admin
+  chown www-data:www-data "$auth_file" 2>/dev/null || true
+  chmod 640 "$auth_file" 2>/dev/null || true
 }
 
 seed_admin_user(){
   log "Registering admin account in application store"
 
   local user_script="$SCRIPT_DIR/users.php"
-  if [[ ! -x "$user_script" ]]; then
+  if [[ ! -f "$user_script" ]]; then
     warn "User management helper not found; skipping admin registration"
     return
   fi


### PR DESCRIPTION
## Summary
- point the admin nginx vhost at the app directory and use a data/.htpasswd file that can be managed by the application
- have the installer create the htpasswd scaffold in the data directory and substitute the new paths when rendering nginx configs
- sync the htpasswd file with the application user database whenever users are saved so newly created accounts can authenticate over basic auth

## Testing
- php -l webroot/admin/api/auth/users_store.php

------
https://chatgpt.com/codex/tasks/task_e_68d6d88acaac8320b02a4d07eaf026a5