### PR TITLE
Refine admin cockpit layout and device status display

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -170,134 +170,117 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .workspace-overview{
   display:flex;
   flex-direction:column;
-  gap:18px;
-  margin:16px 16px 18px;
-  padding:18px 20px 20px;
-  border-radius:18px;
-  background:color-mix(in oklab, var(--panel) 92%, var(--btn-accent) 8%);
-  box-shadow:0 16px 40px -30px rgba(15,23,42,.45);
-  border:1px solid color-mix(in oklab, var(--btn-accent) 35%, var(--inbr));
+  gap:14px;
+  margin:0 16px 18px;
+  padding:14px 16px 16px;
+  border-radius:16px;
+  background:color-mix(in oklab, var(--panel) 94%, var(--btn-accent) 6%);
+  box-shadow:0 18px 42px -30px rgba(15,23,42,.45);
+  border:1px solid color-mix(in oklab, var(--btn-accent) 30%, var(--inbr));
   grid-column:1 / -1;
-  transition:box-shadow .2s ease, border-color .2s ease, transform .2s ease;
+  overflow:hidden;
+  max-height:960px;
+  transition:max-height .25s ease, padding .2s ease, margin .2s ease, opacity .2s ease, transform .2s ease, box-shadow .2s ease, border-color .2s ease, border-width .2s ease;
 }
 .workspace-overview[data-pinned="true"]{
   position:sticky;
   top:var(--cockpit-stick-top);
   z-index:40;
-  box-shadow:0 22px 52px -28px rgba(15,23,42,.5);
+  box-shadow:0 22px 52px -26px rgba(15,23,42,.5);
   border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
 }
 .workspace-overview[data-collapsed="true"]{
-  padding-bottom:14px;
+  padding:0 16px;
+  margin:0 16px;
+  border-width:0;
+  max-height:0;
+  opacity:0;
+  transform:translateY(-10px);
+  pointer-events:none;
+  box-shadow:none;
 }
 .workspace-toolbar{
   display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:12px;
-  flex-wrap:wrap;
+  flex-direction:column;
+  gap:6px;
+}
+.workspace-toolbar-text{
+  display:flex;
+  flex-direction:column;
+  gap:2px;
 }
 .workspace-title{
   margin:0;
-  font-size:18px;
+  font-size:17px;
   letter-spacing:.02em;
 }
-.workspace-toolbar-actions{
-  display:flex;
-  flex-wrap:wrap;
-  gap:8px;
-}
-.workspace-tool-btn{
-  appearance:none;
-  display:inline-flex;
-  align-items:center;
-  gap:6px;
-  border-radius:999px;
-  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--inbr));
-  background:color-mix(in oklab, var(--panel) 95%, transparent);
-  color:inherit;
+.workspace-subtitle{
+  margin:0;
   font-size:13px;
-  font-weight:600;
-  padding:6px 12px;
-  cursor:pointer;
-  transition:transform .16s ease, border-color .16s ease, background-color .16s ease, box-shadow .16s ease;
-}
-.workspace-tool-btn:hover,
-.workspace-tool-btn:focus-visible{
-  border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
-  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
-  box-shadow:0 12px 30px -22px rgba(124,58,237,.55);
-  transform:translateY(-1px);
-}
-.workspace-tool-btn:focus-visible{
-  outline:2px solid var(--btn-accent);
-  outline-offset:2px;
-}
-.workspace-tool-btn.is-active{
-  border-color:color-mix(in oklab, var(--btn-accent) 65%, var(--border));
-  background:color-mix(in oklab, var(--btn-accent) 24%, var(--panel));
-}
-.workspace-tool-icon{
-  font-size:14px;
-  line-height:1;
-}
-.workspace-tool-label{
-  display:inline-flex;
-  align-items:center;
+  color:var(--muted);
 }
 .workspace-body{
   display:flex;
   flex-direction:column;
-  gap:16px;
+  gap:12px;
 }
 .workspace-overview[data-collapsed="true"] .workspace-body{
   display:none;
 }
 .workspace-grid{
   display:grid;
-  gap:14px;
-  grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));
+  gap:12px;
+  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
 }
 .workspace-card{
-  background:color-mix(in oklab, var(--panel) 96%, transparent);
-  border-radius:16px;
-  border:1px solid color-mix(in oklab, var(--btn-accent) 14%, var(--inbr));
-  padding:18px 18px 20px;
-  box-shadow:0 16px 40px -32px rgba(15,23,42,.5);
-  display:flex;
-  flex-direction:column;
-  gap:12px;
-}
-.workspace-card-head{
-  display:flex;
-  gap:12px;
-  align-items:flex-start;
-}
-.workspace-card-icon{
-  font-size:28px;
-  line-height:1;
-}
-.workspace-card-head h3{
-  margin:0 0 4px;
-  font-size:16px;
-}
-.workspace-card-head p{
-  margin:0;
-  color:var(--muted);
-}
-.workspace-card-list{
-  margin:0;
-  padding-left:20px;
-  display:flex;
-  flex-direction:column;
-  gap:6px;
-  color:color-mix(in oklab, var(--fg) 82%, var(--muted));
-  font-size:13px;
-}
-.workspace-card-actions{
+  background:color-mix(in oklab, var(--panel) 97%, transparent);
+  border-radius:14px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 18%, var(--inbr));
+  padding:14px 14px 16px;
+  box-shadow:0 14px 34px -28px rgba(15,23,42,.45);
   display:flex;
   flex-direction:column;
   gap:10px;
