### PR TITLE
Refine cockpit layout and visibility cues

### DIFF
--- a/webroot/admin/css/admin.css
+++ b/webroot/admin/css/admin.css
@@ -109,6 +109,17 @@ body{
   font:var(--fs)/1.45 system-ui, Segoe UI, Roboto, Arial, sans-serif;
   scroll-padding-top:var(--workspace-offset);
 }
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0, 0, 0, 0);
+  white-space:nowrap;
+  border:0;
+}
 a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:none; }
 }
 
@@ -182,6 +193,14 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
   max-height:960px;
   transition:max-height .25s ease, padding .2s ease, margin .2s ease, opacity .2s ease, transform .2s ease, box-shadow .2s ease, border-color .2s ease, border-width .2s ease;
 }
+.workspace-overview.cockpit-compact{
+  gap:10px;
+  margin:0 12px 16px;
+  padding:12px 14px;
+}
+.workspace-overview.cockpit-compact .workspace-body{
+  gap:10px;
+}
 .workspace-overview[data-pinned="true"]{
   position:sticky;
   top:var(--cockpit-stick-top);
@@ -232,6 +251,22 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
   gap:12px;
   grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
 }
+.workspace-overview.cockpit-compact .workspace-grid{
+  display:flex;
+  gap:12px;
+  overflow-x:auto;
+  padding-bottom:6px;
+  margin:0 -4px;
+  scrollbar-width:thin;
+  scroll-snap-type:x proximity;
+}
+.workspace-overview.cockpit-compact .workspace-grid::-webkit-scrollbar{
+  height:6px;
+}
+.workspace-overview.cockpit-compact .workspace-grid::-webkit-scrollbar-thumb{
+  background:color-mix(in oklab, var(--btn-accent) 45%, transparent);
+  border-radius:999px;
+}
 .workspace-card{
   background:color-mix(in oklab, var(--panel) 97%, transparent);
   border-radius:14px;
@@ -241,6 +276,13 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
   display:flex;
   flex-direction:column;
   gap:10px;
+}
+.workspace-overview.cockpit-compact .workspace-card{
+  min-width:240px;
+  flex:0 0 240px;
+  padding:12px 12px 14px;
+  gap:8px;
+  scroll-snap-align:start;
 }
 .workspace-card-head{
   display:flex;
@@ -260,11 +302,21 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
   color:color-mix(in oklab, var(--fg) 78%, var(--muted));
   font-size:13px;
 }
