### PR TITLE
Fix badge reset when adding new entries

### DIFF
--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -170,16 +170,37 @@ function ensureBadgeLibrary(settings){
     seen.add(id);
   };
 
+  const collectFromList = (list, assignIds = false) => {
+    if (!Array.isArray(list)) return false;
+    const before = normalized.length;
+    list.forEach((entry) => pushEntry(entry, assignIds));
+    return normalized.length > before;
+  };
+
   const raw = settings.slides.badgeLibrary;
-  const hadArray = Array.isArray(raw);
-  const hadEntries = hadArray && raw.some(entry => entry && typeof entry === 'object');
-  if (hadArray){
-    raw.forEach(entry => pushEntry(entry, true));
+  const hadSettingsEntries = collectFromList(raw, true);
+
+  if (!hadSettingsEntries) {
+    const styleSets = settings.slides?.styleSets;
+    if (styleSets && typeof styleSets === 'object') {
+      const activeId = settings.slides?.activeStyleSet;
+      const tryUseBadgeList = (candidate) => collectFromList(candidate, true);
+      let loaded = false;
+      if (activeId && styleSets[activeId]?.slides) {
+        loaded = tryUseBadgeList(styleSets[activeId].slides.badgeLibrary);
+      }
+      if (!loaded) {
+        Object.values(styleSets).some((entry) => {
+          if (!entry || typeof entry !== 'object') return false;
+          return tryUseBadgeList(entry.slides?.badgeLibrary);
+        });
+      }
+    }
   }
 
-  if (!normalized.length && (!hadArray || hadEntries)){
+  if (!normalized.length) {
     const fallback = DEFAULTS.slides?.badgeLibrary || [];
-    if (Array.isArray(fallback)) fallback.forEach(entry => pushEntry(entry, true));
+    if (Array.isArray(fallback)) collectFromList(fallback, true);
   }
 
   settings.slides.badgeLibrary = normalized;


### PR DESCRIPTION
## Summary
- ensure the badge library normalizer reuses entries from settings or the active style set before reaching for defaults so custom edits persist when adding badges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6ef2898048320bdf603d86bfbb22d