### PR TITLE
Fix cockpit docking spacing and retain badge library edits

### DIFF
--- a/webroot/admin/index.html
+++ b/webroot/admin/index.html
@@ -987,10 +987,14 @@
     const updateOffsets = () => {
       const headerHeight = header?.offsetHeight || 0;
       const pinned = cockpit.dataset.pinned === 'true';
-      const cockpitHeight = pinned ? resolveCockpitHeight() : 0;
-      const workspaceOffset = Math.max(132, headerHeight + cockpitHeight + (pinned ? 28 : 24));
-      const stickTop = headerHeight + 12;
-      const devicesOffset = headerHeight + cockpitHeight + 12;
+      const collapsed = cockpit.dataset.collapsed === 'true';
+      const pinnedActive = pinned && !collapsed;
+      const cockpitHeight = pinnedActive ? resolveCockpitHeight() : 0;
+      const gap = pinnedActive ? 16 : 24;
+      const workspaceOffset = Math.max(112, headerHeight + cockpitHeight + gap);
+      const stickGap = pinnedActive ? 6 : 12;
+      const stickTop = Math.max(0, headerHeight + stickGap);
+      const devicesOffset = headerHeight + (pinnedActive ? cockpitHeight : 0) + 8;
 
       root?.style.setProperty('--workspace-offset', `${workspaceOffset}px`);
       root?.style.setProperty('--cockpit-stick-top', `${stickTop}px`);

--- a/webroot/admin/js/ui/slides_master.js
+++ b/webroot/admin/js/ui/slides_master.js
@@ -214,9 +214,11 @@ function ensureBadgeLibrary(settings){
   };
 
   const raw = settings.slides.badgeLibrary;
-  const hadSettingsEntries = collectFromList(raw, true);
+  const rawIsArray = Array.isArray(raw);
+  collectFromList(raw, true);
+  const isExplicitEmpty = rawIsArray && raw.length === 0;
 
-  if (!hadSettingsEntries) {
+  if (!normalized.length && !isExplicitEmpty) {
     const styleSets = settings.slides?.styleSets;
     if (styleSets && typeof styleSets === 'object') {
       const activeId = settings.slides?.activeStyleSet;
@@ -234,7 +236,7 @@ function ensureBadgeLibrary(settings){
     }
   }
 
-  if (!normalized.length) {
+  if (!normalized.length && !isExplicitEmpty) {
     const fallback = DEFAULTS.slides?.badgeLibrary || [];
     if (Array.isArray(fallback)) collectFromList(fallback, true);
   }


### PR DESCRIPTION
## Summary
- tighten the cockpit docking offsets so the pinned view stays compact underneath the header
- keep an explicitly empty badge library instead of repopulating default entries when adding new badges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d78b65bda883208c056825a219f945