+.workspace-overview.cockpit-compact .workspace-card-head p{
+  font-size:12px;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+}
 .workspace-card-tags{
   display:flex;
   flex-wrap:wrap;
   gap:6px;
   margin:0;
+}
+.workspace-overview.cockpit-compact .workspace-card-tags{
+  display:none;
 }
 .workspace-card-tag{
   display:inline-flex;
@@ -292,6 +344,9 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
   display:flex;
   flex-wrap:wrap;
   gap:4px;
+}
+.workspace-overview.cockpit-compact .workspace-card-branches{
+  gap:6px;
 }
 .workspace-card-btn{
   border-radius:999px;
@@ -342,12 +397,24 @@ a{ color: color-mix(in oklab, var(--btn-accent) 70%, #1e3a8a); text-decoration:n
   cursor:pointer;
   transition:transform .16s ease, border-color .16s ease, background-color .16s ease, box-shadow .16s ease;
 }
+.workspace-branch-btn.workspace-branch-devices{
+  background:linear-gradient(135deg, var(--btn-primary), var(--btn-primary-2));
+  color:var(--btn-primary-fg);
+  border-color:color-mix(in oklab, var(--btn-primary) 55%, var(--btn-primary-2));
+  box-shadow:0 12px 26px -18px color-mix(in oklab, var(--btn-primary) 60%, transparent);
+}
 .workspace-branch-btn:hover,
 .workspace-branch-btn:focus-visible{
   transform:translateY(-1px);
   border-color:color-mix(in oklab, var(--btn-accent) 55%, var(--border));
   background:color-mix(in oklab, var(--btn-accent) 18%, var(--panel));
   box-shadow:0 12px 28px -22px rgba(124,58,237,.45);
+}
+.workspace-branch-btn.workspace-branch-devices:hover,
+.workspace-branch-btn.workspace-branch-devices:focus-visible{
+  background:linear-gradient(135deg, var(--btn-primary-2), var(--btn-primary));
+  border-color:color-mix(in oklab, var(--btn-primary) 70%, var(--btn-primary-2));
+  box-shadow:0 14px 28px -16px color-mix(in oklab, var(--btn-primary) 60%, transparent);
 }
 .workspace-branch-btn:focus-visible{
   outline:2px solid var(--btn-accent);
@@ -422,28 +489,70 @@ header .header-title{
   justify-content:flex-end;
 }
 .header-cockpit-controls{
-  display:inline-flex;
+  display:flex;
   align-items:center;
-  gap:6px;
   padding-right:10px;
-  margin-right:2px;
-  border-right:1px solid color-mix(in oklab, var(--border) 80%, transparent);
+  margin-right:6px;
+  border-right:1px solid color-mix(in oklab, var(--border) 75%, transparent);
 }
-.header-cockpit-controls .btn{
-  font-size:13px;
-  gap:6px;
+.header-cockpit-toggle{
+  display:flex;
+  align-items:center;
+  gap:0;
+  background:color-mix(in oklab, var(--panel) 92%, var(--btn-accent) 8%);
+  border-radius:999px;
+  border:1px solid color-mix(in oklab, var(--btn-accent) 32%, var(--border));
+  box-shadow:0 10px 24px -18px rgba(124,58,237,.45);
+  overflow:hidden;
 }
 .header-cockpit-btn{
   display:inline-flex;
   align-items:center;
   gap:6px;
+  padding:6px 14px;
+  border-radius:999px 0 0 999px;
+  border:0;
+  background:transparent;
+  color:inherit;
+  font-size:13px;
+  font-weight:600;
 }
-.header-cockpit-icon{ font-size:14px; line-height:1; }
-.header-cockpit-label{ font-weight:600; }
-.header-cockpit-pin{ padding-inline:10px; }
-.header-cockpit-controls .btn.is-active{
-  border-color:color-mix(in oklab, var(--btn-accent) 45%, var(--ghost-border));
-  background:color-mix(in oklab, var(--btn-accent) 14%, var(--ghost-bg));
+.header-cockpit-btn .header-cockpit-icon{ font-size:13px; }
+.header-cockpit-pinstate{ font-size:14px; line-height:1; filter:drop-shadow(0 0 4px color-mix(in oklab, currentColor 65%, transparent)); }
+.header-cockpit-pin{
+  border-radius:0 999px 999px 0;
+  border:0;
+  padding:6px 10px;
+  font-size:13px;
+  background:color-mix(in oklab, var(--panel) 90%, transparent);
+  color:inherit;
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+}
+.header-cockpit-pin .header-cockpit-icon{ font-size:14px; }
+.header-cockpit-pin.is-active{
+  background:color-mix(in oklab, var(--btn-primary) 32%, transparent);
+  color:color-mix(in oklab, var(--btn-primary) 70%, var(--fg));
+}
+.header-cockpit-toggle .btn{
+  border:none;
+  box-shadow:none;
+}
+.header-cockpit-toggle .btn:hover,
+.header-cockpit-toggle .btn:focus-visible{
+  background:color-mix(in oklab, var(--btn-accent) 18%, transparent);
+}
+.header-cockpit-toggle.is-pinned{
+  border-color:color-mix(in oklab, var(--btn-primary) 35%, var(--btn-accent));
+  background:color-mix(in oklab, var(--btn-primary) 24%, var(--panel));
+}
+.header-cockpit-toggle.is-pinned .header-cockpit-pinstate{ color:color-mix(in oklab, var(--btn-primary) 75%, var(--fg)); }
+.header-cockpit-toggle .btn.is-pinned{
+  background:color-mix(in oklab, var(--btn-primary) 16%, transparent);
+}
+.header-cockpit-toggle .btn.is-active{
+  background:color-mix(in oklab, var(--btn-accent) 12%, transparent);
 }
 
 #unsavedBadge{
@@ -507,11 +616,30 @@ header .header-title{
 
 body.has-unsaved-changes header{
   border-bottom-color: color-mix(in oklab, var(--unsaved-bg) 55%, var(--border));
-  box-shadow:0 14px 32px color-mix(in oklab, var(--unsaved-bg) 24%, transparent);
+  box-shadow:0 18px 36px color-mix(in oklab, var(--unsaved-bg) 22%, transparent);
+  background:color-mix(in oklab, var(--panel) 88%, var(--unsaved-bg) 12%);
+}
+
+body.has-unsaved-changes header::after{
+  content:"";
+  position:absolute;
+  inset:auto 16px -6px 16px;
+  height:3px;
+  border-radius:999px;
+  background:var(--unsaved-bg);
+  box-shadow:0 0 0 4px color-mix(in oklab, var(--unsaved-glow) 45%, transparent);
+}
+
+body.has-unsaved-changes .header-title h1{
+  color:color-mix(in oklab, var(--unsaved-bg) 65%, var(--fg));
 }
 
 body.has-unsaved-changes #btnSave{
   animation:unsavedBtnGlow 1.35s ease-in-out infinite alternate;
+}
+
+body.has-unsaved-changes #unsavedBadge{
+  animation:unsavedBadgePulse 2.2s ease-in-out infinite;
 }
 
 body.device-mode header{
@@ -746,6 +874,7 @@ details.ac[open] .chev{ transform: rotate(90deg); }
   filter:grayscale(40%);
 }
 .btn.sm{ padding:var(--btn-sm-pad); border-radius:10px; }
+.btn.xs{ padding:4px 8px; border-radius:999px; font-size:12px; }
 .btn.icon{ width:28px; height:28px; padding:0; display:grid; place-items:center; }
 .btn.has-meta{ position:relative; padding-right:38px; }
 .btn.sm.has-meta{ padding-right:34px; }
@@ -819,7 +948,12 @@ details.ac[open] .chev{ transform: rotate(90deg); }
   opacity:0;
   cursor:pointer;
 }
-.sys-cleanup{ margin-top:12px; }
+.sys-cleanup{
+  margin-top:12px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
 
 }
 
@@ -2147,6 +2281,17 @@ footer{ display:flex; justify-content:flex-end; padding:12px 16px; border-top:1p
 @keyframes unsavedBtnGlow{
   from{ transform:translateY(0); box-shadow:0 6px 16px rgba(15,23,42,.18); }
   to{ transform:translateY(-1px); box-shadow:0 12px 26px color-mix(in oklab, var(--unsaved-bg) 30%, transparent); }
+}
+
+@keyframes unsavedBadgePulse{
+  0%,100%{
+    box-shadow:0 0 0 1px color-mix(in oklab, var(--unsaved-bg) 55%, transparent), 0 0 0 0 color-mix(in oklab, var(--unsaved-glow) 0%, transparent);
+    transform:translateY(0);
+  }
+  50%{
+    box-shadow:0 0 0 1px color-mix(in oklab, var(--unsaved-bg) 65%, transparent), 0 0 0 10px color-mix(in oklab, var(--unsaved-glow) 85%, transparent);
+    transform:translateY(-1px);
+  }
 }
 
 /* Ansicht-Menü (Header) */

--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -30,14 +30,18 @@
       </label>
     </div>
     <div class="header-actions">
-      <div class="header-cockpit-controls" role="group" aria-label="Admin-Cockpit">
-        <button type="button" class="btn ghost sm header-cockpit-btn" data-action="toggle" data-cockpit-control="toggle" aria-controls="adminCockpitBody" aria-expanded="true" aria-label="Cockpit schließen" title="Cockpit minimieren">
-          <span class="header-cockpit-icon" data-role="icon" data-icon-expanded="▾" data-icon-collapsed="▸" aria-hidden="true">▾</span>
-          <span class="header-cockpit-label" data-role="label" data-label-expanded="Cockpit schließen" data-label-collapsed="Cockpit öffnen">Cockpit schließen</span>
-        </button>
-        <button type="button" class="btn ghost sm header-cockpit-pin" data-action="pin" data-cockpit-control="pin" aria-pressed="false" aria-label="Cockpit anheften" title="Cockpit anheften">
-          <span class="header-cockpit-icon" data-role="icon" data-icon-pinned="📍" data-icon-unpinned="📌" aria-hidden="true">📌</span>
-        </button>
+      <div class="header-cockpit-controls" role="group" aria-label="Cockpit-Schnellzugriff">
+        <div class="header-cockpit-toggle">
+          <button type="button" class="btn ghost sm header-cockpit-btn" data-action="toggle" data-cockpit-control="toggle" data-title-expanded="Cockpit ausblenden" data-title-collapsed="Cockpit anzeigen" aria-controls="adminCockpitBody" aria-expanded="true" aria-label="Cockpit ein-/ausblenden" title="Cockpit ein-/ausblenden">
+            <span class="header-cockpit-icon" data-role="icon" data-icon-expanded="▾" data-icon-collapsed="▸" aria-hidden="true">▾</span>
+            <span class="header-cockpit-label" data-role="label" data-label-expanded="Cockpit" data-label-collapsed="Cockpit">Cockpit</span>
+            <span class="header-cockpit-pinstate" data-role="pin" data-icon-pinned="📍" data-icon-unpinned="📌" aria-hidden="true">📌</span>
+          </button>
+          <button type="button" class="btn ghost xs header-cockpit-pin" data-action="pin" data-cockpit-control="pin" aria-pressed="false" aria-label="Cockpit anheften" title="Cockpit anheften">
+            <span class="header-cockpit-icon" data-role="icon" data-icon-pinned="📍" data-icon-unpinned="📌" aria-hidden="true">📌</span>
+            <span class="sr-only" data-role="label" data-label-pinned="Angeheftet" data-label-unpinned="Nicht angeheftet">Nicht angeheftet</span>
+          </button>
+        </div>
       </div>
       <!-- Ansicht-Menü -->
       <span class="help-anchor" data-help-key="devices-panel">
@@ -53,7 +57,6 @@
       </div>
     </div>
       <button class="btn" id="btnHelp">Hilfe</button>
-      <button class="btn" id="btnUsers">Benutzer</button>
       <button class="btn" id="btnOpen">Slideshow öffnen</button>
       <span class="help-anchor" data-help-key="save">
         <button class="btn primary" id="btnSave">Speichern</button>
@@ -66,12 +69,9 @@
   </header>
 
   <main class="layout">
-    <section class="workspace-overview" aria-labelledby="adminCockpitTitle" data-collapsed="false" data-pinned="false" data-help-key="cockpit">
+    <section class="workspace-overview cockpit-compact" aria-label="Cockpit-Schnellzugriff" data-collapsed="false" data-pinned="false" data-help-key="cockpit">
       <header class="workspace-toolbar">
-        <div class="workspace-toolbar-text">
-          <h2 id="adminCockpitTitle" class="workspace-title">Admin-Cockpit</h2>
-          <p class="workspace-subtitle">Schnellzugriff auf Vorschau, Geräte, Planung und Inhalte.</p>
-        </div>
+        <p class="workspace-subtitle">Schnellzugriff auf Vorschau, Geräte, Planung und Inhalte.</p>
       </header>
 
       <div class="workspace-body" id="adminCockpitBody">
@@ -94,7 +94,7 @@
                 <button type="button" class="workspace-card-btn primary" data-view="preview" data-highlight="dockPane">Vorschau öffnen</button>
               </div>
               <div class="workspace-card-branches" role="group" aria-label="Geräteverwaltung">
-                <button type="button" class="workspace-branch-btn" data-devices="toggle" data-highlight="devicesPane">Gerätebereich</button>
+                <button type="button" class="workspace-branch-btn workspace-branch-devices" data-devices="toggle" data-highlight="devicesPane">Geräte</button>
                 <button type="button" class="workspace-branch-btn" data-devices="refresh" data-highlight="devicesPane">Status aktualisieren</button>
               </div>
             </div>
@@ -836,6 +836,7 @@
           </div>
           <div class="sys-cleanup">
             <button class="btn sm ghost" id="btnCleanupSys">Assets aufräumen</button>
+            <button class="btn sm" id="btnUsers">Benutzer</button>
           </div>
           <small class="help">Export/Import von Einstellungen & Plan. „Bilder einschließen“ packt Flamme & Saunen-Bilder mit ein.</small>
         </div>
@@ -1024,6 +1025,7 @@
     const resolveControls = (action) => Array.from(document.querySelectorAll(`[data-action="${action}"][data-cockpit-control]`));
     const pinButtons = resolveControls('pin');
     const toggleButtons = resolveControls('toggle');
+    const toggleGroup = document.querySelector('.header-cockpit-toggle');
 
     let storageAvailable = true;
     try{
@@ -1068,6 +1070,19 @@
         pinBtn.setAttribute('title', pinTitle);
         pinBtn.setAttribute('aria-label', pinTitle);
       });
+      toggleButtons.forEach((toggleBtn) => {
+        toggleBtn.classList.toggle('is-pinned', pinned);
+        const pinIndicator = toggleBtn.querySelector('[data-role="pin"]');
+        if (pinIndicator){
+          const onIcon = pinIndicator.dataset.iconPinned || pinIndicator.textContent;
+          const offIcon = pinIndicator.dataset.iconUnpinned || pinIndicator.textContent;
+          pinIndicator.textContent = pinned ? onIcon : offIcon;
+          pinIndicator.classList.toggle('is-pinned', pinned);
+        }
+      });
+      if (toggleGroup){
+        toggleGroup.classList.toggle('is-pinned', pinned);
+      }
       save(PIN_KEY, pinned ? '1' : null);
       scheduleUpdate();
     };
@@ -1096,7 +1111,9 @@
           const collapsedIcon = icon.dataset.iconCollapsed || icon.textContent;
           icon.textContent = collapsed ? collapsedIcon : expandedIcon;
         }
-        const toggleTitle = collapsed ? collapsedText : expandedText;
+        const expandedTitle = toggleBtn.dataset.titleExpanded || expandedText;
+        const collapsedTitle = toggleBtn.dataset.titleCollapsed || collapsedText;
+        const toggleTitle = collapsed ? collapsedTitle : expandedTitle;
         toggleBtn.setAttribute('title', toggleTitle);
         toggleBtn.setAttribute('aria-label', toggleTitle);
       });