+}
+.workspace-card-head{
+  display:flex;
+  gap:10px;
+  align-items:flex-start;
+}
+.workspace-card-icon{
+  font-size:24px;
+  line-height:1;
+}
+.workspace-card-head h3{
+  margin:0 0 2px;
+  font-size:15px;
+}
+.workspace-card-head p{
+  margin:0;
+  color:color-mix(in oklab, var(--fg) 78%, var(--muted));
+  font-size:13px;
+}
+.workspace-card-tags{
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  margin:0;
+}
+.workspace-card-tag{
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+  padding:4px 10px;
+  border-radius:999px;
+  font-size:12px;
+  font-weight:600;
+  color:color-mix(in oklab, var(--fg) 80%, var(--muted));
+  background:color-mix(in oklab, var(--btn-accent) 12%, transparent);
+}
+.workspace-card-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
   margin-top:auto;
 }
 .workspace-card-actions-main{
@@ -308,13 +291,13 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .workspace-card-branches{
   display:flex;
   flex-wrap:wrap;
-  gap:6px;
+  gap:4px;
 }
 .workspace-card-btn{
   border-radius:999px;
-  padding:8px 16px;
+  padding:7px 14px;
   font-weight:600;
-  border:1px solid color-mix(in oklab, var(--btn-accent) 25%, var(--inbr));
+  border:1px solid color-mix(in oklab, var(--btn-accent) 22%, var(--inbr));
   background:color-mix(in oklab, var(--panel) 96%, transparent);
   color:inherit;
   cursor:pointer;
@@ -324,8 +307,8 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
 .workspace-card-btn:not(.primary):focus-visible{
   transform:translateY(-1px);
   border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
-  background:color-mix(in oklab, var(--btn-accent) 16%, var(--panel));
-  box-shadow:0 16px 32px -26px rgba(124,58,237,.55);
+  background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
+  box-shadow:0 16px 32px -26px rgba(124,58,237,.45);
 }
 .workspace-card-btn:focus-visible{
   outline:2px solid var(--btn-accent);
@@ -435,6 +418,32 @@ header .header-title{
   align-items:center;
   gap:10px;
   margin-left:auto;
+  flex-wrap:wrap;
+  justify-content:flex-end;
+}
+.header-cockpit-controls{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding-right:10px;
+  margin-right:2px;
+  border-right:1px solid color-mix(in oklab, var(--border) 80%, transparent);
+}
+.header-cockpit-controls .btn{
+  font-size:13px;
+  gap:6px;
+}
+.header-cockpit-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.header-cockpit-icon{ font-size:14px; line-height:1; }
+.header-cockpit-label{ font-weight:600; }
+.header-cockpit-pin{ padding-inline:10px; }
+.header-cockpit-controls .btn.is-active{
+  border-color:color-mix(in oklab, var(--btn-accent) 45%, var(--ghost-border));
+  background:color-mix(in oklab, var(--btn-accent) 14%, var(--ghost-bg));
 }
 
 #unsavedBadge{
@@ -1220,19 +1229,6 @@ body.device-mode #devPairedList tr.selected{
 #devPairedList .dev-heartbeat[data-state="crit"] .dev-heartbeat-dot{ background:#EF4444; box-shadow:0 0 0 3px rgba(239,68,68,.26); }
 #devPairedList .dev-heartbeat[data-state="unknown"] .dev-heartbeat-dot{ background:#9CA3AF; box-shadow:0 0 0 3px rgba(156,163,175,.22); }
 #devPairedList .dev-heartbeat time{ font-size:12px; font-weight:500; color:var(--muted); }
-#devPairedList td.dev-telemetry{ font-size:12px; line-height:1.4; min-width:220px; }
-.dev-telemetry-list{ display:grid; grid-template-columns:auto 1fr; gap:6px 12px; margin:0; }
-.dev-telemetry-list dt{ font-weight:600; color:var(--muted-strong); }
-.dev-telemetry-list dd{ margin:0; }
-.dev-telemetry-list dd .mut{ color:var(--muted); }
-.dev-telemetry-empty{ display:block; font-size:12px; color:var(--muted); }
-.dev-error-list{ margin:0; padding-left:18px; }
-.dev-error-list li{ margin:0; }
-.dev-history{ display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
-.dev-history-chip{ display:inline-flex; align-items:center; gap:4px; padding:2px 6px; border-radius:999px; font-weight:600; font-size:11px; background:var(--surface-muted); color:var(--muted-strong); }
-.dev-history-chip time{ color:inherit; font-weight:inherit; font-size:inherit; }
-.dev-history-chip[data-state="offline"]{ background:#fee2e2; color:#b91c1c; }
-.dev-history-chip[data-state="online"]{ background:#dcfce7; color:#166534; }
   #devPairedList tr.ind{ border-left:none; border-inline-start:4px solid var(--btn-accent); padding-left:8px; }
   body.device-mode #devPairedList tr.ind{ border-inline-start-color:var(--btn-primary); }
   #devPairedList tr.selected{ outline-offset:2px; }

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -30,6 +30,15 @@
       </label>
     </div>
     <div class="header-actions">
+      <div class="header-cockpit-controls" role="group" aria-label="Admin-Cockpit">
+        <button type="button" class="btn ghost sm header-cockpit-btn" data-action="toggle" data-cockpit-control="toggle" aria-controls="adminCockpitBody" aria-expanded="true" aria-label="Cockpit schließen" title="Cockpit minimieren">
+          <span class="header-cockpit-icon" data-role="icon" data-icon-expanded="▾" data-icon-collapsed="▸" aria-hidden="true">▾</span>
+          <span class="header-cockpit-label" data-role="label" data-label-expanded="Cockpit schließen" data-label-collapsed="Cockpit öffnen">Cockpit schließen</span>
+        </button>
+        <button type="button" class="btn ghost sm header-cockpit-pin" data-action="pin" data-cockpit-control="pin" aria-pressed="false" aria-label="Cockpit anheften" title="Cockpit anheften">
+          <span class="header-cockpit-icon" data-role="icon" data-icon-pinned="📍" data-icon-unpinned="📌" aria-hidden="true">📌</span>
+        </button>
+      </div>
       <!-- Ansicht-Menü -->
       <button class="btn" id="btnDevices">Geräte</button>
       <div class="menuwrap" id="viewMenuWrap">
@@ -55,16 +64,9 @@
   <main class="layout">
     <section class="workspace-overview" aria-labelledby="adminCockpitTitle" data-collapsed="false" data-pinned="false">
       <header class="workspace-toolbar">
-        <h2 id="adminCockpitTitle" class="workspace-title">Admin-Cockpit</h2>
-        <div class="workspace-toolbar-actions" role="group" aria-label="Cockpit-Optionen">
-          <button type="button" class="workspace-tool-btn" data-action="pin" aria-pressed="false" title="Cockpit anheften">
-            <span class="workspace-tool-icon" data-role="icon" data-icon-pinned="📍" data-icon-unpinned="📌" aria-hidden="true">📌</span>
-            <span class="workspace-tool-label" data-role="label" data-label-pinned="Lösen" data-label-unpinned="Anheften">Anheften</span>
-          </button>
-          <button type="button" class="workspace-tool-btn" data-action="toggle" aria-controls="adminCockpitBody" aria-expanded="true" title="Cockpit minimieren">
-            <span class="workspace-tool-icon" data-role="icon" data-icon-expanded="▾" data-icon-collapsed="▸" aria-hidden="true">▾</span>
-            <span class="workspace-tool-label" data-role="label" data-label-expanded="Einklappen" data-label-collapsed="Aufklappen">Einklappen</span>
-          </button>
+        <div class="workspace-toolbar-text">
+          <h2 id="adminCockpitTitle" class="workspace-title">Admin-Cockpit</h2>
+          <p class="workspace-subtitle">Schnellzugriff auf Vorschau, Geräte, Planung und Inhalte.</p>
         </div>
       </header>
 
@@ -75,14 +77,14 @@
               <span class="workspace-card-icon" aria-hidden="true">🖥️</span>
               <div>
                 <h3>Vorschau &amp; Geräte</h3>
-                <p>Slides live prüfen, Geräte verwalten und Anzeigen aktualisieren.</p>
+                <p>Live-Status und Display-Steuerung im Blick.</p>
               </div>
             </div>
-            <ul class="workspace-card-list">
-              <li>Slideshow in der Vorschau kontrollieren</li>
-              <li>Gerätestatus, Firmware und Pairings im Blick behalten</li>
-              <li>Displays neu laden oder Geräte koppeln</li>
-            </ul>
+            <div class="workspace-card-tags" role="list">
+              <span class="workspace-card-tag" role="listitem">Vorschau starten</span>
+              <span class="workspace-card-tag" role="listitem">Geräte überwachen</span>
+              <span class="workspace-card-tag" role="listitem">Displays neu laden</span>
+            </div>
             <div class="workspace-card-actions">
               <div class="workspace-card-actions-main">
                 <button type="button" class="workspace-card-btn primary" data-view="preview" data-highlight="dockPane">Vorschau öffnen</button>
@@ -99,14 +101,14 @@
               <span class="workspace-card-icon" aria-hidden="true">🗓️</span>
               <div>
                 <h3>Tagesplan &amp; Wochenablauf</h3>
-                <p>Zeiten strukturieren, Reihenfolge anpassen und Wochenvorlagen sichern.</p>
+                <p>Zeitpläne schnell anpassen und sichern.</p>
               </div>
             </div>
-            <ul class="workspace-card-list">
-              <li>Zeiten verschieben, duplizieren oder löschen</li>
-              <li>Wochentage vergleichen und speichern</li>
-              <li>Schnell zu freien Slots navigieren</li>
-            </ul>
+            <div class="workspace-card-tags" role="list">
+              <span class="workspace-card-tag" role="listitem">Zeiten verschieben</span>
+              <span class="workspace-card-tag" role="listitem">Vorlagen speichern</span>
+              <span class="workspace-card-tag" role="listitem">Freie Slots finden</span>
+            </div>
             <div class="workspace-card-actions">
               <div class="workspace-card-actions-main">
                 <button type="button" class="workspace-card-btn primary" data-view="grid" data-jump="gridPane" aria-controls="gridPane">Plan bearbeiten</button>
@@ -119,14 +121,14 @@
               <span class="workspace-card-icon" aria-hidden="true">🔥</span>
               <div>
                 <h3>Saunen &amp; Hinweise</h3>
-                <p>Saunen, Fußnoten und Badge-Bibliothek pflegen – inklusive Vorschau und Reihenfolge.</p>
+                <p>Saunen und Hinweise zentral verwalten.</p>
               </div>
             </div>
-            <ul class="workspace-card-list">
-              <li>Saunen aktivieren/deaktivieren</li>
-              <li>Badges und Hinweise verwalten</li>
-              <li>Übersicht für den Aufgussplan anpassen</li>
-            </ul>
+            <div class="workspace-card-tags" role="list">
+              <span class="workspace-card-tag" role="listitem">Saunen steuern</span>
+              <span class="workspace-card-tag" role="listitem">Badges pflegen</span>
+              <span class="workspace-card-tag" role="listitem">Bibliothek verwalten</span>
+            </div>
             <div class="workspace-card-actions">
               <div class="workspace-card-actions-main">
                 <button type="button" class="workspace-card-btn primary" data-jump="boxSaunas" aria-controls="boxSaunas">Saunen öffnen</button>
@@ -143,14 +145,14 @@
               <span class="workspace-card-icon" aria-hidden="true">🎬</span>
               <div>
                 <h3>Slides &amp; Automationen</h3>
-                <p>Dauer, Übergänge und Reihenfolgen einstellen, damit der Ablauf passt.</p>
+                <p>Abläufe und Automationen feinjustieren.</p>
               </div>
             </div>
-            <ul class="workspace-card-list">
-              <li>Globale oder individuelle Slide-Dauer wählen</li>
-              <li>Automatisierungen aktivieren</li>
-              <li>Übersichten &amp; Vorschauen prüfen</li>
-            </ul>
+            <div class="workspace-card-tags" role="list">
+              <span class="workspace-card-tag" role="listitem">Dauer einstellen</span>
+              <span class="workspace-card-tag" role="listitem">Automationen steuern</span>
+              <span class="workspace-card-tag" role="listitem">Reihenfolge prüfen</span>
+            </div>
             <div class="workspace-card-actions">
               <div class="workspace-card-actions-main">
                 <button type="button" class="workspace-card-btn primary" data-jump="slidesMaster" aria-controls="slidesMaster">Ablauf steuern</button>
@@ -167,14 +169,14 @@
               <span class="workspace-card-icon" aria-hidden="true">🖼️</span>
               <div>
                 <h3>Infos &amp; Story-Slides</h3>
-                <p>Zusatzinhalte, Countdowns, Wellness-Tipps und Story-Baukasten betreuen.</p>
+                <p>Zusatzinfos und Story-Slides kuratieren.</p>
               </div>
             </div>
-            <ul class="workspace-card-list">
-              <li>Wellness-, Gastro- und Eventinfos pflegen</li>
-              <li>Hero-Timeline aktivieren und timen</li>
-              <li>Story-Slides mit Spalten-Baukasten gestalten</li>
-            </ul>
+            <div class="workspace-card-tags" role="list">
+              <span class="workspace-card-tag" role="listitem">Wellness-Tipps pflegen</span>
+              <span class="workspace-card-tag" role="listitem">Countdowns planen</span>
+              <span class="workspace-card-tag" role="listitem">Story-Slides bauen</span>
+            </div>
             <div class="workspace-card-actions">
               <div class="workspace-card-actions-main">
                 <button type="button" class="workspace-card-btn primary" data-jump="boxStories" aria-controls="boxStories">Zusatzinfos</button>
@@ -194,14 +196,14 @@
               <span class="workspace-card-icon" aria-hidden="true">🎨</span>
               <div>
                 <h3>Medien &amp; Layout</h3>
-                <p>Slides mit Bildern, Texten, Farben und Layouts gestalten – inklusive Presets.</p>
+                <p>Medien und Layout-Optionen bündeln.</p>
               </div>
             </div>
-            <ul class="workspace-card-list">
-              <li>Medien-Slides verwalten und sortieren</li>
-              <li>Layouts für Splitscreens und Anzeigearten festlegen</li>
-              <li>Style-Presets pflegen und anwenden</li>
-            </ul>
+            <div class="workspace-card-tags" role="list">
+              <span class="workspace-card-tag" role="listitem">Medienslides ordnen</span>
+              <span class="workspace-card-tag" role="listitem">Layouts definieren</span>
+              <span class="workspace-card-tag" role="listitem">Style-Presets nutzen</span>
+            </div>
             <div class="workspace-card-actions">
               <div class="workspace-card-actions-main">
                 <button type="button" class="workspace-card-btn primary" data-jump="boxImages" aria-controls="boxImages">Medienbereich</button>
@@ -966,17 +968,12 @@
   (function(){
     const cockpit = document.querySelector('.workspace-overview');
     if (!cockpit) return;
-    const body = cockpit.querySelector('.workspace-body');
-    if (!body) return;
-
     const root = document.documentElement;
     const header = document.querySelector('header');
-    const toolbar = cockpit.querySelector('.workspace-toolbar');
-
     const resolveCockpitHeight = () => {
       if (cockpit.dataset.pinned !== 'true') return 0;
       if (cockpit.dataset.collapsed === 'true') {
-        return toolbar?.offsetHeight || cockpit.offsetHeight;
+        return 0;
       }
       return cockpit.offsetHeight;
     };
@@ -1019,8 +1016,9 @@
 
     window.addEventListener('resize', scheduleUpdate, { passive:true });
 
-    const pinBtn = cockpit.querySelector('[data-action="pin"]');
-    const toggleBtn = cockpit.querySelector('[data-action="toggle"]');
+    const resolveControls = (action) => Array.from(document.querySelectorAll(`[data-action="${action}"][data-cockpit-control]`));
+    const pinButtons = resolveControls('pin');
+    const toggleButtons = resolveControls('toggle');
 
     let storageAvailable = true;
     try{
@@ -1046,7 +1044,7 @@
 
     const setPinState = (pinned) => {
       cockpit.dataset.pinned = pinned ? 'true' : 'false';
-      if (pinBtn){
+      pinButtons.forEach((pinBtn) => {
         pinBtn.setAttribute('aria-pressed', String(pinned));
         pinBtn.classList.toggle('is-active', pinned);
         const label = pinBtn.querySelector('[data-role="label"]');
@@ -1061,23 +1059,31 @@
           const offIcon = icon.dataset.iconUnpinned || icon.textContent;
           icon.textContent = pinned ? onIcon : offIcon;
         }
-        pinBtn.setAttribute('title', pinned ? 'Cockpit lösen' : 'Cockpit anheften');
-      }
+        const pinTitle = pinned ? 'Cockpit lösen' : 'Cockpit anheften';
+        pinBtn.setAttribute('title', pinTitle);
+        pinBtn.setAttribute('aria-label', pinTitle);
+      });
       save(PIN_KEY, pinned ? '1' : null);
       scheduleUpdate();
     };
 
     const setCollapseState = (collapsed) => {
       cockpit.dataset.collapsed = collapsed ? 'true' : 'false';
-      body.hidden = collapsed;
-      if (toggleBtn){
+      if (collapsed) {
+        cockpit.setAttribute('aria-hidden', 'true');
+      } else {
+        cockpit.removeAttribute('aria-hidden');
+      }
+      toggleButtons.forEach((toggleBtn) => {
         toggleBtn.setAttribute('aria-expanded', String(!collapsed));
         toggleBtn.classList.toggle('is-active', !collapsed);
         const label = toggleBtn.querySelector('[data-role="label"]');
         const icon = toggleBtn.querySelector('[data-role="icon"]');
+        let expandedText = 'Cockpit schließen';
+        let collapsedText = 'Cockpit öffnen';
         if (label){
-          const expandedText = label.dataset.labelExpanded || label.textContent;
-          const collapsedText = label.dataset.labelCollapsed || label.textContent;
+          expandedText = label.dataset.labelExpanded || expandedText;
+          collapsedText = label.dataset.labelCollapsed || collapsedText;
           label.textContent = collapsed ? collapsedText : expandedText;
         }
         if (icon){
@@ -1085,8 +1091,10 @@
           const collapsedIcon = icon.dataset.iconCollapsed || icon.textContent;
           icon.textContent = collapsed ? collapsedIcon : expandedIcon;
         }
-        toggleBtn.setAttribute('title', collapsed ? 'Cockpit öffnen' : 'Cockpit minimieren');
-      }
+        const toggleTitle = collapsed ? collapsedText : expandedText;
+        toggleBtn.setAttribute('title', toggleTitle);
+        toggleBtn.setAttribute('aria-label', toggleTitle);
+      });
       save(COLLAPSE_KEY, collapsed ? '1' : null);
       scheduleUpdate();
     };
@@ -1098,14 +1106,18 @@
     setCollapseState(collapsed);
     scheduleUpdate();
 
-    pinBtn?.addEventListener('click', () => {
-      pinned = !pinned;
-      setPinState(pinned);
+    pinButtons.forEach((pinBtn) => {
+      pinBtn.addEventListener('click', () => {
+        pinned = !pinned;
+        setPinState(pinned);
+      });
     });
 
-    toggleBtn?.addEventListener('click', () => {
-      collapsed = !collapsed;
-      setCollapseState(collapsed);
+    toggleButtons.forEach((toggleBtn) => {
+      toggleBtn.addEventListener('click', () => {
+        collapsed = !collapsed;
+        setCollapseState(collapsed);
+      });
     });
   })();
 </script>

--- a/webroot/admin/js/app.js
+++ b/webroot/admin/js/app.js
@@ -2755,121 +2755,6 @@ async function createDevicesPane(){
     return `vor ${Math.round(seconds / 86400)} Tagen`;
   };
 
-  const renderTelemetryCell = (cell, device) => {
-    if (!cell) return;
-    cell.innerHTML = '';
-    const status = device?.status && typeof device.status === 'object' ? device.status : {};
-    const metrics = device?.metrics && typeof device.metrics === 'object' ? device.metrics : {};
-    const history = Array.isArray(device?.heartbeatHistory) ? device.heartbeatHistory : [];
-
-    const list = document.createElement('dl');
-    list.className = 'dev-telemetry-list';
-    const addItem = (label, content) => {
-      if (!content) return;
-      const dt = document.createElement('dt');
-      dt.textContent = label;
-      const dd = document.createElement('dd');
-      if (Array.isArray(content)) {
-        content.filter(Boolean).forEach((node) => dd.appendChild(node));
-      } else if (content instanceof Node) {
-        dd.appendChild(content);
-      } else {
-        dd.textContent = content;
-      }
-      if (!dd.textContent && !dd.children.length) return;
-      list.append(dt, dd);
-    };
-
-    const versionParts = [];
-    if (status.firmware) versionParts.push(`Firmware ${status.firmware}`);
-    if (status.appVersion) versionParts.push(`App ${status.appVersion}`);
-    addItem('Version', versionParts.join(' · '));
-
-    if (status.ip) {
-      addItem('IP', status.ip);
-    }
-
-    if (status.network && typeof status.network === 'object') {
-      const netParts = [];
-      if (status.network.type) netParts.push(status.network.type);
-      if (Number.isFinite(status.network.quality)) netParts.push(`${Math.round(status.network.quality)} %`);
-      if (Number.isFinite(status.network.signal)) netParts.push(`${Math.round(status.network.signal)} dBm`);
-      if (Number.isFinite(status.network.latency)) netParts.push(`${Math.round(status.network.latency)} ms`);
-      const netLabel = netParts.length ? netParts.join(' · ') : '—';
-      const span = document.createElement('span');
-      span.textContent = netLabel;
-      if (status.network.ssid) {
-        span.title = `SSID: ${status.network.ssid}`;
-      }
-      addItem('Netz', span);
-    }
-
-    const metricParts = [];
-    if (Number.isFinite(metrics.cpuLoad)) metricParts.push(`CPU ${Math.round(metrics.cpuLoad)} %`);
-    if (Number.isFinite(metrics.memoryUsage)) metricParts.push(`RAM ${Math.round(metrics.memoryUsage)} %`);
-    if (Number.isFinite(metrics.temperature)) metricParts.push(`${Math.round(metrics.temperature)} °C`);
-    if (Number.isFinite(metrics.batteryLevel)) metricParts.push(`Akku ${Math.round(metrics.batteryLevel)} %`);
-    if (Number.isFinite(metrics.latency)) metricParts.push(`Ping ${Math.round(metrics.latency)} ms`);
-    addItem('Leistung', metricParts.join(' · '));
-
-    if (status.notes) {
-      addItem('Hinweis', status.notes);
-    }
-
-    if (Array.isArray(status.errors) && status.errors.length) {
-      const errorList = document.createElement('ul');
-      errorList.className = 'dev-error-list';
-      status.errors.slice(0, 3).forEach((error) => {
-        const li = document.createElement('li');
-        const label = [error.code, error.message].filter(Boolean).join(': ');
-        li.textContent = label || 'Fehler';
-        if (error.ts) {
-          const date = new Date(error.ts * 1000);
-          li.title = date.toLocaleString('de-DE');
-        }
-        errorList.appendChild(li);
-      });
-      if (status.errors.length > 3) {
-        const li = document.createElement('li');
-        li.className = 'mut';
-        li.textContent = `+${status.errors.length - 3} weitere`;
-        errorList.appendChild(li);
-      }
-      addItem('Fehler', errorList);
-    }
-
-    if (history.length) {
-      const wrap = document.createElement('div');
-      wrap.className = 'dev-history';
-      history.slice(-4).reverse().forEach((entry) => {
-        const chip = document.createElement('span');
-        chip.className = 'dev-history-chip';
-        chip.dataset.state = entry.offline ? 'offline' : 'online';
-        const ts = Number(entry.ts);
-        if (ts) {
-          const date = new Date(ts * 1000);
-          chip.title = date.toLocaleString('de-DE');
-          const time = document.createElement('time');
-          time.dateTime = date.toISOString();
-          const relSeconds = Number(entry.ago);
-          time.textContent = Number.isFinite(relSeconds) ? formatRelativeSeconds(relSeconds) : date.toLocaleTimeString('de-DE');
-          chip.appendChild(time);
-        }
-        wrap.appendChild(chip);
-      });
-      addItem('Heartbeats', wrap);
-    }
-
-    if (!list.children.length) {
-      const empty = document.createElement('span');
-      empty.className = 'mut dev-telemetry-empty';
-      empty.textContent = 'Keine Telemetriedaten empfangen';
-      cell.appendChild(empty);
-    } else {
-      cell.appendChild(list);
-    }
-  };
-
   async function render(options = {}) {
     const { bypassCache = false } = options || {};
     const snapshot = await loadDeviceSnapshots({ bypassCache });
@@ -2936,14 +2821,16 @@ async function createDevicesPane(){
             if (secondsAgo <= OFFLINE_AFTER_MIN * 180) return 'warn';
             return 'crit';
           })();
-          const relativeText = formatRelativeSeconds(secondsAgo);
-          const heartbeatHtml = `<div class="dev-heartbeat" data-state="${heartbeatState}"><span class="dev-heartbeat-dot"></span><span>${offline ? 'offline' : 'online'}</span>${Number.isFinite(secondsAgo) && lastSeenAt ? `<time datetime="${new Date(lastSeenAt * 1000).toISOString()}">${relativeText}</time>` : ''}</div>`;
+          const relativeText = Number.isFinite(secondsAgo) ? formatRelativeSeconds(secondsAgo) : '';
+          const heartbeatTime = lastSeenAt ? new Date(lastSeenAt * 1000) : null;
+          const heartbeatLabel = lastSeenAt ? seenText : '';
+          const heartbeatHtml = `<div class="dev-heartbeat" data-state="${heartbeatState}"><span class="dev-heartbeat-dot"></span><span>${offline ? 'offline' : 'online'}</span>${heartbeatTime ? ` <time datetime="${heartbeatTime.toISOString()}"${relativeText ? ` title="${relativeText}"` : ''}>${heartbeatLabel}</time>` : ''}</div>`;
 
           const row = document.createElement('tr');
           if (currentDeviceCtx === device.id) row.classList.add('current');
           if (useOverrides) row.classList.add('ind');
           if (offline) row.classList.add('offline');
-          const lastSeenHtml = lastSeenAt ? `<br><small class="mut">${seenText}</small>` : '';
+          const lastSeenHtml = relativeText ? `<br><small class="mut">${relativeText}</small>` : '';
           const statusCell = `<td class="status ${offline ? 'offline' : 'online'}">${heartbeatHtml}${lastSeenHtml}</td>`;
 
           row.innerHTML = `
@@ -2957,12 +2844,8 @@ async function createDevicesPane(){
             <td><button class="btn sm" data-rename>Umbenennen</button></td>
             <td><button class="btn sm ghost" data-url>URL kopieren</button></td>
             <td><button class="btn sm danger" data-unpair>Trennen…</button></td>
-            <td class="dev-telemetry" data-telemetry></td>
             ${statusCell}
           `;
-
-          const telemetryCell = row.querySelector('[data-telemetry]');
-          renderTelemetryCell(telemetryCell, device);
 
           const modeInput = row.querySelector('[data-mode]');
           const modeLabel = row.querySelector('[data-mode-label]');


### PR DESCRIPTION
## Summary
- integrate the admin cockpit into a collapsible header dropdown with refreshed styling
- replace cockpit list items with compact tag chips and tighter card spacing
- remove the telemetry column and show the last heartbeat time inline in the device overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70479140883208dc3c270757c699d