### PR TITLE
Fix badge library fallback overwriting edits

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -177,7 +177,8 @@ function ensureBadgeLibrary(settings){
     raw.forEach(entry => pushEntry(entry, true));
   }
 
-  if (!normalized.length && (!hadArray || hadEntries)){
+  const shouldUseFallback = !normalized.length && (!hadArray || !hadEntries);
+  if (shouldUseFallback){
     const fallback = DEFAULTS.slides?.badgeLibrary || [];
     if (Array.isArray(fallback)) fallback.forEach(entry => pushEntry(entry, true));
   }


### PR DESCRIPTION
## Summary
- prevent the badge-library normalizer from re-populating defaults when an edited list already contains entries by tightening the fallback condition

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6ef2898048320bdf603d86bfbb22d