--- a/webroot/admin/js/ui/context_help.js
+++ b/webroot/admin/js/ui/context_help.js
@@ -6,10 +6,10 @@
 
 const HELP_TOPICS = {
   'cockpit': {
-    title: 'Admin-Cockpit',
-    description: 'Das Cockpit bündelt Schnellzugriffe auf Vorschau, Geräteverwaltung und Inhaltsbereiche.',
+    title: 'Cockpit-Schnellzugriff',
+    description: 'Der kompakte Cockpit-Bereich bündelt Schnellzugriffe auf Vorschau, Geräteverwaltung und Inhaltsbereiche.',
     steps: [
-      'Nutze die Karten, um direkt zu wichtigen Abschnitten zu springen.',
+      'Nutze die Karten oder Schnellaktionen, um direkt zu wichtigen Abschnitten zu springen.',
       'Mit den verlinkten Aktionen kannst du Vorschau oder Gerätebereich sofort öffnen.'
     ]
   },


### PR DESCRIPTION
## Summary
- integrate the cockpit toggle/pin control into a compact pill and move the Benutzer entry into the System section
- condense the cockpit overview into a horizontal carousel with a highlighted "Geräte" shortcut and remove the Admin-Cockpit heading
- make unsaved changes more prominent with stronger header feedback and updated contextual help wording

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d786c7c20c8320a0ac60ea9cbedfdd